### PR TITLE
Fix inconsistent behaviour when setting Column.pandas_type

### DIFF
--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -77,7 +77,6 @@ class Column(SeriesSchemaBase):
             raise ValueError(
                 "You cannot specify a non-string name when setting regex=True")
         self.required = required
-        self.pandas_dtype = pandas_dtype
         self._name = name
         self._regex = regex
 

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -472,6 +472,14 @@ class SeriesSchemaBase():
         return self._name
 
     @property
+    def pandas_dtype(self) -> Union[
+            str,
+            dtypes.PandasDtype,
+            dtypes.PandasExtensionType]:
+        """Get the pandas dtype"""
+        return self._pandas_dtype
+
+    @property
     def dtype(self) -> Union[str, None]:
         """String representation of the dtype."""
         try:

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -479,6 +479,15 @@ class SeriesSchemaBase():
         """Get the pandas dtype"""
         return self._pandas_dtype
 
+    @pandas_dtype.setter
+    def pandas_dtype(self, value: Union[
+            str,
+            dtypes.PandasDtype,
+            dtypes.PandasExtensionType]) -> None:
+        """Set the pandas dtype"""
+        #TODO do we need specfifi checks or actions for consistency here?
+        self._pandas_dtype = value
+
     @property
     def dtype(self) -> Union[str, None]:
         """String representation of the dtype."""

--- a/tests/test_schema_components.py
+++ b/tests/test_schema_components.py
@@ -34,6 +34,19 @@ def test_column():
         Column(Int)(data)
 
 
+def test_column_type_can_be_set():
+    """Test that the Column dtype can be edited during schema construction."""
+
+    column_a = Column(Int, name="a")
+    changed_type = Float
+
+    column_a.pandas_dtype = Float
+
+    assert column_a.pandas_dtype == changed_type
+    assert column_a.dtype == changed_type
+
+
+
 def test_coerce_nullable_object_column():
     """Test that Object dtype coercing preserves object types."""
     df_objects_with_na = pd.DataFrame({

--- a/tests/test_schema_components.py
+++ b/tests/test_schema_components.py
@@ -43,7 +43,7 @@ def test_column_type_can_be_set():
     column_a.pandas_dtype = Float
 
     assert column_a.pandas_dtype == changed_type
-    assert column_a.dtype == changed_type
+    assert column_a.dtype == changed_type.str_alias
 
 
 


### PR DESCRIPTION
Replace the Column.pandas_dtype attribute by a property on SeriesSchemaBase relying on the already existing attribute ``SeriesSchemaBase._pandas_dtype``.

Closes #191 