### PR TITLE
implement pylint in CI & pre-commit hook, remove flake8, code compliance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v2.4.4
+    hooks:
+    -   id: pylint

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,9 @@
+[BASIC]
+good-names=
+    fn,
+    i,
+    e,
+    logger,
+
+[MESSAGES CONTROL]
+disable=R0913,C0103,R1705,R1720,W0222,R1721,C0116,W0613,C0114,R0205,R0201,C0115,W0122,W0212

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,6 @@ script:
   - pytest --cov=pandera tests/
   - codecov
   # Check conformity to flake8 style guide
-  - flake8 pandera/pandera.py tests
+  - pylint pandera tests
   # Check docs can build, treating warnings as errors
   - python -m sphinx -E -W -b=doctest "docs/source" "docs/_build"

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,3 +1,5 @@
+"""A flexible and expressive pandas validation library."""
+
 from . import errors, constants
 from .checks import Check
 from .hypotheses import Hypothesis

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -1,8 +1,8 @@
 """Data validation checks."""
 
-import pandas as pd
-
 from typing import Union, Optional, List, Dict, Callable
+
+import pandas as pd
 
 from . import errors, constants
 from .dtypes import PandasDtype
@@ -17,7 +17,7 @@ SeriesCheckObj = Union[pd.Series, Dict[str, pd.Series]]
 DataFrameCheckObj = Union[pd.DataFrame, Dict[str, pd.DataFrame]]
 
 
