### PR TITLE
feature/define-check-base

### DIFF
--- a/docs/source/_static/default.css
+++ b/docs/source/_static/default.css
@@ -3,7 +3,7 @@ a {
 }
 
 .toctree-l1 a:active, .toctree-l1 a:hover {
-  background-color: #858585 !important;
+  background-color: #676767;
 }
 
 .wy-nav-top {

--- a/docs/source/_templates/class.rst
+++ b/docs/source/_templates/class.rst
@@ -4,6 +4,20 @@
 
 .. autoclass:: {{ objname }}
 
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :nosignatures:
+
+   {% for item in attributes %}
+     ~{{ name }}.{{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}
+
    {% block methods %}
    {% if methods %}
    .. rubric:: Methods
@@ -18,4 +32,9 @@
    {%- endif %}
    {%- endfor %}
    {% endif %}
+
+   {%- if '__call__' in members %}
+      ~{{ name }}.__call__
+   {%- endif %}
+
    {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,6 +64,12 @@ exclude_patterns = []
 autoclass_content = 'both'
 pygments_style = None
 
+autodoc_default_options = {
+    # 'special-members': '__call__',
+    'undoc-members': False,
+    # 'exclude-members': '__weakref__'
+}
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -50,7 +50,7 @@ required_ parameter allows control over whether or not the column is allowed to
 be missing.
 
 :ref:`Column checks<checks>` allow for the DataFrame's values to be
-checked against a user provided function. ``Check`` objects also support
+checked against a user-provided function. ``Check`` objects also support
 :ref:`grouping<grouping>` by a different column so that the user can make
 assertions about subsets of the column of interest.
 

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -23,8 +23,8 @@ SeriesCheckObj = Union[pd.Series, Dict[str, pd.Series]]
 DataFrameCheckObj = Union[pd.DataFrame, Dict[str, pd.DataFrame]]
 
 
-class Check():
-    """Check a pandas Series or DataFrame for certain properties."""
+class _CheckBase():
+    """Check base class."""
 
     def __init__(
             self,
@@ -127,7 +127,7 @@ class Check():
         ... })
         >>>
         >>> schema.validate(df)[["measure_1", "measure_2", "group"]]
-           measure_1  measure_2 group
+            measure_1  measure_2 group
         0         10          2     B
         1         12          4     B
         2         14          6     A
@@ -136,6 +136,7 @@ class Check():
         See :ref:`here<checks>` for more usage details.
 
         """
+
         if element_wise and groupby is not None:
             raise errors.SchemaInitError(
                 "Cannot use groupby when element_wise=True.")
@@ -232,8 +233,8 @@ class Check():
     ) -> CheckResult:
         """Validate pandas DataFrame or Series.
 
-        :df_or_series: pandas DataFrame of Series to validate.
-        :column: apply the check function to this column.
+        :param df_or_series: pandas DataFrame of Series to validate.
+        :param column: apply the check function to this column.
         :returns: CheckResult tuple containing checked object,
             check validation result, and failure cases from the checked object.
         """
@@ -303,14 +304,17 @@ class Check():
         return "<Check %s: %s>" % (name, self.error) \
             if self.error is not None else "<Check %s>" % name
 
+
+class Check(_CheckBase):
+    """Check a pandas Series or DataFrame for certain properties."""
+
     @staticmethod
     def greater_than(min_value, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` ensuring all values of a series are strictly greater
-            than a certain value.
+        """Ensure values of a series are strictly greater than a minimum value.
 
-        :param min_value: Lower bound to be exceeded. Must be a type comparable to
-            the dtype of the :class:`pandas.Series` to be validated (e.g. a numerical
-            type for float or int and a datetime for datetime).
+        :param min_value: Lower bound to be exceeded. Must be a type comparable
+            to the dtype of the :class:`pandas.Series` to be validated (e.g. a
+            numerical type for float or int and a datetime for datetime).
         :param raise_warning: if True, check raises UserWarning instead of
             SchemaError on validation.
 
@@ -332,10 +336,11 @@ class Check():
     @staticmethod
     def greater_than_or_equal_to(
             min_value, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` ensuring all values are greater or equal a certain value.
+        """Ensure all values are greater or equal a certain value.
 
-        :param min_value: Allowed minimum value for values of a series. Must be a type
-            comparable to the dtype of the :class:`pandas.Series` to be validated.
+        :param min_value: Allowed minimum value for values of a series. Must be
+            a type comparable to the dtype of the :class:`pandas.Series` to be
+            validated.
         :param raise_warning: if True, check raises UserWarning instead of
             SchemaError on validation.
 
@@ -356,11 +361,11 @@ class Check():
 
     @staticmethod
     def less_than(max_value, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` ensuring all values are strictly below a certain value.
+        """Ensure values of a series are strictly below a maximum value.
 
-        :param max_value: All elements of a series must be strictly smaller than this.
-            Must be a type comparable to the dtype of the :class:`pandas.Series` to be
-            validated.
+        :param max_value: All elements of a series must be strictly smaller
+            than this. Must be a type comparable to the dtype of the
+            :class:`pandas.Series` to be validated.
         :param raise_warning: if True, check raises UserWarning instead of
             SchemaError on validation.
 
@@ -382,10 +387,11 @@ class Check():
     @staticmethod
     def less_than_or_equal_to(
             max_value, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` ensuring no value of a series exceeds a certain value.
+        """Ensure no value of a series exceeds a certain value.
 
-        :param max_value: Upper bound not to be exceeded. Must be a type comparable to
-            the dtype of the :class:`pandas.Series` to be validated.
+        :param max_value: Upper bound not to be exceeded. Must be a type
+            comparable to the dtype of the :class:`pandas.Series` to be
+            validated.
         :param raise_warning: if True, check raises UserWarning instead of
             SchemaError on validation.
 
@@ -408,15 +414,17 @@ class Check():
     def in_range(
             min_value, max_value, include_min=True, include_max=True,
             raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` ensuring all values of a series are within an interval.
+        """Ensure all values of a series are within an interval.
 
         :param min_value: Left / lower endpoint of the interval.
-        :param max_value: Right / upper endpoint of the interval. Must not be smaller
-            than min_value.
+        :param max_value: Right / upper endpoint of the interval. Must not be
+            smaller than min_value.
         :param include_min: Defines whether min_value is also an allowed value
-            (the default) or whether all values must be strictly greater than min_value.
+            (the default) or whether all values must be strictly greater than
+            min_value.
         :param include_max: Defines whether min_value is also an allowed value
-            (the default) or whether all values must be strictly smaller than max_value.
+            (the default) or whether all values must be strictly smaller than
+            max_value.
         :param raise_warning: if True, check raises UserWarning instead of
             SchemaError on validation.
 
@@ -431,9 +439,11 @@ class Check():
             raise ValueError("max_value must not be None")
         if max_value < min_value or (min_value == max_value
                                      and (not include_min or not include_max)):
-            raise ValueError("The combination of min_value = %s and max_value = %s "
-                             "defines an empty interval!" % (min_value, max_value))
-        # Using functions from operator module to keep conditions out of the closure
+            raise ValueError(
+                "The combination of min_value = %s and max_value = %s "
+                "defines an empty interval!" % (min_value, max_value))
+        # Using functions from operator module to keep conditions out of the
+        # closure
         left_op = operator.le if include_min else operator.lt
         right_op = operator.ge if include_max else operator.gt
 
@@ -449,9 +459,10 @@ class Check():
 
     @staticmethod
     def equal_to(value, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` ensuring all elements of a series equal a certain value.
+        """Ensure all elements of a series equal a certain value.
 
-        :param value: This value all elements of a given :class:`pandas.Series` must have.
+        :param value: All elements of a given :class:`pandas.Series` must have
+            this value
         :param raise_warning: if True, check raises UserWarning instead of
             SchemaError on validation.
 
@@ -468,9 +479,10 @@ class Check():
 
     @staticmethod
     def not_equal_to(value, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` ensuring no elements of a series equals a certain value.
+        """Ensure no elements of a series equals a certain value.
 
-        :param value: This value must not occur in a :class:`pandas.Series` to check.
+        :param value: This value must not occur in the checked
+            :class:`pandas.Series`.
         :param raise_warning: if True, check raises UserWarning instead of
             SchemaError on validation.
 
@@ -488,7 +500,7 @@ class Check():
 
     @staticmethod
     def isin(allowed_values: Iterable, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` to ensure only allowed values occur within a series.
+        """Ensure only allowed values occur within a series.
 
         :param allowed_values: The set of allowed values. May be any iterable.
         :param raise_warning: if True, check raises UserWarning instead of
@@ -496,19 +508,23 @@ class Check():
 
         :returns: :class:`Check` object
 
-        Note: It is checked whether all elements of a :class:`pandas.Series` are part
-        of the set of elements of allowed values. If allowed values is a string, the
-        set of elements consists of all distinct characters of the string. Thus only
-        single characters which occur in allowed_values at least once can meet this
-        condition. If you want to check for substrings use :func:`Check.str_is_substring`.
+        .. note::
+            It is checked whether all elements of a :class:`pandas.Series`
+            are part of the set of elements of allowed values. If allowed
+            values is a string, the set of elements consists of all distinct
+            characters of the string. Thus only single characters which occur
+            in allowed_values at least once can meet this condition. If you
+            want to check for substrings use :func:`Check.str_is_substring`.
         """
-        # Turn allowed_values into a set. Not only for performance but also avoid issues
-        # with a mutable argument passed by reference which may be changed from outside.
+        # Turn allowed_values into a set. Not only for performance but also
+        # avoid issues with a mutable argument passed by reference which may be
+        # changed from outside.
         try:
             allowed_values = frozenset(allowed_values)
         except TypeError:
-            raise ValueError("Argument allowed_values must be iterable. Got %s" %
-                             allowed_values)
+            raise ValueError(
+                "Argument allowed_values must be iterable. Got %s" %
+                allowed_values)
 
         def _isin(series: pd.Series) -> pd.Series:
             """Comparison function for check"""
@@ -524,26 +540,30 @@ class Check():
     def notin(
             forbidden_values: Iterable,
             raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` to ensure some defined values don't occur within a series.
+        """Ensure some defined values don't occur within a series.
 
-        :param forbidden_values: The set of values which should not occur. May be any iterable.
+        :param forbidden_values: The set of values which should not occur. May
+            be any iterable.
         :param raise_warning: if True, check raises UserWarning instead of
             SchemaError on validation.
 
         :returns: :class:`Check` object
 
-        Note: Like :func:`Check.isin` this check operates on single characters if it is
-        applied on strings. A string as paraforbidden_valuesmeter forbidden_values is understood as
-        set of prohibited characters. Any string of length > 1 can't be in it by
-        design.
+        .. note::
+            Like :func:`Check.isin` this check operates on single characters if
+            it is applied on strings. A string as paraforbidden_valuesmeter
+            forbidden_values is understood as set of prohibited characters. Any
+            string of length > 1 can't be in it by design.
         """
-        # Turn forbidden_values into a set. Not only for performance but also avoid issues
-        # with a mutable argument passed by reference which may be changed from outside.
+        # Turn forbidden_values into a set. Not only for performance but also
+        # avoid issues with a mutable argument passed by reference which may be
+        # changed from outside.
         try:
             forbidden_values = frozenset(forbidden_values)
         except TypeError:
-            raise ValueError("Argument forbidden_values must be iterable. Got %s" %
-                             forbidden_values)
+            raise ValueError(
+                "Argument forbidden_values must be iterable. Got %s" %
+                forbidden_values)
 
         def _notin(series: pd.Series) -> pd.Series:
             """Comparison function for check"""
@@ -557,7 +577,7 @@ class Check():
 
     @staticmethod
     def str_matches(pattern: str, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` to validate if strings values match a regular expression.
+        """Ensure that string values match a regular expression.
 
         :param pattern: Regular expression pattern to use for matching
         :param raise_warning: if True, check raises UserWarning instead of
@@ -571,11 +591,14 @@ class Check():
         try:
             regex = re.compile(pattern)
         except TypeError:
-            raise ValueError('pattern="%s" cannot be compiled as regular expression' %
-                             pattern)
+            raise ValueError(
+                'pattern="%s" cannot be compiled as regular expression' %
+                pattern)
 
         def _match(series: pd.Series) -> pd.Series:
-            """Check if all strings in the series match the regular expression."""
+            """
+            Check if all strings in the series match the regular expression.
+            """
             return series.str.match(regex, na=False)
 
         return Check(
@@ -586,7 +609,7 @@ class Check():
 
     @staticmethod
     def str_contains(pattern: str, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` to validate if the pattern can be found within each row
+        """Ensure that a pattern can be found within each row.
 
         :param pattern: Regular expression pattern to use for searching
         :param raise_warning: if True, check raises UserWarning instead of
@@ -600,8 +623,9 @@ class Check():
         try:
             regex = re.compile(pattern)
         except TypeError:
-            raise ValueError('pattern="%s" cannot be compiled as regular expression' %
-                             pattern)
+            raise ValueError(
+                'pattern="%s" cannot be compiled as regular expression' %
+                pattern)
 
         def _contains(series: pd.Series) -> pd.Series:
             """Check if a regex search is successful within each value"""
@@ -615,7 +639,7 @@ class Check():
 
     @staticmethod
     def str_startswith(string: str, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` to validate if all values start with a certain string
+        """Ensure that all values start with a certain string.
 
         :param string: String all values should start with
         :param raise_warning: if True, check raises UserWarning instead of
@@ -635,7 +659,7 @@ class Check():
 
     @staticmethod
     def str_endswith(string: str, raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` to validate if all values ends with a certain string
+        """Ensure that all values end with a certain string.
 
         :param string: String all values should end with
         :param raise_warning: if True, check raises UserWarning instead of
@@ -658,7 +682,7 @@ class Check():
             min_len: int = None,
             max_len: int = None,
             raise_warning: bool = False) -> 'Check':
-        """Create a :class:`Check` to validate  if the length of strings is within a specified range
+        """Ensure that the length of strings is within a specified range.
 
         :param min_len: Minimum length of strings (default: no minimum)
         :param max_len: Maximum length of strings (default: no maximum)
@@ -668,7 +692,9 @@ class Check():
         :returns: :class:`Check` object
         """
         if min_len is None and max_len is None:
-            raise ValueError("At least a minimum or a maximum need to be specified. Got None.")
+            raise ValueError(
+                "At least a minimum or a maximum need to be specified. Got "
+                "None.")
         if max_len is None:
             def check_fn(series: pd.Series) -> pd.Series:
                 """Check for the minimum string length"""
@@ -680,7 +706,8 @@ class Check():
         else:
             def check_fn(series: pd.Series) -> pd.Series:
                 """Check for both, minimum and maximum string length"""
-                return (series.str.len() <= max_len) & (series.str.len() >= min_len)
+                return (series.str.len() <= max_len) & \
+                    (series.str.len() >= min_len)
 
         return Check(
             fn=check_fn,

--- a/pandera/error_formatters.py
+++ b/pandera/error_formatters.py
@@ -5,11 +5,12 @@ from typing import Union, Optional
 import pandas as pd
 
 from .checks import Check
+from .hypotheses import Hypothesis
 
 
 def format_generic_error_message(
         parent_schema,
-        check: Check,
+        check: Union[Check, Hypothesis],
         check_index: int,
 ) -> str:
     """Construct an error message when a check validator fails.
@@ -24,7 +25,7 @@ def format_generic_error_message(
 
 def format_vectorized_error_message(
         parent_schema,
-        check: Check,
+        check: Union[Check, Hypothesis],
         check_index: int,
         failure_cases: pd.Series) -> str:
     """Construct an error message when a validator fails.

--- a/pandera/hypotheses.py
+++ b/pandera/hypotheses.py
@@ -7,15 +7,16 @@ import pandas as pd
 from scipy import stats
 
 from . import errors
-from .checks import Check, SeriesCheckObj, DataFrameCheckObj
+from .checks import _CheckBase, SeriesCheckObj, DataFrameCheckObj
 
 
 DEFAULT_ALPHA = 0.01
 
 
-class Hypothesis(Check):
-    """Perform a hypothesis test on a Column."""
+class Hypothesis(_CheckBase):
+    """Special type of :class:`Check` that defines hypothesis tests on data."""
 
+    #: Relationships available for built-in hypothesis tests.
     RELATIONSHIPS = {
         "greater_than": (lambda stat, pvalue, alpha=DEFAULT_ALPHA:
                          stat > 0 and pvalue / 2 < alpha),
@@ -39,9 +40,10 @@ class Hypothesis(Check):
     ) -> None:
         """Perform a hypothesis test on a Series or DataFrame.
 
-        Can function on a single column or be grouped by another column.
-
-        :param callable test: A function to check a series schema.
+        :param test: The hypothesis test function. It should take one or more
+            arrays as positional arguments and return a test statistic and a
+            p-value. The arrays passed into the test function are determined
+            by the ``samples`` argument.
         :param samples: for `Column` or `SeriesSchema` hypotheses, this refers
             to the group keys in the `groupby` column(s) used to group the
             `Series` into a dict of `Series`. The `samples` column(s) are
@@ -77,7 +79,7 @@ class Hypothesis(Check):
             `**relationship_kwargs` argument.
 
             Default is "equal" for the null hypothesis.
-        :param dict test_kwargs: Key Word arguments to be supplied to the test.
+        :param dict test_kwargs: Keyword arguments to be supplied to the test.
         :param dict relationship_kwargs: Keyword arguments to be supplied to
             the relationship function. e.g. `alpha` could be used to specify a
             threshold in a t-test.
@@ -222,13 +224,12 @@ class Hypothesis(Check):
             equal_var=True,
             nan_policy="propagate",
             raise_warning=False,
-        ):
-        """Calculate a t-test for the means of two columns.
+    ):
+        """Calculate a t-test for the means of two samples.
 
-        This reuses the scipy.stats.ttest_ind to perfom a two-sided test for
-        the null hypothesis that 2 independent samples have identical average
-        (expected) values. This test assumes that the populations have
-        identical variances by default.
+        Perform a two-sided test for the null hypothesis that 2 independent
+        samples have identical average (expected) values. This test assumes
+        that the populations have identical variances by default.
 
         :param sample1: The first sample group to test. For `Column` and
             `SeriesSchema` hypotheses, refers to the level in the `groupby`
@@ -331,7 +332,7 @@ class Hypothesis(Check):
             alpha: float = DEFAULT_ALPHA,
             raise_warning=False,
     ):
-        """Calculate a t-test for the mean of one column.
+        """Calculate a t-test for the mean of one sample.
 
         :param sample: The sample group to test. For `Column` and
             `SeriesSchema` hypotheses, refers to the `groupby` level in the

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -2,15 +2,14 @@
 
 from copy import copy
 
-from typing import Union, Optional, Tuple, Any
+from typing import Union, Optional, Tuple, Any, List
 
 import numpy as np
 import pandas as pd
 
 from . import errors, dtypes
 from .dtypes import PandasDtype
-from .checks import Check, List
-from .schemas import DataFrameSchema, SeriesSchemaBase
+from .schemas import DataFrameSchema, SeriesSchemaBase, CheckList
 
 
 def _is_valid_multiindex_tuple_str(x: Tuple[Any]) -> bool:
@@ -25,7 +24,7 @@ class Column(SeriesSchemaBase):
             self,
             pandas_dtype: Union[
                 str, PandasDtype, dtypes.PandasExtensionType] = None,
-            checks: Union[Check, List[Check]] = None,
+            checks: CheckList = None,
             nullable: bool = False,
             allow_duplicates: bool = True,
             coerce: bool = False,
@@ -219,7 +218,7 @@ class Index(SeriesSchemaBase):
             self,
             pandas_dtype: Union[
                 str, PandasDtype, dtypes.PandasExtensionType] = None,
-            checks: Union[Check, List[Check]] = None,
+            checks: CheckList = None,
             nullable: bool = False,
             allow_duplicates: bool = True,
             coerce: bool = False,

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -9,9 +9,17 @@ import pandas as pd
 
 from . import errors, constants, dtypes, error_formatters
 from .checks import Check, CheckResult
+from .hypotheses import Hypothesis
 
 
 N_INDENT_SPACES = 4
+
+CheckList = Optional[
+    Union[
+        Union[Check, Hypothesis],
+        List[Union[Check, Hypothesis]]
+    ]
+]
 
 
 class DataFrameSchema():
@@ -20,7 +28,7 @@ class DataFrameSchema():
     def __init__(
             self,
             columns: Dict[Any, Any] = None,
-            checks: Optional[List[Check]] = None,
+            checks: CheckList = None,
             index=None,
             transformer: Callable = None,
             coerce: bool = False,
@@ -79,7 +87,7 @@ class DataFrameSchema():
         """
         if checks is None:
             checks = []
-        if isinstance(checks, Check):
+        if isinstance(checks, (Check, Hypothesis)):
             checks = [checks]
 
         self.columns = {} if columns is None else columns
@@ -178,8 +186,8 @@ class DataFrameSchema():
 
     def get_dtype(self, dataframe: pd.DataFrame) -> Dict[str, str]:
         """
-        Same as the ``dtype`` property, but expands columns where regex == True
-        based on the supplied dataframe.
+        Same as the ``dtype`` property, but expands columns where
+        ``regex == True`` based on the supplied dataframe.
 
         :returns: dictionary of columns and their associated dtypes.
         """
@@ -333,7 +341,7 @@ class DataFrameSchema():
             tail: Optional[int] = None,
             sample: Optional[int] = None,
             random_state: Optional[int] = None):
-        """Delegate to `validate` method.
+        """Alias for :func:`DataFrameSchema.validate` method.
 
         :param pd.DataFrame dataframe: the dataframe to be validated.
         :param head: validate the first n rows. Rows overlapping with `tail` or
@@ -425,7 +433,7 @@ class SeriesSchemaBase():
             pandas_dtype: Union[
                 str, dtypes.PandasDtype, dtypes.PandasExtensionType
             ] = None,
-            checks: Optional[Union[Check, List[Check]]] = None,
+            checks: CheckList = None,
             nullable: bool = False,
             allow_duplicates: bool = True,
             coerce: bool = False,
@@ -437,8 +445,10 @@ class SeriesSchemaBase():
             http://pandas.pydata.org/pandas-docs/stable/basics.html#dtypes
         :param checks: If element_wise is True, then callable signature should
             be:
-            x -> x where x is a scalar element in the column. Otherwise,
-            x is assumed to be a pandas.Series object.
+
+            ``Callable[Any, bool]`` where the ``Any`` input is a scalar element
+            in the column. Otherwise, the input is assumed to be a
+            pandas.Series object.
         :type checks: callable
         :param nullable: Whether or not column can contain null values.
         :type nullable: bool
@@ -451,7 +461,7 @@ class SeriesSchemaBase():
         self._coerce = coerce
         if checks is None:
             checks = []
-        if isinstance(checks, Check):
+        if isinstance(checks, (Check, Hypothesis)):
             checks = [checks]
         self.checks = checks
         self._name = name
@@ -627,7 +637,7 @@ class SeriesSchemaBase():
             sample: Optional[int] = None,
             random_state: Optional[int] = None,
     ) -> Union[pd.DataFrame, pd.Series]:
-        """Validate a series or column in a dataframe."""
+        """Alias for ``validate`` method."""
         return self.validate(check_obj, head, tail, sample, random_state)
 
     def __eq__(self, other):
@@ -636,48 +646,6 @@ class SeriesSchemaBase():
 
 class SeriesSchema(SeriesSchemaBase):
     """Series validator."""
-
-    def __init__(
-            self,
-            pandas_dtype: Union[
-                str, dtypes.PandasDtype, dtypes.PandasExtensionType
-            ] = None,
-            checks: List[Check] = None,
-            nullable: bool = False,
-            allow_duplicates: bool = True,
-            coerce: bool = False,
-            name: str = None) -> None:
-        """Initialize series schema object.
-
-        :param pandas_dtype: datatype of the column. If a string is specified,
-            then assumes one of the valid pandas string values:
-            https://pandas.pydata.org/pandas-docs/stable/getting_started/basics.html#dtypes
-        :param checks: If element_wise is True, then callable signature should
-            be:
-            x -> x where x is a scalar element in the column. Otherwise,
-            x is assumed to be a pandas.Series object.
-        :param nullable: Whether or not column can contain null values.
-        :param allow_duplicates:
-        :param coerce: whether or not to coerce all of the columns on
-            validation.
-
-        :example:
-
-        >>> import pandas as pd
-        >>> import pandera as pa
-        >>>
-        >>>
-        >>> series_schema = pa.SeriesSchema(
-        ...     pa.Float, [
-        ...         pa.Check(lambda s: s > 0),
-        ...         pa.Check(lambda s: s < 1000),
-        ...         pa.Check(lambda s: s.mean() > 300),
-        ...     ])
-
-        See :ref:`here<SeriesSchemas>` for more usage details.
-        """
-        super(SeriesSchema, self).__init__(
-            pandas_dtype, checks, nullable, allow_duplicates, coerce, name)
 
     @property
     def _allow_groupby(self) -> bool:
@@ -748,7 +716,7 @@ class SeriesSchema(SeriesSchemaBase):
             sample: Optional[int] = None,
             random_state: Optional[int] = None,
     ) -> pd.Series:
-        """Validate a series or column in a dataframe."""
+        """Alias for :func:`SeriesSchema.validate` method."""
         return self.validate(check_obj)
 
     def __eq__(self, other):
@@ -776,7 +744,7 @@ def _pandas_obj_to_validate(
 def _handle_check_results(
         schema: Union[DataFrameSchema, SeriesSchemaBase],
         check_index: int,
-        check: Check,
+        check: Union[Check, Hypothesis],
         check_result: CheckResult) -> bool:
     """Handle check results, raising SchemaError on check failure.
 


### PR DESCRIPTION
This PR makes a couple of changes:

- define a `_CheckBase` class the children of which are `Check` and `Hypothesis`.
  This cleans up the `Hypothesis` API, as the `Check` built-ins were accessible to
  `Hypothesis` before this change
- clean up a bunch of things in the docs, mainly add the` __call__` special member to
  the API reference and add class attributes.