### PR TITLE
yaml schema import and builtin checks

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
     - enum34 # [py==27]
     - numpy
     - pandas
+    - pyyaml
     - scipy
     - wrapt
   run:
@@ -22,6 +23,7 @@ requirements:
     - enum34 # [py==27]
     - numpy
     - pandas
+    - pyyaml
     - scipy
     - wrapt
 

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -1,0 +1,36 @@
+"""Built-in standard checks for pandera"""
+
+import pandera
+import pandas as pd
+
+
+class ValueRange(pandera.Check):
+    """Check whether values are within a certain range."""
+    def __init__(self, min_value=None, max_value=None):
+        """Create a new ValueRange check object.
+
+        :param min_value: Allowed minimum value. Should be a type comparable to
+            the type of the pandas series to be validated (e.g. a numerical type
+            for float or int and a datetime for datetime) .
+        :param max_value: Allowed maximum value. Should be a type comparable to
+            the type of the pandas series to be validated (e.g. a numerical type
+            for float or int and a datetime for datetime).
+        """
+        super().__init__(fn=self.check)
+        self.min_value = min_value
+        self.max_value = max_value
+
+    def check(self, series: pd.Series) -> pd.Series:
+        """Compare the values of the series to the predefined limits.
+
+        :returns pd.Series with the comparison result as True or False
+        """
+        if self.min_value is not None:
+            bool_series = series >= self.min_value
+        else:
+            bool_series = pd.Series(data=True, index=series.index)
+
+        if self.max_value is not None:
+            return bool_series & (series <= self.max_value)
+        else:
+            return bool_series

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -4,36 +4,62 @@ import pandera
 import pandas as pd
 
 
-class ValueRange(pandera.Check):
-    """Check whether values are within a certain range."""
-    def __init__(self, min_value=None, max_value=None):
-        """Create a new ValueRange check object.
+def in_range(min_value, max_value, **check_params):
+    """Compare values of a series to predefined limits.
 
-        :param min_value: Allowed minimum value. Should be a type comparable to
-            the type of the pandas series to be validated (e.g. a numerical type
-            for float or int and a datetime for datetime) .
-        :param max_value: Allowed maximum value. Should be a type comparable to
-            the type of the pandas series to be validated (e.g. a numerical type
-            for float or int and a datetime for datetime).
-        """
-        super().__init__(fn=self.check)
-        self.min_value = min_value
-        self.max_value = max_value
+    :param min_value: Allowed minimum value. Should be a type comparable to
+        the type of the pandas series to be validated (e.g. a numerical type
+        for float or int and a datetime for datetime) .
+    :param max_value: Allowed maximum value. Should be a type comparable to
+        the type of the pandas series to be validated (e.g. a numerical type
+        for float or int and a datetime for datetime).
+    :param check_params: Additional keyword parameters for pandera.Check
 
-    def check(self, series: pd.Series) -> pd.Series:
-        """Compare the values of the series to the predefined limits.
+    :returns pandera.Check object with a comparison function
+    """
+    def _in_range(series: pd.Series) -> pd.Series:
+        """Comparison function for check"""
+        return (series >= min_value) & (series <= max_value)
 
-        :returns pd.Series with the comparison result as True or False
-        """
-        if self.min_value is not None:
-            bool_series = series >= self.min_value
-        else:
-            bool_series = pd.Series(data=True, index=series.index)
+    return pandera.Check(fn=_in_range, **check_params)
 
-        if self.max_value is not None:
-            return bool_series & (series <= self.max_value)
 
-        return bool_series
+def greater_than(min_value, **check_params):
+    """Ensure values of a series are above a certain threshold.
+
+    :param min_value: Allowed minimum value. Should be a type comparable to
+        the type of the pandas series to be validated (e.g. a numerical type
+        for float or int and a datetime for datetime) .
+    :param check_params: Additional keyword parameters for pandera.Check
+
+    :returns pandera.Check object with a comparison function
+    """
+
+    def _greater_than(series: pd.Series) -> pd.Series:
+        """Comparison function for check"""
+        return (series >= min_value)
+
+    return pandera.Check(fn=_greater_than, **check_params)
+
+
+def smaller_than(max_value, **check_params):
+    """Ensure values of a series are above a certain threshold.
+
+    :param max_value: Allowed maximum value. Should be a type comparable to
+        the type of the pandas series to be validated (e.g. a numerical type
+        for float or int and a datetime for datetime).
+    :param check_params: Additional keyword parameters for pandera.Check
+
+    :returns pandera.Check object with a comparison function
+    """
+
+    def _smaller_than(series: pd.Series) -> pd.Series:
+        """Comparison function for check"""
+        return (series <= max_value)
+
+    return pandera.Check(fn=_smaller_than, **check_params)
+
+
 
 
 class StringMatch(pandera.Check):

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -32,5 +32,51 @@ class ValueRange(pandera.Check):
 
         if self.max_value is not None:
             return bool_series & (series <= self.max_value)
