### PR TITLE
coerce=True should work when supplying string dtypes

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -163,14 +163,12 @@ class DataFrameSchema():
                     check.prepare_dataframe_input(dataframe)))
         return all(val_results)
 
-
     @property
     def dtype(self) -> Dict[str, str]:
         """A pandas style dtype dict where the keys are column names and values
         are pandas dtype for the column
         """
         return {k: v.dtype for k, v in self.columns.items()}
-
 
     def validate(
             self,
@@ -334,33 +332,24 @@ class SeriesSchemaBase():
         """Whether to coerce series to specified type."""
         return self._coerce
 
-
     @property
     def dtype(self) -> str:
-        """String representation of the dtype
-        """
+        """String representation of the dtype."""
         return self._pandas_dtype if (
             isinstance(self._pandas_dtype, str) or self._pandas_dtype is None
         ) else self._pandas_dtype.value
 
-
     def coerce_dtype(self, series: pd.Series) -> pd.Series:
-        """Coerce the type of a pd.Series by the type specified in the Column
-            object's self._pandas_dtype
+        """Coerce type of a pd.Series by type specified in pandas_dtype.
 
         :param pd.Series series: One-dimensional ndarray with axis labels
             (including time series).
         :returns: ``Series`` with coerced data type
-
         """
-        _dtype = str if self._pandas_dtype is dtypes.PandasDtype.String \
-            else self._pandas_dtype.value
-        if _dtype is str:
+        if self._pandas_dtype is dtypes.PandasDtype.String:
             # only coerce non-null elements to string
-            _series = series.copy()
-            _series[series.notna()] = _series[series.notna()].astype(str)
-            return _series
-        return series.astype(_dtype)
+            return series.where(series.isna(), series.astype(str))
+        return series.astype(self.dtype)
 
     @property
     def _allow_groupby(self):

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -33,8 +33,7 @@ def test_numeric_dtypes():
             dtypes.Float,
             dtypes.Float16,
             dtypes.Float32,
-            dtypes.Float64
-            ]:
+            dtypes.Float64]:
         assert all(
             isinstance(
                 schema.validate(

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -33,13 +33,21 @@ def test_numeric_dtypes():
             dtypes.Float,
             dtypes.Float16,
             dtypes.Float32,
-            dtypes.Float64]:
-        schema = DataFrameSchema({"col": Column(dtype, nullable=False)})
-        validated_df = schema.validate(
-            pd.DataFrame(
-                {"col": [-123.1, -7654.321, 1.0, 1.1, 1199.51, 5.1, 4.6]},
-                dtype=dtype.value))
-        assert isinstance(validated_df, pd.DataFrame)
+            dtypes.Float64
+            ]:
+        assert all(
+            isinstance(
+                schema.validate(
+                    pd.DataFrame(
+                        {"col": [-123.1, -7654.321, 1.0, 1.1, 1199.51, 5.1]},
+                        dtype=dtype.value)),
+                pd.DataFrame
+            )
+            for schema in [
+                DataFrameSchema({"col": Column(dtype, nullable=False)}),
+                DataFrameSchema({"col": Column(dtype.value, nullable=False)})
+            ]
+        )
 
     for dtype in [
             dtypes.Int,
@@ -47,23 +55,38 @@ def test_numeric_dtypes():
             dtypes.Int16,
             dtypes.Int32,
             dtypes.Int64]:
-        schema = DataFrameSchema({"col": Column(dtype, nullable=False)})
-        validated_df = schema.validate(
-            pd.DataFrame(
-                {"col": [-712, -4, -321, 0, 1, 777, 5, 123, 9000]},
-                dtype=dtype.value))
-        assert isinstance(validated_df, pd.DataFrame)
+        assert all(
+            isinstance(
+                schema.validate(
+                    pd.DataFrame(
+                        {"col": [-712, -4, -321, 0, 1, 777, 5, 123, 9000]},
+                        dtype=dtype.value)),
+                pd.DataFrame
+            )
+            for schema in [
+                DataFrameSchema({"col": Column(dtype, nullable=False)}),
+                DataFrameSchema({"col": Column(dtype.value, nullable=False)})
+            ]
+        )
 
     for dtype in [
             dtypes.UInt8,
             dtypes.UInt16,
             dtypes.UInt32,
             dtypes.UInt64]:
-        schema = DataFrameSchema({"col": Column(dtype, nullable=False)})
-        validated_df = schema.validate(
-            pd.DataFrame(
-                {"col": [1, 777, 5, 123, 9000]}, dtype=dtype.value))
-        assert isinstance(validated_df, pd.DataFrame)
+        assert all(
+            isinstance(
+                schema.validate(
+                    pd.DataFrame(
+                        {"col": [1, 777, 5, 123, 9000]},
+                        dtype=dtype.value)),
+                pd.DataFrame
+            )
+            for schema in [
+                DataFrameSchema({"col": Column(dtype, nullable=False)}),
+                DataFrameSchema({"col": Column(dtype.value, nullable=False)})
+            ]
+        )
 
 
 def test_category_dtype():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -9,6 +9,7 @@ from pandera import (
     DateTime, Float, Int, Object, String, Timedelta, errors)
 from tests.test_dtypes import TESTABLE_DTYPES
 
+
 def test_dataframe_schema():
     """Tests the Checking of a DataFrame that has a wide variety of types and
     conditions. Tests include: when the Schema works, when a column is dropped,


### PR DESCRIPTION
this diff fixes a bug where coerce=True would not work if
a legal pandas string argument is passed into the `pandas_dtype`.
Update the unit tests to enforce this