### PR TITLE
feature/refactor-checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,4 +8,4 @@ good-names=
     x,
 
 [MESSAGES CONTROL]
-disable=R0913,W0222
+disable=R0913

--- a/pandera/error_formatters.py
+++ b/pandera/error_formatters.py
@@ -1,0 +1,105 @@
+"""Make schema error messages human-friendly."""
+
+from typing import Union
+
+import pandas as pd
+
+from .checks import Check
+
+
+def format_generic_error_message(
+        parent_schema,
+        check: Check,
+        check_index: int,
+) -> str:
+    """Construct an error message when a check validator fails.
+
+    :param parent_schema: class of schema being validated.
+    :param check: check that generated error.
+    :param check_index: The validator that failed.
+    """
+    return "%s failed series validator %d: %s" % \
+        (parent_schema, check_index, check)
+
+
+def format_vectorized_error_message(
+        parent_schema,
+        check: Check,
+        check_index: int,
+        failure_cases: pd.Series) -> str:
+    """Construct an error message when a validator fails.
+
+    :param parent_schema: class of schema being validated.
+    :param check: check that generated error.
+    :param check_index: The validator that failed.
+    :param failure_cases: The failure cases encountered by the element-wise
+        or vectorized validator.
+
+    """
+    return (
+        "%s failed element-wise validator %d:\n"
+        "%s\nfailure cases:\n%s" % (
+            parent_schema,
+            check_index,
+            check,
+            format_failure_cases(failure_cases, check.n_failure_cases)
+        )
+    )
+
+
+def format_failure_cases(
+        failure_cases: Union[pd.DataFrame, pd.Series],
+        n_cases: int) -> pd.DataFrame:
+    """Construct readable error messages for vectorized_error_message.
+
+    :param failure_cases: The failure cases encountered by the element-wise
+        or vectorized validator.
+    :returns: DataFrame where index contains failure cases, the "index"
+        column contains a list of integer indexes in the validation
+        DataFrame that caused the failure, and a "count" column
+        representing how many failures of that case occurred.
+
+    """
+    if hasattr(failure_cases, "index") and \
+            isinstance(failure_cases.index, pd.MultiIndex):
+        index_name = failure_cases.index.name
+        failure_cases = (
+            failure_cases
+            .rename("failure_case")
+            .reset_index()
+            .assign(
+                index=lambda df: (
+                    df.apply(tuple, axis=1).astype(str)
+                )
+            )
+        )
+    elif isinstance(failure_cases, pd.DataFrame):
+        index_name = failure_cases.index.name
+        failure_cases = (
+            failure_cases
+            .pipe(lambda df: pd.Series(
+                df.itertuples()).map(lambda x: x.__repr__()))
+            .rename("failure_case")
+            .reset_index()
+        )
+    elif isinstance(failure_cases, pd.Series):
+        index_name = failure_cases.index.name
+        failure_cases = (
+            failure_cases
+            .rename("failure_case")
+            .reset_index()
+        )
+    else:
+        raise TypeError(
+            "type of failure_cases argument not understood: %s" %
+            type(failure_cases))
+
+    index_name = "index" if index_name is None else index_name
+    failure_cases = (
+        failure_cases
+        .groupby("failure_case")[index_name].agg([list, len])
+        .rename(columns={"list": index_name, "len": "count"})
+        .sort_values("count", ascending=False)
+    )
+
+    return failure_cases.head(n_cases)

--- a/pandera/hypotheses.py
+++ b/pandera/hypotheses.py
@@ -7,7 +7,7 @@ import pandas as pd
 from scipy import stats
 
 from . import errors
-from .checks import Check
+from .checks import Check, SeriesCheckObj, DataFrameCheckObj
 
 
 DEFAULT_ALPHA = 0.01
@@ -144,22 +144,15 @@ class Hypothesis(Check):
     def _prepare_series_input(
             self,
             series: pd.Series,
-            dataframe_context: pd.DataFrame):
-        """Prepare input for Hypothesis check.
-
-        :param pd.Series series: One-dimensional ndarray with axis labels
-            (including time series).
-        :param pd.DataFrame dataframe_context: optional dataframe to supply
-            when checking a Column in a DataFrameSchema.
-        :return: a check_obj dictionary of pd.Series to be used by `_check_fn`
-            and `_vectorized_check`
-
-        """
+            dataframe_context: pd.DataFrame = None
+    ) -> SeriesCheckObj:
+        """Prepare Series input for Hypothesis check."""
         self.groups = self.samples
         return super(Hypothesis, self)._prepare_series_input(
             series, dataframe_context)
 