+
+        return bool_series
+
+
+class StringMatch(pandera.Check):
+    """Check if strings in a pandas.Series match a given regular expression."""
+    def __init__(self, regex: str):
+        """Create a new StringMatch object based on the given regex.
+
+        :param regex: Regular expression which must be matched
+        """
+        super().__init__(fn=self.match)
+        self.regex = regex
+
+    def match(self, series: pd.Series) -> pd.Series:
+        """Check if all strings in the series match the regular expression.
+
+        :returns pd.Series with the comparison result as True or False
+        """
+        return series.str.match(self.regex)
+
+
+class StringLength(pandera.Check):
+    """Check if the length of strings is within a specified range"""
+
+    def __init__(self, min_len: int = None, max_len: int = None):
+        """Create a new StringLength object with a given range
+
+        :param min_len: Minimum length of strings (default: no minimum)
+        :param max_len: Maximu length of strings (default: no maximum)
+        """
+        super().__init__(fn=self.check_string_length)
+        self.min_len = min_len
+        self.max_len = max_len
+
+    def check_string_length(self, series: pd.Series) -> pd.Series:
+        """Check if all strings does have an acceptable length
+
+        :returns pd.Series with the validation result as True or False
+        """
+        if self.min_len is not None:
+            bool_series = series.str.len() >= self.min_len
         else:
-            return bool_series
+            bool_series = pd.Series(data=True, index=series.index)
+
+        if self.max_len is not None:
+            return bool_series & (series.str.len() <= self.max_len)
+        return bool_series

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -887,7 +887,7 @@ class MultiIndex(DataFrameSchema):
 class Column(SeriesSchemaBase):
 
     def __init__(
-            self, pandas_dtype, checks=None, nullable=False,
+            self, dtype, checks=None, nullable=False,
             allow_duplicates=True,
             coerce=False, required=True):
         """Initialize column validator object.
@@ -912,7 +912,7 @@ class Column(SeriesSchemaBase):
         :type required:  bool
         """
         super(Column, self).__init__(
-            pandas_dtype, checks, nullable, allow_duplicates)
+            dtype, checks, nullable, allow_duplicates)
         self.coerce = coerce
         self.required = required
 

