### PR TITLE
bugfix: string and object coercion work correctly

### DIFF
--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -24,7 +24,10 @@ class PandasDtype(Enum):
     UInt32 = "uint32"
     UInt64 = "uint64"
     Object = "object"
-    String = "object"
+    # the string datatype doesn't map to a unique string representation and is
+    # representated as a numpy object array. This will change after pandas 1.0,
+    # but for now will need to handle this as a special case.
+    String = "string"
     Timedelta = "timedelta64[ns]"
 
 

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -394,9 +394,14 @@ class SeriesSchemaBase():
     @property
     def dtype(self) -> str:
         """String representation of the dtype."""
-        return self._pandas_dtype if (
-            isinstance(self._pandas_dtype, str) or self._pandas_dtype is None
-        ) else self._pandas_dtype.value
+        if isinstance(self._pandas_dtype, str) or self._pandas_dtype is None:
+            dtype = self._pandas_dtype
+        elif self._pandas_dtype is dtypes.PandasDtype.String:
+            # handle special case of string.
+            dtype = dtypes.PandasDtype.Object.value
+        else:
+            dtype = self._pandas_dtype.value
+        return dtype
 
     def coerce_dtype(
             self, series_or_index: Union[pd.Series, pd.Index]) -> pd.Series:
@@ -453,6 +458,7 @@ class SeriesSchemaBase():
                         "series '%s' to be int, found: %s" %
                         (series.name, set(series)))
                 series = _series
+
         nulls = series.isnull()
         if nulls.sum() > 0:
             if series.dtype != _dtype:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -261,6 +261,7 @@ def test_coerce_dtype_in_dataframe():
 
 def test_coerce_dtype_nullable_str():
     """Tests how null values are handled in string dtypes."""
+    # dataframes with columns where the last two values are null
     df_nans = pd.DataFrame({
         "col": ["foobar", "foo", "bar", "baz", np.nan, np.nan],
     })
@@ -279,7 +280,12 @@ def test_coerce_dtype_nullable_str():
     })
 
     for df in [df_nans, df_nones]:
-        assert isinstance(schema.validate(df), pd.DataFrame)
+        validated_df = schema.validate(df)
+        assert isinstance(validated_df, pd.DataFrame)
+        assert pd.isna(validated_df["col"].iloc[-1])
+        assert pd.isna(validated_df["col"].iloc[-2])
+        for i in range(4):
+            assert isinstance(validated_df["col"].iloc[i], str)
 
 
 def test_no_dtype_dataframe():


### PR DESCRIPTION
fixes #159. coercion of a nullable Object dtype preserves all of the types in the objects in the column.