-    def prepare_dataframe_input(self, dataframe: pd.DataFrame):
+    def _prepare_dataframe_input(
+            self, dataframe: pd.DataFrame) -> DataFrameCheckObj:
         """Prepare input for DataFrameSchema Hypothesis check."""
         if self.groupby is not None:
             raise errors.SchemaDefinitionError(

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -77,13 +77,12 @@ class Column(SeriesSchemaBase):
         self._name = name
         return self
 
-    def __call__(self, df: pd.DataFrame) -> bool:
+    def __call__(self, df_or_series: Union[pd.DataFrame, pd.Series]) -> bool:
         """Validate DataFrameSchema Column."""
         if self._name is None:
             raise RuntimeError(
                 "need to `set_name` of column before calling it.")
-        return super(Column, self).__call__(
-            df[self._name], dataframe_context=df.drop(self._name, axis=1))
+        return super(Column, self).__call__(df_or_series)
 
     def __repr__(self):
         if isinstance(self._pandas_dtype, PandasDtype):
@@ -150,9 +149,9 @@ class Index(SeriesSchemaBase):
         """Whether the schema or schema component allows groupby operations."""
         return False
 
-    def __call__(self, df: pd.DataFrame) -> bool:
+    def __call__(self, df_or_series: Union[pd.DataFrame, pd.Series]) -> bool:
         """Validate DataFrameSchema Index."""
-        return super(Index, self).__call__(pd.Series(df.index))
+        return super(Index, self).__call__(pd.Series(df_or_series.index))
 
     def __repr__(self):
         if self._name is None:
@@ -231,10 +230,14 @@ class MultiIndex(DataFrameSchema):
             strict=strict,
         )
 
-    def __call__(self, df: pd.DataFrame) -> bool:
+    def __call__(self, df_or_series: Union[pd.DataFrame, pd.Series]) -> bool:
+        # pylint: disable=signature-differs,W0222
+        # false positive warning is raised here, even though method signature
+        # is exactly the same. Will need to investigate why this is being
+        # raised.
         """Validate DataFrameSchema MultiIndex."""
         return isinstance(
-            super(MultiIndex, self).__call__(df.index.to_frame()),
+            super(MultiIndex, self).__call__(df_or_series.index.to_frame()),
             pd.DataFrame
         )
 

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Union, Dict
 
 import pandas as pd
 
-from . import errors, constants, dtypes
+from . import errors, constants, dtypes, error_formatters
 from .checks import Check
 
 
@@ -154,14 +154,12 @@ class DataFrameSchema():
             pd.concat(dataframe_subsample).drop_duplicates()
 
     def _check_dataframe(self, dataframe):
-        val_results = []
+        check_results = []
         for check_index, check in enumerate(self.checks):
-            val_results.append(
-                check(
-                    self,
-                    check_index,
-                    check.prepare_dataframe_input(dataframe)))
-        return all(val_results)
+            check_results.append(
+                _handle_check_results(self, check_index, check, dataframe)
+            )
+        return all(check_results)
 
     @property
     def dtype(self) -> Dict[str, str]:
@@ -239,10 +237,12 @@ class DataFrameSchema():
 
         dataframe_to_validate = self._dataframe_to_validate(
             dataframe, head, tail, sample, random_state)
+
         assert (
             all(schema_component(dataframe_to_validate)
                 for schema_component in schema_components)
-            and self._check_dataframe(dataframe))
+            and self._check_dataframe(dataframe_to_validate))
+
         if self.transformer is not None:
             dataframe = self.transformer(dataframe)
 
@@ -337,6 +337,11 @@ class SeriesSchemaBase():
         return self._coerce
 
     @property
+    def name(self) -> str:
+        """Get SeriesSchema name."""
+        return self._name
+
+    @property
     def dtype(self) -> str:
         """String representation of the dtype."""
         return self._pandas_dtype if (
@@ -362,12 +367,17 @@ class SeriesSchemaBase():
             "The _allow_groupby property must be implemented by subclasses "
             "of SeriesSchemaBase")
 
