### PR TITLE
re-order CI, add comments and check reqts.txt generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,10 +77,16 @@ install:
     conda list
 
 script:
+  # Use the conda environment
   - source activate hosts
+  # Tests
   - pytest --cov=pandera tests/
+  # Coverage
   - codecov
-  # Check conformity to flake8 style guide
-  - pylint pandera tests
   # Check docs can build, treating warnings as errors
   - python -m sphinx -E -W -b=doctest "docs/source" "docs/_build"
+  # Dependencies
+  # Check that requirements-dev.text is generated exclusively by environment.yml
+  - python ./scripts/generate_pip_deps_from_conda.py --compare
+  # Linting
+  - pylint pandera tests

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -90,12 +90,13 @@ def main(conda_fname, pip_fname, compare=False):
         elif isinstance(dep, dict) and len(dep) == 1 and "pip" in dep:
             pip_deps += dep["pip"]
         else:
-            raise ValueError(f"Unexpected dependency {dep}")
+            raise ValueError("Unexpected dependency %s" % dep)
 
     fname = os.path.split(conda_fname)[1]
     header = (
-        f"# This file is auto-generated from {fname}, do not modify.\n"
-        "# See that file for comments about the need/usage of each dependency.\n\n"
+        "# This file is auto-generated from %s, do not modify.\n"
+        "# See that file for comments about the need/usage of "
+        "each dependency.\n\n" % fname
     )
     pip_content = header + "\n".join(pip_deps)
 
@@ -130,13 +131,13 @@ if __name__ == "__main__":
     )
     if res:
         msg = (
-            f"`requirements-dev.txt` has to be generated with `{sys.argv[0]}` after "
-            "`environment.yml` is modified.\n"
+            "`requirements-dev.txt` has to be generated with `%s` after "
+            "`environment.yml` is modified.\n" % sys.argv[0]
         )
         if args.azure:
             msg = (
                 "##vso[task.logissue type=error;"
-                f"sourcepath=requirements-dev.txt]{msg}"
+                "sourcepath=requirements-dev.txt]%s" % msg
             )
         sys.stderr.write(msg)
     sys.exit(res)


### PR DESCRIPTION
This PR:
- re-orders the CI in order of execution time
  - `pylint` takes much longer than the documentation build, so I've moved it to the end. This will cause the CI pipelines to fail quicker (if ∃ a failure)
- adds comments to CI script steps
- adds a check to ensure that `requirements-dev.txt` matches `environment.yml`