### PR TITLE
fix reqts-dev.txt generator script

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  # required
   - python
 
   # environment management

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 # This file is auto-generated from environment.yml, do not modify.
 # See that file for comments about the need/usage of each dependency.
 
-python
 pip
 sphinx
 sphinx_rtd_theme

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -51,6 +51,9 @@ def conda_package_to_pip(package):
 
         break
 
+    if package in EXCLUDE:
+        return
+
     if package in RENAME:
         return RENAME[package]
 


### PR DESCRIPTION
The ReadTheDocs builds are still failing because `python` is included in the pip `requirements-dev.txt` file, which pip doesn't like.

This is a slight oversight in the original auto-generate script which this PR fixes. The script has also been run to include the updated file which should fix the ReadTheDocs build issues.