-    def __call__(
-            self,
-            series: pd.Series,
-            dataframe_context: pd.DataFrame = None) -> bool:
+    def __call__(self, df_or_series: Union[pd.DataFrame, pd.Series]) -> bool:
         # pylint: disable=too-many-branches,W0212
-        """Validate a series."""
+        """Validate a series.
+
+        :df_or_series: pandas DataFrame of Series to validate.
+        :returns: True if validation checks pass.
+
+        """
+        series = df_or_series if isinstance(df_or_series, pd.Series) \
+            else df_or_series[self.name]
+
         if series.name != self._name:
             raise errors.SchemaError(
                 "Expected %s to have name '%s', found '%s'" %
@@ -377,8 +387,6 @@ class SeriesSchemaBase():
 
         if self._nullable:
             series = series.dropna()
-            if dataframe_context is not None:
-                dataframe_context = dataframe_context.loc[series.index]
             if _dtype in ["int_", "int8", "int16", "int32", "int64", "uint8",
                           "uint16", "uint32", "uint64"]:
                 _series = series.astype(_dtype)
@@ -427,14 +435,20 @@ class SeriesSchemaBase():
                 "expected series '%s' to have type %s, got %s" %
                 (series.name, _dtype, series.dtype))
 
-        val_results = []
+        check_results = []
+
+        if isinstance(df_or_series, pd.Series):
+            check_args = (series, )
+        else:
+            df_or_series = df_or_series.loc[series.index]
+            df_or_series[self.name] = series
+            check_args = (df_or_series, self.name)
+
         for check_index, check in enumerate(self.checks):
-            val_results.append(
-                check(
-                    self,
-                    check_index,
-                    check._prepare_series_input(series, dataframe_context)))
-        return all(val_results)
+            check_results.append(
+                _handle_check_results(self, check_index, check, *check_args)
+            )
+        return all(check_results)
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
@@ -523,3 +537,27 @@ class SeriesSchema(SeriesSchemaBase):
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
+
+
+def _handle_check_results(
+        schema: Union[DataFrameSchema, SeriesSchemaBase],
+        check_index: int,
+        check: Check,
+        *check_args) -> bool:
+    """Handle check results, raising SchemaError on check failure.
+
+    :param check_index: index of check in the schema component check list.
+    :param check: Check object used to validate pandas object.
+    :param check_args: arguments to pass into check object.
+    """
+    check_result = check(*check_args)
+    if not check_result.check_passed:
+        if check_result.failure_cases is None:
+            raise errors.SchemaError(
+                error_formatters.format_generic_error_message(
+                    schema, check, check_index))
+        raise errors.SchemaError(
+            error_formatters.format_vectorized_error_message(
+                schema, check, check_index, check_result.failure_cases)
+        )
+    return check_result.check_passed

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -4,7 +4,7 @@ import copy
 import pandas as pd
 import pytest
 
-from pandera import errors
+from pandera import errors, error_formatters
 from pandera import (
     Column, DataFrameSchema, Index, SeriesSchema, Bool,
     Check, Float, Int, String)
@@ -265,7 +265,7 @@ def test_format_failure_case_exceptions():
     check = Check(lambda x: x.isna().sum() == 0)
     for data in [1, "foobar", 1.0, {"key": "value"}, list(range(10))]:
         with pytest.raises(TypeError):
-            check._format_failure_cases(data)
+            error_formatters.format_failure_cases(data, check.n_failure_cases)
 
 
 def test_check_equality_operators():

--- a/tests/test_hypotheses.py
+++ b/tests/test_hypotheses.py
@@ -9,7 +9,6 @@ from pandera import (
     Column, DataFrameSchema, Float, Int, String, Hypothesis)
 
 
-
 def test_dataframe_hypothesis_checks():
     """Test that two specific implementations of a Hypothesis work as expected
     and that using a Column that wasn't defined will error."""


### PR DESCRIPTION
This diff makes the Check API cleaner by moving out the
error handling into the schema doing the data validation
instead of within the `__call__` subroutine.

This also standardizes the `Check.__call__` signature such that
it takes the dataframe or series object to be checked.

This also cleans up the SeriesSchemaBase API and its subclasses,
where the `__call__` method takes a single argument df_or_series,
which is the object to be checked.