### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 codecov
-enum34
 flake8
 numpy >= 1.9.0
 pandas >= 0.23.0


### PR DESCRIPTION
removes enum34 which is no longer needed when Python 2 support is dropped in v2.0