-class Check(object):
+class Check():
     """Check a pandas Series or DataFrame for certain properties."""
 
     def __init__(
@@ -143,6 +143,7 @@ class Check(object):
         if isinstance(groups, str):
             groups = [groups]
         self.groups = groups
+        self.failure_cases = None
 
     @property
     def _error_message(self):
@@ -166,11 +167,11 @@ class Check(object):
 
         """
         return (
-                "%s failed element-wise validator %d:\n"
-                "%s\nfailure cases:\n%s" %
-                (parent_schema, check_index,
-                 self._error_message,
-                 self._format_failure_cases(failure_cases)))
+            "%s failed element-wise validator %d:\n"
+            "%s\nfailure cases:\n%s" %
+            (parent_schema, check_index,
+             self._error_message,
+             self._format_failure_cases(failure_cases)))
 
     def _generic_error_message(
             self,
@@ -247,7 +248,8 @@ class Check(object):
             self,
             groupby_obj: GroupbyObject,
             groups: List[str]
-            ) -> Union[Dict[str, Union[pd.Series, pd.DataFrame]]]:
+        ) -> Union[Dict[str, Union[pd.Series, pd.DataFrame]]]:
+        # pylint: disable=no-self-use
         """Format groupby object into dict of groups to Series or DataFrame.
 
         :param groupby_obj: a pandas groupby object.
@@ -296,7 +298,7 @@ class Check(object):
 
         return self._format_groupby_input(groupby_obj, self.groups)
 
-    def _prepare_dataframe_input(
+    def prepare_dataframe_input(
             self, dataframe: pd.DataFrame) -> DataFrameCheckObj:
         """Prepare input for DataFrameSchema check.
 
@@ -315,7 +317,7 @@ class Check(object):
             parent_schema: type,
             check_index: int,
             check_obj: Dict[str, Union[pd.Series, pd.DataFrame]]
-            ) -> bool:
+        ) -> bool:
         """Perform a vectorized check on a series.
 
         :param parent_schema: class of schema being validated.

--- a/pandera/constants.py
+++ b/pandera/constants.py
@@ -1,1 +1,2 @@
-N_FAILURE_CASES = 10
+"""Constants for use across the library"""
+N_FAILURE_CASES = 10 #The number of failure cases to report.

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -97,6 +97,7 @@ def check_input(
             instance: Union[None, Any],
             args: Tuple[Any],
             kwargs: Dict[str, Any]):
+        # pylint: disable=unused-argument
         """Check pandas DataFrame or Series before calling the function.
 
         :param fn: check the DataFrame or Series input of this function
@@ -113,17 +114,17 @@ def check_input(
                 args[obj_getter] = schema.validate(args[obj_getter])
             except IndexError as e:
                 raise errors.SchemaError(
-                        "error in check_input decorator of function '%s': the "
-                        "index '%s' was supplied to the check but this "
-                        "function accepts '%s' arguments, so the maximum "
-                        "index is '%s'. The full error is: '%s'" %
-                        (fn.__name__,
-                         obj_getter,
-                         len(_get_fn_argnames(fn)),
-                         max(0, len(_get_fn_argnames(fn))-1),
-                         e
-                         )
-                        )
+                    "error in check_input decorator of function '%s': the "
+                    "index '%s' was supplied to the check but this "
+                    "function accepts '%s' arguments, so the maximum "
+                    "index is '%s'. The full error is: '%s'" %
+                    (fn.__name__,
+                     obj_getter,
+                     len(_get_fn_argnames(fn)),
+                     max(0, len(_get_fn_argnames(fn))-1),
+                     e
+                     )
+                    )
         elif isinstance(obj_getter, str):
             if obj_getter in kwargs:
                 kwargs[obj_getter] = schema.validate(kwargs[obj_getter])
@@ -220,6 +221,7 @@ def check_output(
             instance: Union[None, Any],
             args: Tuple[Any],
             kwargs: Dict[str, Any]):
+        # pylint: disable=unused-argument
         """Check pandas DataFrame or Series before calling the function.
 
         :param fn: check the DataFrame or Series output of this function

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -3,14 +3,11 @@
 
 class SchemaInitError(Exception):
     """Raised when schema initialization fails."""
-    pass
 
 
 class SchemaDefinitionError(Exception):
     """Raised when schema definition is invalid on object validation."""
-    pass
 
 
 class SchemaError(Exception):
     """Raised when object does not pass schema validation constraints."""
-    pass

--- a/pandera/hypotheses.py
+++ b/pandera/hypotheses.py
@@ -1,11 +1,10 @@
 """Data validation checks for hypothesis testing."""
 
-import pandas as pd
-
 from functools import partial
-
-from scipy import stats
 from typing import Callable, Union, Optional, List, Dict
+
+import pandas as pd
+from scipy import stats
 
 from . import errors
 from .checks import Check
@@ -160,7 +159,7 @@ class Hypothesis(Check):
         return super(Hypothesis, self)._prepare_series_input(
             series, dataframe_context)
 
-    def _prepare_dataframe_input(self, dataframe: pd.DataFrame):
+    def prepare_dataframe_input(self, dataframe: pd.DataFrame):
         """Prepare input for DataFrameSchema Hypothesis check."""
         if self.groupby is not None:
             raise errors.SchemaDefinitionError(

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -11,6 +11,7 @@ from .schemas import DataFrameSchema, SeriesSchemaBase
 
 
 class Column(SeriesSchemaBase):
+    """Extends SeriesSchemaBase with Column-specific options"""
 
     def __init__(
             self,
@@ -67,7 +68,7 @@ class Column(SeriesSchemaBase):
         """Whether the schema or schema component allows groupby operations."""
         return True
 
-    def _set_name(self, name: str):
+    def set_name(self, name: str):
         """Used to set or modify the name of a column object.
 
         :param str name: the name of the column object
@@ -93,6 +94,7 @@ class Column(SeriesSchemaBase):
 
 
 class Index(SeriesSchemaBase):
+    """Extends SeriesSchemaBase with Index-specific options"""
 
     def __init__(
             self,
@@ -156,6 +158,7 @@ class Index(SeriesSchemaBase):
 
 
 class MultiIndex(DataFrameSchema):
+    """Extends SeriesSchemaBase with Multi-index-specific options"""
 
     def __init__(
             self,
@@ -211,7 +214,7 @@ class MultiIndex(DataFrameSchema):
             columns={
                 i if index._name is None else index._name: Column(
                     pandas_dtype=index._pandas_dtype,
-                    checks=index._checks,
+                    checks=index.checks,
                     nullable=index._nullable,
                     allow_duplicates=index._allow_duplicates,
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 codecov
-flake8
 numpy >= 1.9.0
 pandas >= 0.23.0
+pre_commit
+pylint
 pytest
 pytest-cov
 scipy >= 1.2.0

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -123,8 +123,7 @@ def test_check_function_decorator_errors():
 
     with pytest.raises(
             errors.SchemaError,
-            match=r"^error in check_input decorator of function"
-            ):
+            match=r"^error in check_input decorator of function"):
         test_incorrect_check_input_index(pd.DataFrame({"column1": [1, 2, 3]})
                                          )
 
@@ -165,6 +164,7 @@ def test_check_input_method_decorators():
         return df.assign(column2=[1, 2, 3])
 
     class TransformerClass(object):
+        """A repeatable set of decorator input styles for testing"""
 
         @check_input(in_schema)
         @check_output(out_schema)

--- a/tests/test_hypotheses.py
+++ b/tests/test_hypotheses.py
@@ -1,10 +1,11 @@
 import pandas as pd
 import pytest
+from scipy import stats
 
 from pandera import errors
 from pandera import (
     Column, DataFrameSchema, Float, Int, String, Hypothesis)
-from scipy import stats
+
 
 
 def test_dataframe_hypothesis_checks():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2,10 +2,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandera import errors
 from pandera import (
-    Column, DataFrameSchema, Index,  SeriesSchema, Bool, Category, Check,
-    DateTime, Float, Int, Object, String, Timedelta)
+    Column, DataFrameSchema, Index, SeriesSchema, Bool, Category, Check,
+    DateTime, Float, Int, Object, String, Timedelta, errors)
 
 
 def test_dataframe_schema():
@@ -30,20 +29,21 @@ def test_dataframe_schema():
                         Check(lambda x: x < pd.Timedelta(10, unit="D"),
                               element_wise=True))
         })
-    df = pd.DataFrame({
-        "a": [1, 2, 3],
-        "b": [1.1, 2.5, 9.9],
-        "c": ["z", "y", "x"],
-        "d": [True, True, False],
-        "e": pd.Series(["c2", "c1", "c3"], dtype="category"),
-        "f": [(3,), (2,), (1,)],
-        "g": [pd.Timestamp("2015-02-01"),
-              pd.Timestamp("2015-02-02"),
-              pd.Timestamp("2015-02-03")],
-        "i": [pd.Timedelta(1, unit="D"),
-              pd.Timedelta(5, unit="D"),
-              pd.Timedelta(9, unit="D")]
-    })
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [1.1, 2.5, 9.9],
+            "c": ["z", "y", "x"],
+            "d": [True, True, False],
+            "e": pd.Series(["c2", "c1", "c3"], dtype="category"),
+            "f": [(3,), (2,), (1,)],
+            "g": [pd.Timestamp("2015-02-01"),
+                  pd.Timestamp("2015-02-02"),
+                  pd.Timestamp("2015-02-03")],
+            "i": [pd.Timedelta(1, unit="D"),
+                  pd.Timedelta(5, unit="D"),
+                  pd.Timedelta(9, unit="D")]
+        })
     assert isinstance(schema.validate(df), pd.DataFrame)
 
     # error case
@@ -143,6 +143,7 @@ def test_series_schema_multiple_validators():
 
 
 class SeriesGreaterCheck:
+    # pylint: disable=too-few-public-methods
     """Class creating callable objects to check if series elements exceed a
     lower bound.
     """
@@ -176,12 +177,13 @@ def series_greater_than_ten(s: pd.Series):
     (SeriesGreaterCheck(lower_bound=10), True)
 ])
 def test_dataframe_schema_check_function_types(check_function, should_fail):
-    schema = DataFrameSchema({
+    schema = DataFrameSchema(
+        {
             "a": Column(Int,
                         Check(fn=check_function, element_wise=False)),
             "b": Column(Float,
                         Check(fn=check_function, element_wise=False))
-    })
+        })
     df = pd.DataFrame({
         "a": [1, 2, 3],
         "b": [1.1, 2.5, 9.9]


### PR DESCRIPTION
Addresses #108, pylinting and associated changes.

This PR has two major parts:
1. CI Improvements
- implements pylint in the CI process
- drops flake8 which was looking at pandera.py only
- adds pylint pre-commit-hook configs
- the following files are affected: `.travis.yml`, `.pre-commit-config.yaml`, `requirements.txt`

2. Code changes due to pylint
- Changes genuine pylint failures or one-off issues
- Adds `# pylint: disable=` to a small number of functions where we probably don't want to change the functions as it would make the whole code more confusing
- Uses a `.pylintrc` file to disable the classes of error below

I've tried to limit this PR to be as small as possible and made changes only when they're relatively minor.

Some of the ignored error classes should be revisited, but they'd require larger changes to fix and would be better handled in separate PRs where it's clearer what is changing.

R0913 too-many-arguments:
 	Too many arguments (%s/%s) Used when a function or method takes too many arguments.
C0103 invalid-name:
 	%s name "%s" doesn't conform to %s Used when the name doesn't conform to naming rules associated to its type (constant, variable, class...).
R1705 no-else-return
 	Unnecessary "%s" after "return" Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.
R1720 no-else-raise:
 	Unnecessary "%s" after "raise" Used in order to highlight an unnecessary block of code following an if containing a raise statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a raise statement.
R1721 unnecessary-comprehension:
 	Unnecessary use of a comprehension Instead of using an identitiy comprehension, consider using the list, dict or set constructor. It is faster and simpler.
W0222 signature-differs:
 	Signature differs from %s %r method Used when a method signature is different than in the implemented interface or in an overridden method.