### PR TITLE
Fix #188

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -603,12 +603,11 @@ class SeriesSchemaBase():
                 (series.name, _dtype, series.dtype))
 
         check_results = []
-        if len(self.checks) != 0:
+        if self.checks:
             if isinstance(check_obj, pd.Series):
                 check_args = [series, None]
             else:
                 _check_obj = check_obj.loc[series.index.unique()].copy()
-                _check_obj[self.name] = series
                 check_args = [_check_obj, self.name]
 
             for check_index, check in enumerate(self.checks):

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -603,19 +603,19 @@ class SeriesSchemaBase():
                 (series.name, _dtype, series.dtype))
 
         check_results = []
+        if len(self.checks) != 0:
+            if isinstance(check_obj, pd.Series):
+                check_args = [series, None]
+            else:
+                _check_obj = check_obj.loc[series.index.unique()].copy()
+                _check_obj[self.name] = series
+                check_args = [_check_obj, self.name]
 
-        if isinstance(check_obj, pd.Series):
-            check_args = [series, None]
-        else:
-            _check_obj = check_obj.loc[series.index.unique()].copy()
-            _check_obj[self.name] = series
-            check_args = [_check_obj, self.name]
-
-        for check_index, check in enumerate(self.checks):
-            check_results.append(
-                _handle_check_results(
-                    self, check_index, check, check(*check_args))
-            )
+            for check_index, check in enumerate(self.checks):
+                check_results.append(
+                    _handle_check_results(
+                        self, check_index, check, check(*check_args))
+                )
 
         assert all(check_results)
         return check_obj

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -607,7 +607,7 @@ class SeriesSchemaBase():
         if isinstance(check_obj, pd.Series):
             check_args = [series, None]
         else:
-            _check_obj = check_obj.loc[series.index].copy()
+            _check_obj = check_obj.loc[series.index.unique()].copy()
             _check_obj[self.name] = series
             check_args = [_check_obj, self.name]
 

--- a/tests/test_checks_builtin.py
+++ b/tests/test_checks_builtin.py
@@ -369,12 +369,10 @@ class TestEqualTo:
 
     @staticmethod
     @pytest.mark.parametrize('series_values, value', [
-        ((1, None), 1),
-        ((-1, None, -1), -1),
-        ((pd.Timestamp("2015-02-01"),
-          None),
-         pd.Timestamp("2015-02-01")),
-        (("foo", None), "foo")
+        [(1, None), 1],
+        [(-1, None, -1), -1],
+        [(pd.Timestamp("2015-02-01"), None), pd.Timestamp("2015-02-01")],
+        [("foo", None), "foo"],
     ])
     def test_failing_with_none(series_values, value):
         """Validate the check works also on dataframes with None values"""


### PR DESCRIPTION
#188

The series was accessed by "check_obj.loc[series.index]" Each access retrieves every element with corresponding index value, but multiple accesses are attempted for one index value, as series.index is duplicated.

I solved this problem by making series.index distinct.

I confirmed that this fix worked well for my case, but I am not sure it will work with other complicated schemas. Further investigation seems necessary.