--- a/pandera/yaml_schema.py
+++ b/pandera/yaml_schema.py
@@ -1,0 +1,47 @@
+"""Functions to load schemata from yaml"""
+
+import pandera
+import yaml
+
+
+def df_schema_from_yaml(yaml_definition: str):
+    """Create a pandera.DataFrameSchema from a yaml file"""
+    schema_dict = yaml.safe_load(yaml_definition)
+
+    # First validate if the dataframe key exists
+    if 'dataframe' not in schema_dict:
+        raise pandera.SchemaDefinitionError(
+            "Expected key 'dataframe' missing in yaml schema definition."
+        )
+
+    # Deserialize the dataframe wide Check objects
+    if schema_dict['dataframe'].get('checks'):
+        df_checks = []
+        for check_params in schema_dict['dataframe']['checks']:
+            if not isinstance(check_params, dict):
+                raise pandera.SchemaDefinitionError(
+                    "Invalid definition of dataframe check: %s\n"
+                    "Specify parameters for constructing a Check object." %
+                    check_params
+                )
+            df_checks.append(pandera.Check(**check_params))
+        schema_dict['dataframe']['checks'] = df_checks
+    else:
+        schema_dict['dataframe']['checks'] = None
+
+    # Deserialize the Column objects
+    for name, params in schema_dict['dataframe']['columns'].items():
+        if 'dtype' not in params:
+            raise pandera.SchemaDefinitionError(
+                "Column definition '%s' lacks a data type definition. "
+                "Expected key 'dtype' in the column definition." % name)
+        try:
+            params['dtype'] = pandera.PandasDtype[params['dtype']]
+        except KeyError:
+            raise pandera.SchemaDefinitionError(
+                "Unknown data type '%s' in column "
+                "definition '%s'" % (params['dtype'], name)
+            )
+        schema_dict['dataframe']['columns'][name] = pandera.Column(**params)
+
+    return pandera.DataFrameSchema(**schema_dict['dataframe'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy >= 1.9.0
 pandas >= 0.23.0
 pytest
 pytest-cov
+pyyaml
 scipy >= 1.2.0
 sphinx
 sphinx_rtd_theme

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,9 +1,9 @@
+"""Tests for pandera.checks"""
 
 import pandas as pd
 import pandera
-import pytest
-
 from pandera import checks
+import pytest
 
 
 @pytest.mark.parametrize('min_val, max_val, should_fail', [
@@ -76,14 +76,64 @@ def test_value_range_datetime(min_val, max_val, should_fail):
     (None, pd.Timedelta(3, unit="D"), True),
     (pd.Timedelta(3, unit="D"), None, True),
 ])
-def test_value_range_datetime(min_val, max_val, should_fail):
-    """Test the ValueRange class for timestamp values"""
+def test_value_range_timedelta(min_val, max_val, should_fail):
+    """Test the ValueRange class for timedelta values"""
     series = pd.Series([pd.Timedelta(1, unit="D"),
                         pd.Timedelta(5, unit="D"),
                         pd.Timedelta(9, unit="D")])
     schema = pandera.SeriesSchema(
         pandas_dtype=series.dtype.name, nullable=True,
         checks=[checks.ValueRange(min_value=min_val, max_value=max_val)]
+    )
+    if should_fail:
+        with pytest.raises(pandera.SchemaError):
+            schema.validate(series)
+    else:
+        schema.validate(series)
+
+
+@pytest.mark.parametrize("pattern, should_fail", [(r".*", False),
+                                                  (r"[\w\s\.,]*", False),
+                                                  (r".+", True),
+                                                  (r"[a-z]+", True)])
+def test_string_match(pattern, should_fail):
+    """Test the StringMatch class"""
+    series = pd.Series([
+        "There is a theory which states that if ever anyone discovers ",
+        "exactly what the Universe is for and why it is here, it will",
+        " instantly disappear and be replaced by something even more ",
+        "bizarre and inexplicable. There is another theory mentioned, ",
+        "which states that this has already happened.", ""
+    ])
+    schema = pandera.SeriesSchema(
+        pandas_dtype=pandera.String,
+        nullable=False,
+        checks=[checks.StringMatch(regex=pattern)],
+        name=series.name,
+    )
+    if should_fail:
+        with pytest.raises(pandera.SchemaError):
+            schema.validate(series)
+    else:
+        schema.validate(series)
+
+
+@pytest.mark.parametrize("min_len, max_len, should_fail", [(0, 3, False),
+                                                           (None, 3, False),
+                                                           (0, None, False),
+                                                           (None, None, False),
+                                                           (2, 3, True),
+                                                           (0, 2, True),
+                                                           (None, 2, True),
+                                                           (2, None, True)])
+def test_string_length(min_len, max_len, should_fail):
+    """Test the StringLength check class"""
+    series = pd.Series(["", "1", "12", "123"])
+    schema = pandera.SeriesSchema(
+        pandas_dtype=pandera.String,
+        nullable=False,
+        checks=[checks.StringLength(min_len=min_len, max_len=max_len)],
+        name=series.name,
     )
     if should_fail:
         with pytest.raises(pandera.SchemaError):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,92 @@
+
+import pandas as pd
+import pandera
+import pytest
+
+from pandera import checks
+
+
+@pytest.mark.parametrize('min_val, max_val, should_fail', [
+    (1, 3, False),
+    (None, 3, False),
+    (1, None, False),
+    (None, None, False),
+    (2, 3, True),
+    (1, 2, True),
+    (None, 2, True),
+    (2, None, True)
+])
+def test_value_range_int(min_val, max_val, should_fail):
+    """Test the ValueRange class for integer values"""
+    series = pd.Series([1, 2, 3])
+
+    schema = pandera.SeriesSchema(
+        pandas_dtype=series.dtype.name, nullable=True,
+        checks=[checks.ValueRange(min_value=min_val, max_value=max_val)]
+    )
+    if should_fail:
+        with pytest.raises(pandera.SchemaError):
+            schema.validate(series)
+    else:
+        schema.validate(series)
+
+
+@pytest.mark.parametrize('min_val, max_val, should_fail', [
+    (pd.Timestamp("2015-02-01"), pd.Timestamp("2015-02-03"), False),
+    (None, pd.Timestamp("2015-02-03"), False),
+    (pd.Timestamp("2015-02-01"), None, False),
+    (None, None, False),
+    (pd.Timestamp("2015-02-02"), pd.Timestamp("2015-02-03"), True),
+    (pd.Timestamp("2015-02-01"), pd.Timestamp("2015-02-02"), True),
+    (None, pd.Timestamp("2015-02-02"), True),
+    (pd.Timestamp("2015-02-02"), None, True),
+    # Once again with strings (should be converted automatically)
+    ("2015-02-01", "2015-02-03", False),
+    (None, "2015-02-03", False),
+    ("2015-02-01", None, False),
+    (None, None, False),
+    ("2015-02-02", "2015-02-03", True),
+    ("2015-02-01", "2015-02-02", True),
+    (None, "2015-02-02", True),
+    ("2015-02-02", None, True)
+])
+def test_value_range_datetime(min_val, max_val, should_fail):
+    """Test the ValueRange class for timestamp values"""
+    series = pd.Series([pd.Timestamp("2015-02-01"),
+                        pd.Timestamp("2015-02-02"),
+                        pd.Timestamp("2015-02-03")])
+    schema = pandera.SeriesSchema(
+        pandas_dtype=series.dtype.name, nullable=True,
+        checks=[checks.ValueRange(min_value=min_val, max_value=max_val)]
+    )
+    if should_fail:
+        with pytest.raises(pandera.SchemaError):
+            schema.validate(series)
+    else:
+        schema.validate(series)
+
+
+@pytest.mark.parametrize('min_val, max_val, should_fail', [
+    (pd.Timedelta(1, unit="D"), pd.Timedelta(9, unit="D"), False),
+    (None, pd.Timedelta(9, unit="D"), False),
+    (pd.Timedelta(1, unit="D"), None, False),
+    (None, None, False),
+    (pd.Timedelta(3, unit="D"), pd.Timedelta(9, unit="D"), True),
+    (pd.Timedelta(1, unit="D"), pd.Timedelta(3, unit="D"), True),
+    (None, pd.Timedelta(3, unit="D"), True),
+    (pd.Timedelta(3, unit="D"), None, True),
+])
+def test_value_range_datetime(min_val, max_val, should_fail):
+    """Test the ValueRange class for timestamp values"""
+    series = pd.Series([pd.Timedelta(1, unit="D"),
+                        pd.Timedelta(5, unit="D"),
+                        pd.Timedelta(9, unit="D")])
+    schema = pandera.SeriesSchema(
+        pandas_dtype=series.dtype.name, nullable=True,
+        checks=[checks.ValueRange(min_value=min_val, max_value=max_val)]
+    )
+    if should_fail:
+        with pytest.raises(pandera.SchemaError):
+            schema.validate(series)
+    else:
+        schema.validate(series)

--- a/tests/test_yaml_schema-sample_df_schema.yml
+++ b/tests/test_yaml_schema-sample_df_schema.yml
@@ -1,0 +1,42 @@
+# Sample dataframe schema in yaml syntax for the unit test test_yaml_schema.py
+
+dataframe:
+    checks:
+    columns:
+        int_col:
+            dtype: Int
+            checks:
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+        float_col:
+            dtype: Float
+            checks:
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+        str_col:
+            dtype: String
+            checks:
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+        bool_col:
+            dtype: Bool
+            checks:
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+        datetime_col:
+            dtype: DateTime
+            checks:
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+    coerce: True
+    strict: False

--- a/tests/test_yaml_schema.py
+++ b/tests/test_yaml_schema.py
@@ -1,5 +1,6 @@
 """Test the yaml loading capabilities in pandera.yaml_schema"""
 
+from pathlib import Path
 from typing import Dict
 
 import pandas as pd
@@ -11,6 +12,7 @@ import yaml
 
 @pytest.fixture(scope='function')
 def sample_df():
+    """Multi-typed sample dataframe for the tests below"""
     return pd.DataFrame({
         "int_col": [1, 2, 3],
         "float_col": [1.1, 2.5, 9.9],
@@ -27,48 +29,8 @@ def sample_df():
 
 @pytest.fixture
 def sample_df_schema():
-    return """
-      dataframe:
-        checks:
-        columns:
-          int_col:
-            dtype: Int
-            checks: 
-            nullable: False
-            allow_duplicates: True
-            coerce: False
-            required: True
-          float_col:
-            dtype: Float
-            checks: 
-            nullable: False
-            allow_duplicates: True
-            coerce: False
-            required: True
-          str_col:
-            dtype: String
-            checks: 
-            nullable: False
-            allow_duplicates: True
-            coerce: False
-            required: True
-          bool_col:
-            dtype: Bool
-            checks: 
-            nullable: False
-            allow_duplicates: True
-            coerce: False
-            required: True
-          datetime_col:
-            dtype: DateTime
-            checks: 
-            nullable: False
-            allow_duplicates: True
-            coerce: False
-            required: True
-        coerce: True
-        strict: False
-      """
+    """YAML definition of a schema matching the dataframe of sample_df()"""
+    return open(Path(__file__).parent / 'test_yaml_schema-sample_df_schema.yml')
 
 
 def test_valid_yaml(sample_df_schema):
@@ -97,7 +59,7 @@ def update_nested_dict(old_dict: Dict, change_path: str, new_value) -> Dict:
     :param new_value: The new value which should be assigned to the specified
         key.
 
-    :return: A copy of the dictionary with the specified value beeing replaced.
+    :return: A copy of the dictionary with the specified value being replaced.
     """
     keys = change_path.split('.')
     if not keys[0] in old_dict:
@@ -142,7 +104,7 @@ def test_update_nested_dict_key_error(old, keypath, value):
 def test_invalid_schema(invalid_schema, error_match):
     """Pass an invalid yaml file and see if a SchemaDefinitionError is raised.
     """
-    with pytest.raises((pandera.SchemaDefinitionError), match=error_match):
+    with pytest.raises(pandera.SchemaDefinitionError, match=error_match):
         yaml_schema.df_schema_from_yaml(invalid_schema)
 
 

--- a/tests/test_yaml_schema.py
+++ b/tests/test_yaml_schema.py
@@ -1,0 +1,163 @@
+"""Test the yaml loading capabilities in pandera.yaml_schema"""
+
+from typing import Dict
+
+import pandas as pd
+import pytest
+import pandera
+from pandera import yaml_schema
+import yaml
+
+
+@pytest.fixture(scope='function')
+def sample_df():
+    return pd.DataFrame({
+        "int_col": [1, 2, 3],
+        "float_col": [1.1, 2.5, 9.9],
+        "str_col": ["z", "y", "x"],
+        "bool_col": [True, True, False],
+        "datetime_col": [
+            pd.Timestamp("2015-02-01"),
+            pd.Timestamp("2015-02-02"),
+            pd.Timestamp("2015-02-03")
+        ],
+        "unexpected_col": [1, 1, 1]
+    })
+
+
+@pytest.fixture
+def sample_df_schema():
+    return """
+      dataframe:
+        checks:
+        columns:
+          int_col:
+            dtype: Int
+            checks: 
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+          float_col:
+            dtype: Float
+            checks: 
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+          str_col:
+            dtype: String
+            checks: 
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+          bool_col:
+            dtype: Bool
+            checks: 
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+          datetime_col:
+            dtype: DateTime
+            checks: 
+            nullable: False
+            allow_duplicates: True
+            coerce: False
+            required: True
+        coerce: True
+        strict: False
+      """
+
+
+def test_valid_yaml(sample_df_schema):
+    """Simply check whether the test yaml is valid"""
+    yaml.safe_load(sample_df_schema)
+
+
+def test_schema_loadable(sample_df_schema):
+    """Try to create a DataFrameSchema object out of the yaml definition"""
+    yaml_schema.df_schema_from_yaml(sample_df_schema)
+
+
+def test_schema_validates_unmodified(sample_df, sample_df_schema):
+    """Unmodified the schema should be loadable and validate the sample df."""
+    schema = yaml_schema.df_schema_from_yaml(sample_df_schema)
+    schema.validate(sample_df)
+
+
+def update_nested_dict(old_dict: Dict, change_path: str, new_value) -> Dict:
+    """Update one value in a nested dict
+
+    :param old_dict: The dict whose value should be changed
+    :param change_path: The keys defining the key of the value to be changed.
+        Dot separated string. E.g. pass 'a.b' to change the value 'd[a][b]' in
+        the dictionary 'd'.
+    :param new_value: The new value which should be assigned to the specified
+        key.
+
+    :return: A copy of the dictionary with the specified value beeing replaced.
+    """
+    keys = change_path.split('.')
+    if not keys[0] in old_dict:
+        raise KeyError("Key %s not found" % keys[0])
+    new_dict = old_dict.copy()
+    if len(keys) == 1:
+        new_dict[keys[0]] = new_value
+    elif len(keys) > 1:
+        new_dict[keys[0]] = update_nested_dict(new_dict[keys[0]],
+                                               '.'.join(keys[1:]), new_value)
+    return new_dict
+
+
+@pytest.mark.parametrize('old, keypath, value, new', [
+    ({'a': 1}, 'a', 2, {'a': 2}),
+    ({'a': {'b': 1}}, 'a.b', 2, {'a': {'b': 2}}),
+    ({'a': {'b': 1}, 'b': 1}, 'a.b', 2, {'a': {'b': 2}, 'b': 1})
+])
+def test_update_nested_dict(old, keypath, value, new):
+    assert update_nested_dict(old, keypath, value) == new
+
+
+@pytest.mark.parametrize('old, keypath, value', [
+    ({}, 'a', 2),
+    ({}, 'a.b', 2),
+    ({'a': 1}, 'b', 2),
+    ({'a': {'b': 1}}, 'a.c', 2)
+])
+def test_update_nested_dict_key_error(old, keypath, value):
+    with pytest.raises(KeyError):
+        update_nested_dict(old, keypath, value)
+
+
+@pytest.mark.parametrize("invalid_schema, error_match",
+                         [("table:\n - x", "Expected key 'dataframe' missing"),
+                          ("dataframe:\n checks:\n  - some_check",
+                           "Invalid definition of dataframe check"),
+                          ("dataframe:\n columns:\n  x: []",
+                           "lacks a data type definition"),
+                          ("dataframe:\n columns:\n  x:\n   dtype: thing",
+                           "Unknown data type")])
+def test_invalid_schema(invalid_schema, error_match):
+    """Pass an invalid yaml file and see if a SchemaDefinitionError is raised.
+    """
+    with pytest.raises((pandera.SchemaDefinitionError), match=error_match):
+        yaml_schema.df_schema_from_yaml(invalid_schema)
+
+
+@pytest.mark.parametrize("change_path, new_value",
+                         [('dataframe.strict', True)])
+def test_schema_modifications(sample_df, sample_df_schema, change_path,
+                              new_value):
+    """Modify the yaml to find out if the individual changes are recognized.
+
+    Each modification should lead to a validation failure.
+    """
+    schema_dict = yaml.safe_load(sample_df_schema)
+    new_yaml = yaml.dump(update_nested_dict(schema_dict, change_path,
+                                            new_value))
+
+    schema = yaml_schema.df_schema_from_yaml(new_yaml)
+    with pytest.raises(pandera.SchemaError):
+        schema.validate(sample_df)


### PR DESCRIPTION
Addressing #91 (yaml import) and also partially #74 (built-in checks).

This is just a draft pull request for making the development more transparent and offering a place to discuss the code.

With what I have now it is possible to create a DataFrameSchema from yaml. Only the Checks are not yet serialized. 
The idea is that the parameters in the yaml file exactly reflect the keyword arguments of the Python code. 

E.g:
```yaml
 dataframe:
        checks:
        columns:
          int_col:
            dtype: Int
            checks: 
            nullable: False
        strict: False
```
addresses the equally named parameters of the DataFrameSchema and Column objects.

So the Python equivalent would be:
```python
DataFrameSchema(checks=None,
                columns={'int_col': Column(int, checks=None, nullable=False)},
                strict=False)
```

The yaml import function should move into the DataframeSchema as from_yaml(). But for now I kept everything in separate modules to avoid conflicts when the pandera module gets restructured.

Does this approach make sense so far? I am curious about any change ideas.