### PR TITLE
fix and enhance multi index docstring

### DIFF
--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -163,7 +163,12 @@ class Index(SeriesSchemaBase):
 
 
 class MultiIndex(DataFrameSchema):
-    """Extends SeriesSchemaBase with Multi-index-specific options"""
+    """Extends DataFrameSchema with Multi-index-specific options.
+
+    Because MultiIndex.__call__ converts the index to a dataframe via
+    to_frame(), each index is treated as a series and it makes sense to inherit
+    the `__call__` and `validate` methods from DataFrameSchema.
+    """
 
     def __init__(
             self,

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -165,9 +165,9 @@ class Index(SeriesSchemaBase):
 class MultiIndex(DataFrameSchema):
     """Extends DataFrameSchema with Multi-index-specific options.
 
-    Because MultiIndex.__call__ converts the index to a dataframe via
-    to_frame(), each index is treated as a series and it makes sense to inherit
-    the `__call__` and `validate` methods from DataFrameSchema.
+    Because `MultiIndex.__call__` converts the index to a dataframe via
+    `to_frame()`, each index is treated as a series and it makes sense to
+    inherit the `__call__` and `validate` methods from DataFrameSchema.
     """
 
     def __init__(


### PR DESCRIPTION
Thanks for clarifying why multi-index inherits from `DataFramSchema`. This PR fixes my mistake in the original docstring of multi-index and extends it with your reasoning. Without this it's not super obvious why we inherit from `DataFrameSchema` over `SeriesSchemaBase`.