### PR TITLE
feature/infer-schema: add basic schema inference

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,7 @@ good-names=
     i,
     e,
     x,
+    _IS_INFERRED,
 
 [MESSAGES CONTROL]
-disable=R0913,duplicate-code,too-many-instance-attributes
+disable=R0913,duplicate-code,too-many-instance-attributes,no-else-return

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_cache:
   - touch $CONDA_DIR/conda-meta/history
 
 os:
-  - linux
-  - osx
+  # - linux
+  # - osx
   - windows
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_cache:
   - touch $CONDA_DIR/conda-meta/history
 
 os:
-  # - linux
-  # - osx
+  - linux
+  - osx
   - windows
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
   # Use the conda environment
   - source activate hosts
   # Tests
-  - pytest --cov=pandera tests/
+  - pytest -v --cov=pandera tests/
   # Coverage
   - codecov
   # Check docs can build, treating warnings as errors

--- a/docs/source/API_reference.rst
+++ b/docs/source/API_reference.rst
@@ -47,6 +47,7 @@ Pandas Data Types
 
 .. autosummary::
    :toctree: generated
+   :template: pandas_dtype_class.rst
    :nosignatures:
 
    PandasDtype
@@ -61,6 +62,16 @@ Decorators
 
    check_input
    check_output
+
+
+Schema Inference
+----------------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   infer_schema
 
 
 Errors

--- a/docs/source/_templates/enum_class.rst
+++ b/docs/source/_templates/enum_class.rst
@@ -1,0 +1,51 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: PandasDtype
+   :show-inheritance:
+   :exclude-members:
+
+   .. autoattribute:: str_alias
+   .. automethod:: from_str_alias
+   .. automethod:: from_pandas_api_type
+
+
+
+
+.. autoclass:: {{ objname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :nosignatures:
+
+   {% for item in attributes %}
+     ~{{ name }}.{{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: Methods
+
+   .. autosummary::
+      :nosignatures:
+      :toctree: methods
+
+   {% for item in methods %}
+   {%- if item not in inherited_members %}
+      ~{{ name }}.{{ item }}
+   {%- endif %}
+   {%- endfor %}
+   {% endif %}
+
+   {%- if '__call__' in members %}
+      ~{{ name }}.__call__
+   {%- endif %}
+
+   {% endblock %}

--- a/docs/source/_templates/pandas_dtype_class.rst
+++ b/docs/source/_templates/pandas_dtype_class.rst
@@ -1,0 +1,25 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :show-inheritance:
+   :exclude-members:
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :nosignatures:
+
+   {% for item in attributes %}
+     ~{{ name }}.{{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}
+
+   .. autoattribute:: str_alias
+   .. automethod:: from_str_alias
+   .. automethod:: from_pandas_api_type

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -195,6 +195,7 @@ Submit issues, feature requests or bugfixes on
    checks
    hypothesis
    decorators
+   schema_inference
    API_reference
 
 Indices and tables

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -28,22 +28,6 @@ a pandas dataframe or series.
    })
    schema = pa.infer_schema(df)
 
-   print(schema)
-
-.. testoutput:: infer_dataframe_schema
-
-   DataFrameSchema(
-       columns={
-           "column1": "<Schema Column: 'column1' type=int64>",
-           "column2": "<Schema Column: 'column2' type=float64>",
-           "column3": "<Schema Column: 'column3' type=string>"
-       },
-       index=None,
-       transformer=None,
-       coerce=True,
-       strict=False
-   )
-
 
 You can then be modify the inferred schema with to obtain the schema definition
 that you're satisfied with.

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -1,0 +1,56 @@
+.. currentmodule:: pandera
+
+.. _schema_inference:
+
+Schema Inference
+================
+
+.. warning::
+   
+   This functionality is experimental and not feature-complete, use with
+   caution!
+
+The :py:func:`infer_schema` enables you to quickly infer a draft schema from
+a pandas dataframe or series.
+
+
+.. testcode:: infer_dataframe_schema
+
+   import pandas as pd
+   import pandera as pa
+
+   from pandera import Check, Column, DataFrameSchema
+
+   df = pd.DataFrame({
+       "column1": [5, 10, 20],
+       "column2": [5., 1., 3.],
+       "column3": ["a", "b", "c"],
+   })
+   schema = pa.infer_schema(df)
+
+   print(schema)
+
+.. testoutput:: infer_dataframe_schema
+
+   DataFrameSchema(
+       columns={
+           "column1": "<Schema Column: 'column1' type=int64>",
+           "column2": "<Schema Column: 'column2' type=float64>",
+           "column3": "<Schema Column: 'column3' type=string>"
+       },
+       index=None,
+       transformer=None,
+       coerce=True,
+       strict=False
+   )
+
+
+You can then be modify the inferred schema with to obtain the schema definition
+that you're satisfied with.
+
+For :py:class:`DataFrameSchema` objects, you can use the
+:py:func:`DataFrameSchema.add_columns`,
+:py:func:`DataFrameSchema.remove_columns`, and
+:py:func:`DataFrameSchema.update_column` methods to produce updated copies
+of the original inferred schema. For :py:class:`SeriesSchema` objects, you
+can update series checks with the :py:func:`SeriesSchema.set_checks` method.

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -7,6 +7,8 @@ from .decorators import check_input, check_output
 from .dtypes import PandasDtype
 from .schemas import DataFrameSchema, SeriesSchema
 from .schema_components import Column, Index, MultiIndex
+from .schema_inference import infer_schema
+
 
 # pylint: disable=invalid-name
 Bool = PandasDtype.Bool

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -299,6 +299,9 @@ class _CheckBase():
 
         return are_fn_objects_equal and are_all_other_check_attributes_equal
 
+    def __hash__(self):
+        return hash(self.__dict__["fn"].__code__.co_code)
+
     def __repr__(self):
         name = getattr(self.fn, '__name__', self.fn.__class__.__name__)
         return "<Check %s: %s>" % (name, self.error) \

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -22,8 +22,8 @@ NUMPY_NONNULLABLE_INT_DTYPES = [
 # for int and float dtype, delegate string representation to the
 # default based on OS. In Windows, pandas defaults to int64 while numpy
 # defaults to int32.
-_DEFAULT_PANDAS_INT_TYPE = str(pd.api.types.pandas_dtype(int))
-_DEFAULT_PANDAS_FLOAT_TYPE = str(pd.api.types.pandas_dtype(float))
+_DEFAULT_PANDAS_INT_TYPE = str(pd.Series([1]).dtype)
+_DEFAULT_PANDAS_FLOAT_TYPE = str(pd.Series([1.]).dtype)
 _DEFAULT_NUMPY_INT_TYPE = str(np.dtype(int))
 _DEFAULT_NUMPY_FLOAT_TYPE = str(np.dtype(float))
 

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -3,6 +3,7 @@
 from enum import Enum
 from typing import Union
 
+import numpy as np
 import pandas as pd
 
 
@@ -21,8 +22,11 @@ NUMPY_NONNULLABLE_INT_DTYPES = [
 # for int and float dtype, delegate string representation to the
 # default based on OS. In Windows, pandas defaults to int64 while numpy
 # defaults to int32.
-_DEFAULT_INT_TYPE = str(pd.Series([1]).dtype)
-_DEFAULT_FLOAT_TYPE = str(pd.Series([1.0]).dtype)
+_DEFAULT_PANDAS_INT_TYPE = str(pd.Series([1]).dtype)
+_DEFAULT_PANDAS_FLOAT_TYPE = str(pd.Series([1.0]).dtype)
+
+_DEFAULT_NUMPY_INT_TYPE = str(np.dtype(int))
+_DEFAULT_NUMPY_FLOAT_TYPE = str(np.dtype(float))
 
 
 class PandasDtype(Enum):
@@ -112,8 +116,8 @@ class PandasDtype(Enum):
     def str_alias(self):
         """Get datatype string alias."""
         return {
-            "int": _DEFAULT_INT_TYPE,
-            "float": _DEFAULT_FLOAT_TYPE,
+            "int": _DEFAULT_NUMPY_INT_TYPE,
+            "float": _DEFAULT_NUMPY_FLOAT_TYPE,
             "string": "object",
         }.get(self.value, self.value)
 
@@ -177,21 +181,13 @@ class PandasDtype(Enum):
             return False
         elif self.value == "string":
             return self.value == other.value
-        elif self.value == "int":
-            return other.str_alias in {"int", _DEFAULT_INT_TYPE}
-        elif other.value == "int":
-            return self.str_alias in {"int", _DEFAULT_INT_TYPE}
-        elif self.value == "float":
-            return self.str_alias in {"float", _DEFAULT_FLOAT_TYPE}
-        elif other.value == "float":
-            return self.str_alias in {"float", _DEFAULT_FLOAT_TYPE}
         return self.str_alias == other.str_alias
 
     def __hash__(self):
         if self is PandasDtype.Int:
-            hash_obj = _DEFAULT_INT_TYPE
+            hash_obj = _DEFAULT_PANDAS_INT_TYPE
         elif self is PandasDtype.Float:
-            hash_obj = _DEFAULT_FLOAT_TYPE
+            hash_obj = _DEFAULT_PANDAS_FLOAT_TYPE
         else:
             hash_obj = self.str_alias
         return id(hash_obj)

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -171,12 +171,20 @@ class PandasDtype(Enum):
         }.get(pandas_api_type)
 
     def __eq__(self, other):
-        # pylint: disable=comparison-with-callable
+        # pylint: disable=comparison-with-callable,too-many-return-statements
         # see https://github.com/PyCQA/pylint/issues/2306
         if other is None:
             return False
         elif self.value == "string":
             return self.value == other.value
+        elif self.value == "int":
+            return other.str_alias in {"int", _DEFAULT_INT_TYPE}
+        elif other.value == "int":
+            return self.str_alias in {"int", _DEFAULT_INT_TYPE}
+        elif self.value == "float":
+            return self.str_alias in {"float", _DEFAULT_FLOAT_TYPE}
+        elif other.value == "float":
+            return self.str_alias in {"float", _DEFAULT_FLOAT_TYPE}
         return self.str_alias == other.str_alias
 
     def __hash__(self):

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -22,9 +22,8 @@ NUMPY_NONNULLABLE_INT_DTYPES = [
 # for int and float dtype, delegate string representation to the
 # default based on OS. In Windows, pandas defaults to int64 while numpy
 # defaults to int32.
-_DEFAULT_PANDAS_INT_TYPE = str(pd.Series([1]).dtype)
-_DEFAULT_PANDAS_FLOAT_TYPE = str(pd.Series([1.0]).dtype)
-
+_DEFAULT_PANDAS_INT_TYPE = str(pd.api.types.pandas_dtype(int))
+_DEFAULT_PANDAS_FLOAT_TYPE = str(pd.api.types.pandas_dtype(float))
 _DEFAULT_NUMPY_INT_TYPE = str(np.dtype(int))
 _DEFAULT_NUMPY_FLOAT_TYPE = str(np.dtype(float))
 
@@ -116,8 +115,8 @@ class PandasDtype(Enum):
     def str_alias(self):
         """Get datatype string alias."""
         return {
-            "int": _DEFAULT_NUMPY_INT_TYPE,
-            "float": _DEFAULT_NUMPY_FLOAT_TYPE,
+            "int": _DEFAULT_PANDAS_INT_TYPE,
+            "float": _DEFAULT_PANDAS_FLOAT_TYPE,
             "string": "object",
         }.get(self.value, self.value)
 

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -2,7 +2,7 @@
 
 from copy import copy
 
-from typing import Union, Optional, Tuple, Any, List
+from typing import Union, Optional, Tuple, Any, List, Dict
 
 import numpy as np
 import pandas as pd
@@ -93,6 +93,20 @@ class Column(SeriesSchemaBase):
     def _allow_groupby(self) -> bool:
         """Whether the schema or schema component allows groupby operations."""
         return True
+
+    @property
+    def properties(self) -> Dict[str, Any]:
+        """Get column properties."""
+        return {
+            "pandas_dtype": self.pandas_dtype,
+            "checks": self._checks,
+            "nullable": self._nullable,
+            "allow_duplicates": self._allow_duplicates,
+            "coerce": self._coerce,
+            "required": self.required,
+            "name": self._name,
+            "regex": self._regex,
+        }
 
     def set_name(self, name: str):
         """Used to set or modify the name of a column object.

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -1,0 +1,192 @@
+"""Module for inferring dataframe/series schema."""
+
+import warnings
+from typing import Any, Dict, Union
+
+import pandas as pd
+
+from .checks import Check
+from .dtypes import PandasDtype
+from .schemas import DataFrameSchema, SeriesSchema
+from .schema_components import Column
+
+
+NUMERIC_DTYPES = frozenset([
+    PandasDtype.Float,
+    PandasDtype.Float16,
+    PandasDtype.Float32,
+    PandasDtype.Float64,
+    PandasDtype.Int,
+    PandasDtype.Int8,
+    PandasDtype.Int16,
+    PandasDtype.Int32,
+    PandasDtype.Int64,
+    PandasDtype.UInt8,
+    PandasDtype.UInt16,
+    PandasDtype.UInt32,
+    PandasDtype.UInt64,
+])
+
+
+def infer_schema(pandas_obj: Union[pd.DataFrame, pd.Series]):
+    """Infer schema for pandas DataFrame or Series object.
+
+    :param pandas_obj: DataFrame or Series object to infer.
+    :returns: DataFrameSchema or SeriesSchema
+    :raises: TypeError if pandas_obj is not expected type.
+    """
+    if isinstance(pandas_obj, pd.DataFrame):
+        return infer_dataframe_schema(pandas_obj)
+    elif isinstance(pandas_obj, pd.Series):
+        return infer_series_schema(pandas_obj)
+    else:
+        raise TypeError(
+            "pandas_obj type not recognized. Expected a pandas DataFrame or "
+            "Series, found %s" % type(pandas_obj)
+        )
+
+
+def infer_dataframe_schema(df: pd.DataFrame) -> DataFrameSchema:
+    """Infer a DataFrameSchema from a pandas DataFrame.
+
+    :param df: DataFrame object to infer.
+    :returns: DataFrameSchema
+    """
+    df_statistics = infer_dataframe_statistics(df)
+    schema = DataFrameSchema(
+        columns={
+            colname: Column(
+                properties["pandas_dtype"],
+                checks=_parse_check_statistics(properties["checks"]),
+                nullable=properties["nullable"],
+            )
+            for colname, properties in df_statistics["columns"].items()
+        },
+        coerce=True,
+    )
+    schema._is_inferred = True  # pylint: disable=protected-access
+    return schema
+
+
+def infer_series_schema(series) -> SeriesSchema:
+    """Infer a SeriesSchema from a pandas DataFrame.
+
+    :param series: Series object to infer.
+    :returns: SeriesSchema
+    """
+    series_statistics = infer_series_statistics(series)
+    schema = SeriesSchema(
+        pandas_dtype=series_statistics["pandas_dtype"],
+        checks=_parse_check_statistics(series_statistics["checks"]),
+        nullable=series_statistics["nullable"],
+        name=series_statistics["name"],
+        coerce=True,
+    )
+    schema._is_inferred = True  # pylint: disable=protected-access
+    return schema
+
+
+def infer_dataframe_statistics(df: pd.DataFrame) -> Dict[str, Any]:
+    """Infer column and index statistics from a pandas DataFrame."""
+    nullable_columns = df.isna().any()
+    inferred_column_dtypes = pd.Series({
+        col: _get_array_type(df[col]) for col in df
+    })
+    column_statistics = {
+        col: {
+            "pandas_dtype": dtype,
+            "nullable": nullable_columns[col],
+            "checks": _get_array_check_statistics(df[col], dtype),
+        }
+        for col, dtype in inferred_column_dtypes.iteritems()
+    }
+    return {
+        "columns": column_statistics,
+        "index": infer_index_statistics(df.index),
+    }
+
+
+def infer_series_statistics(series: pd.Series) -> Dict[str, Any]:
+    """Infer column and index statistics from a pandas Series."""
+    dtype = _get_array_type(series)
+    return {
+        "pandas_dtype": dtype,
+        "nullable": series.isna().any(),
+        "checks": _get_array_check_statistics(series, dtype),
+        "name": series.name,
+    }
+
+
+def infer_index_statistics(index: Union[pd.Index, pd.MultiIndex]):
+    """Infer index statistics given a pandas Index object."""
+
+    def _index_stats(index_level):
+        dtype = _get_array_type(index_level)
+        return {
+            "name": index_level.name,
+            "pandas_dtype": dtype,
+            "nullable": index_level.isna().any(),
+            "checks": _get_array_check_statistics(index_level, dtype),
+        }
+
+    if isinstance(index, pd.MultiIndex):
+        index_statistics = [
+            _index_stats(index.get_level_values(i))
+            for i in range(index.nlevels)
+        ]
+    elif isinstance(index, pd.Index):
+        index_statistics = [_index_stats(index)]
+    else:
+        warnings.warn(
+            "index type %s not recognized, skipping index inference" %
+            type(index),
+            UserWarning
+        )
+        index_statistics = []
+    return index_statistics if index_statistics else None
+
+
+def _get_array_type(x):
+    # get most granular type possible
+    dtype = PandasDtype.from_str_alias(str(x.dtype))
+    # for object arrays, try to infer dtype
+    if dtype is PandasDtype.Object:
+        dtype = PandasDtype.from_pandas_api_type(
+            pd.api.types.infer_dtype(x, skipna=True)
+        )
+    return dtype
+
+
+def _get_array_check_statistics(
+        x, dtype: PandasDtype) -> Union[Dict[str, Any], None]:
+    """Get check statistics from an array-like object."""
+    if dtype in NUMERIC_DTYPES or dtype is PandasDtype.DateTime:
+        check_stats = {
+            "min": x.min(),
+            "max": x.max(),
+        }
+    elif dtype is PandasDtype.Category:
+        try:
+            categories = x.cat.categories
+        except AttributeError:
+            categories = x.categories
+        check_stats = {
+            "levels": categories.tolist(),
+        }
+    else:
+        check_stats = {}
+    return check_stats if check_stats else None
+
+
+def _parse_check_statistics(check_stats: Union[Dict[str, Any], None]):
+    """Convert check statistics to a list of Check objects."""
+    if check_stats is None:
+        return None
+    checks = []
+    if "min" in check_stats:
+        checks.append(Check.greater_than_or_equal_to(check_stats["min"]))
+    if "max" in check_stats:
+        checks.append(Check.less_than_or_equal_to(check_stats["max"]))
+    if "levels" in check_stats:
+        checks.append(Check.isin(check_stats["levels"]))
+    return checks if checks else None

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -177,8 +177,6 @@ def test_datetime():
         )
 
 
-
-
 @pytest.mark.skipif(
     PANDAS_VERSION.release < (1, 0, 0),  # type: ignore
     reason="pandas >= 1.0.0 required",

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -11,7 +11,10 @@ from pandera import (
     Column, DataFrameSchema, SeriesSchema, Check, DateTime, Float, Int,
     String, Bool, Category, Object, Timedelta
 )
-from pandera.dtypes import _DEFAULT_INT_TYPE, _DEFAULT_FLOAT_TYPE
+from pandera.dtypes import (
+    _DEFAULT_PANDAS_INT_TYPE, _DEFAULT_PANDAS_FLOAT_TYPE,
+    _DEFAULT_NUMPY_INT_TYPE, _DEFAULT_NUMPY_FLOAT_TYPE,
+)
 from pandera.errors import SchemaError
 
 
@@ -35,15 +38,16 @@ TESTABLE_DTYPES = [
 
 def test_default_numeric_dtypes():
     """Test that default numeric dtypes int and float are consistent."""
-    assert str(pd.Series([1]).dtype) == _DEFAULT_INT_TYPE
-    # assert str(pd.Series([1], dtype=int).dtype) == _DEFAULT_INT_TYPE
-    assert str(pd.Series([1], dtype="int").dtype) == _DEFAULT_INT_TYPE
-    assert pa.Int.str_alias == _DEFAULT_INT_TYPE
+    assert str(pd.Series([1]).dtype) == _DEFAULT_PANDAS_INT_TYPE
+    assert pa.Int.str_alias == _DEFAULT_PANDAS_INT_TYPE
+    assert str(pd.Series([1], dtype=int).dtype) == _DEFAULT_NUMPY_INT_TYPE
+    assert str(pd.Series([1], dtype="int").dtype) == _DEFAULT_NUMPY_INT_TYPE
 
-    assert str(pd.Series([1.]).dtype) == _DEFAULT_FLOAT_TYPE
-    # assert str(pd.Series([1.], dtype=float).dtype) == _DEFAULT_FLOAT_TYPE
-    assert str(pd.Series([1.], dtype="float").dtype) == _DEFAULT_FLOAT_TYPE
-    assert pa.Float.str_alias == _DEFAULT_FLOAT_TYPE
+    assert str(pd.Series([1.]).dtype) == _DEFAULT_PANDAS_FLOAT_TYPE
+    assert pa.Float.str_alias == _DEFAULT_PANDAS_FLOAT_TYPE
+    assert str(pd.Series([1.], dtype=float).dtype) == _DEFAULT_NUMPY_FLOAT_TYPE
+    assert str(pd.Series([1.], dtype="float").dtype) == \
+        _DEFAULT_NUMPY_FLOAT_TYPE
 
 
 def test_numeric_dtypes():

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -35,12 +35,14 @@ TESTABLE_DTYPES = [
 
 def test_default_numeric_dtypes():
     """Test that default numeric dtypes int and float are consistent."""
-    assert str(pd.Series([1], dtype=int).dtype) == _DEFAULT_INT_TYPE
+    assert str(pd.Series([1]).dtype) == _DEFAULT_INT_TYPE
+    # assert str(pd.Series([1], dtype=int).dtype) == _DEFAULT_INT_TYPE
     assert str(pd.Series([1], dtype="int").dtype) == _DEFAULT_INT_TYPE
     assert pa.Int.str_alias == _DEFAULT_INT_TYPE
 
-    assert str(pd.Series([1], dtype=float).dtype) == _DEFAULT_FLOAT_TYPE
-    assert str(pd.Series([1], dtype="float").dtype) == _DEFAULT_FLOAT_TYPE
+    assert str(pd.Series([1.]).dtype) == _DEFAULT_FLOAT_TYPE
+    # assert str(pd.Series([1.], dtype=float).dtype) == _DEFAULT_FLOAT_TYPE
+    assert str(pd.Series([1.], dtype="float").dtype) == _DEFAULT_FLOAT_TYPE
     assert pa.Float.str_alias == _DEFAULT_FLOAT_TYPE
 
 

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -11,6 +11,7 @@ from pandera import (
     Column, DataFrameSchema, SeriesSchema, Check, DateTime, Float, Int,
     String, Bool, Category, Object, Timedelta
 )
+from pandera.dtypes import _DEFAULT_INT_TYPE, _DEFAULT_FLOAT_TYPE
 from pandera.errors import SchemaError
 
 
@@ -30,6 +31,17 @@ TESTABLE_DTYPES = [
     ("category", "category"),
     ("float64", "float64"),
 ]
+
+
+def test_default_numeric_dtypes():
+    """Test that default numeric dtypes int and float are consistent."""
+    assert str(pd.Series([1], dtype=int).dtype) == _DEFAULT_INT_TYPE
+    assert str(pd.Series([1], dtype="int").dtype) == _DEFAULT_INT_TYPE
+    assert pa.Int.str_alias == _DEFAULT_INT_TYPE
+
+    assert str(pd.Series([1], dtype=float).dtype) == _DEFAULT_FLOAT_TYPE
+    assert str(pd.Series([1], dtype="float").dtype) == _DEFAULT_FLOAT_TYPE
+    assert pa.Float.str_alias == _DEFAULT_FLOAT_TYPE
 
 
 def test_numeric_dtypes():

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -155,7 +155,7 @@ def test_infer_dataframe_schema():
 @pytest.mark.parametrize("series, expectation", [
     *[
         [
-            pd.Series([1, 2, 3], dtype=dtype.value), {
+            pd.Series([1, 2, 3], dtype=dtype.str_alias), {
                 "pandas_dtype": dtype, "nullable": False,
                 "checks": {"min": 1, "max": 3},
                 "name": None,

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -1,0 +1,333 @@
+# pylint: disable=W0212
+"""Unit tests for schema inference module."""
+
+import pandas as pd
+import pytest
+
+import pandera as pa
+from pandera import schema_inference
+from pandera import dtypes, PandasDtype
+
+
+DEFAULT_INT = PandasDtype.from_str_alias(dtypes._DEFAULT_INT_TYPE)
+DEFAULT_FLOAT = PandasDtype.from_str_alias(dtypes._DEFAULT_FLOAT_TYPE)
+
+
+def _create_dataframe(multi_index=False, nullable=False):
+    if multi_index:
+        index = pd.MultiIndex.from_arrays(
+            [[1, 1, 2], ["a", "b", "c"]],
+            names=["int_index", "str_index"],
+        )
+    else:
+        index = pd.Index([10, 11, 12], name="int_index")
+
+    df = pd.DataFrame(
+        data={
+            "int": [1, 2, 3],
+            "float": [1., 2., 3.],
+            "boolean": [True, False, True],
+            "string": ["a", "b", "c"],
+            "datetime": pd.to_datetime(["20180101", "20180102", "20180103"]),
+        },
+        index=index,
+    )
+
+    if nullable:
+        df.iloc[0, :] = None
+
+    return df
+
+
+@pytest.mark.parametrize("pandas_obj, expectation", [
+    [pd.DataFrame({"col": [1, 2, 3]}), pa.DataFrameSchema],
+    [pd.Series([1, 2, 3]), pa.SeriesSchema],
+
+    # error cases
+    [int, TypeError],
+    [pd.Index([1, 2, 3]), TypeError],
+    ["foobar", TypeError],
+    [1, TypeError],
+    [[1, 2, 3], TypeError],
+    [{"key": "value"}, TypeError],
+])
+def test_infer_schema(pandas_obj, expectation):
+    """Test that convenience function correctly infers dataframe or series."""
+    if expectation is TypeError:
+        with pytest.raises(TypeError, match="^pandas_obj type not recognized"):
+            schema_inference.infer_schema(pandas_obj)
+    else:
+        assert isinstance(
+            schema_inference.infer_schema(pandas_obj), expectation
+        )
+
+
+@pytest.mark.parametrize("multi_index, nullable", [
+    [False, False],
+    [True, False],
+    [False, True],
+    [True, True],
+])
+def test_infer_dataframe_statistics(multi_index, nullable):
+    """Test dataframe statistics are correctly inferred."""
+    dataframe = _create_dataframe(multi_index, nullable)
+    statistics = schema_inference.infer_dataframe_statistics(dataframe)
+    stat_columns = statistics["columns"]
+
+    if nullable:
+        # bool and int dtypes are cast to float in the nullable case
+        assert stat_columns["int"]["pandas_dtype"] is DEFAULT_FLOAT
+        assert stat_columns["boolean"]["pandas_dtype"] is DEFAULT_FLOAT
+    else:
+        assert stat_columns["int"]["pandas_dtype"] is DEFAULT_INT
+        assert stat_columns["boolean"]["pandas_dtype"] is pa.Bool
+
+    assert stat_columns["float"]["pandas_dtype"] is DEFAULT_FLOAT
+    assert stat_columns["string"]["pandas_dtype"] is pa.String
+    assert stat_columns["datetime"]["pandas_dtype"] is pa.DateTime
+
+    if multi_index:
+        stat_indices = statistics["index"]
+        for stat_index, name, dtype in zip(
+                stat_indices,
+                ["int_index", "str_index"],
+                [DEFAULT_INT, pa.String]):
+            assert stat_index["name"] == name
+            assert stat_index["pandas_dtype"] is dtype
+            assert not stat_index["nullable"]
+    else:
+        stat_index = statistics["index"][0]
+        assert stat_index["name"] == "int_index"
+        assert stat_index["pandas_dtype"] is DEFAULT_INT
+        assert not stat_index["nullable"]
+
+    for properties in stat_columns.values():
+        if nullable:
+            assert properties["nullable"]
+        else:
+            assert not properties["nullable"]
+
+
+@pytest.mark.parametrize("check_stats, expectation", [
+    [{"min": 1}, [pa.Check.greater_than_or_equal_to(1)]],
+    [{"max": 10}, [pa.Check.less_than_or_equal_to(10)]],
+    [{"levels": ["a", "b", "c"]}, [pa.Check.isin(["a", "b", "c"])]],
+    [
+        {"min": 1, "max": 10},
+        [pa.Check.greater_than_or_equal_to(1),
+         pa.Check.less_than_or_equal_to(10)]
+    ],
+    [{}, None],
+])
+def test_parse_check_statistics(check_stats, expectation):
+    """Test that Checks are correctly parsed from check statistics."""
+    assert schema_inference._parse_check_statistics(check_stats) == expectation
+
+
+def test_infer_dataframe_schema():
+    """Test dataframe schema is correctly inferred."""
+    dataframe = _create_dataframe()
+    schema = schema_inference.infer_dataframe_schema(dataframe)
+    assert isinstance(schema, pa.DataFrameSchema)
+
+    with pytest.warns(
+            UserWarning,
+            match="^This .+ is an inferred schema that hasn't been modified"):
+        schema.validate(dataframe)
+
+    # modifying an inferred schema should set _is_inferred to False
+    schema_with_added_cols = schema.add_columns(
+        {"foo": pa.Column(pa.String)})
+    assert schema._is_inferred
+    assert not schema_with_added_cols._is_inferred
+    assert isinstance(
+        schema_with_added_cols.validate(dataframe.assign(foo="a")),
+        pd.DataFrame)
+
+    schema_with_removed_cols = schema.remove_columns(["int"])
+    assert schema._is_inferred
+    assert not schema_with_removed_cols._is_inferred
+    assert isinstance(
+        schema_with_removed_cols.validate(dataframe.drop("int", axis=1)),
+        pd.DataFrame)
+
+
+@pytest.mark.parametrize("series, expectation", [
+    *[
+        [
+            pd.Series([1, 2, 3], dtype=dtype.value), {
+                "pandas_dtype": dtype, "nullable": False,
+                "checks": {"min": 1, "max": 3},
+                "name": None,
+            }
+        ]
+        for dtype in schema_inference.NUMERIC_DTYPES
+    ],
+    [
+        pd.Series(["a", "b", "c", "a"], dtype="category"), {
+            "pandas_dtype": pa.Category, "nullable": False,
+            "checks": {"levels": ["a", "b", "c"]},
+            "name": None,
+        }
+    ],
+    [
+        pd.Series(["a", "b", "c", "a"], name="str_series"), {
+            "pandas_dtype": pa.String, "nullable": False,
+            "checks": None, "name": "str_series",
+        }
+    ],
+    [
+        pd.Series(pd.to_datetime(["20180101", "20180102", "20180103"])), {
+            "pandas_dtype": pa.DateTime, "nullable": False,
+            "checks": {
+                "min": pd.Timestamp("20180101"),
+                "max": pd.Timestamp("20180103")
+            },
+            "name": None,
+        }
+    ],
+])
+def test_infer_series_schema_statistics(series, expectation):
+    """Test series statistics are correctly inferred."""
+    statistics = schema_inference.infer_series_statistics(series)
+    assert statistics == expectation
+
+
+INTEGER_TYPES = [
+    PandasDtype.Int,
+    PandasDtype.Int8,
+    PandasDtype.Int16,
+    PandasDtype.Int32,
+    PandasDtype.Int64,
+    PandasDtype.UInt8,
+    PandasDtype.UInt16,
+    PandasDtype.UInt32,
+    PandasDtype.UInt64,
+]
+
+
+@pytest.mark.parametrize("null_index, series, expectation", [
+    *[
+        [
+            0, pd.Series([1, 2, 3], dtype=dtype.value), {
+                # introducing nans to integer arrays upcasts to float
+                "pandas_dtype": DEFAULT_FLOAT, "nullable": True,
+                "checks": {"min": 2, "max": 3},
+                "name": None,
+            }
+        ]
+        for dtype in INTEGER_TYPES
+    ],
+    [
+        # introducing nans to integer arrays upcasts to float
+        0, pd.Series([True, False, True, False]), {
+            "pandas_dtype": DEFAULT_FLOAT, "nullable": True,
+            "checks": {"min": 0, "max": 1},
+            "name": None,
+        }
+    ],
+    [
+        0, pd.Series(["a", "b", "c", "a"], dtype="category"), {
+            "pandas_dtype": pa.Category, "nullable": True,
+            "checks": {"levels": ["a", "b", "c"]},
+            "name": None,
+        }
+    ],
+    [
+        0, pd.Series(["a", "b", "c", "a"], name="str_series"), {
+            "pandas_dtype": pa.String, "nullable": True,
+            "checks": None, "name": "str_series",
+        }
+    ],
+    [
+        2, pd.Series(pd.to_datetime(["20180101", "20180102", "20180103"])), {
+            "pandas_dtype": pa.DateTime, "nullable": True,
+            "checks": {
+                "min": pd.Timestamp("20180101"),
+                "max": pd.Timestamp("20180102")
+            },
+            "name": None,
+        }
+    ],
+])
+def test_infer_nullable_series_schema_statistics(
+        null_index, series, expectation):
+    """Test nullable series statistics are correctly inferred."""
+    series.iloc[null_index] = None
+    statistics = schema_inference.infer_series_statistics(series)
+    assert statistics == expectation
+
+
+@pytest.mark.parametrize("series", [
+    pd.Series([1, 2, 3]),
+    pd.Series([1., 2., 3.]),
+    pd.Series([True, False, True]),
+    pd.Series(list("abcdefg")),
+    pd.Series(list("abcdefg"), dtype="category"),
+    pd.Series(pd.to_datetime(["20180101", "20180102", "20180103"])),
+])
+def test_infer_series_schema(series):
+    """Test series schema is correctly inferred."""
+    schema = schema_inference.infer_series_schema(series)
+    assert isinstance(schema, pa.SeriesSchema)
+
+    with pytest.warns(
+            UserWarning,
+            match="^This .+ is an inferred schema that hasn't been modified"):
+        schema.validate(series)
+
+    # modifying an inferred schema should set _is_inferred to False
+    schema_with_new_checks = schema.set_checks(
+        [pa.Check(lambda x: x is not None)])
+    assert schema._is_inferred
+    assert not schema_with_new_checks._is_inferred
+    assert isinstance(schema_with_new_checks.validate(series), pd.Series)
+
+
+@pytest.mark.parametrize("index, expectation", [
+    [
+        pd.RangeIndex(20), [
+            {"name": None, "pandas_dtype": PandasDtype.Int,
+             "nullable": False, "checks": {"min": 0, "max": 19}}
+        ],
+    ],
+    [
+        pd.Index([1, 2, 3], name="int_index"), [
+            {"name": "int_index", "pandas_dtype": PandasDtype.Int,
+             "nullable": False, "checks": {"min": 1, "max": 3}}
+        ],
+    ],
+    [
+        pd.Index(["foo", "bar", "baz"], name="str_index"), [
+            {"name": "str_index", "pandas_dtype": PandasDtype.String,
+             "nullable": False, "checks": None},
+        ],
+    ],
+    [
+        pd.MultiIndex.from_arrays(
+            [[10, 11, 12], pd.Series(["a", "b", "c"], dtype="category")],
+            names=["int_index", "str_index"],
+        ),
+        [
+            {"name": "int_index", "pandas_dtype": PandasDtype.Int,
+             "nullable": False, "checks": {"min": 10, "max": 12}},
+            {"name": "str_index", "pandas_dtype": PandasDtype.Category,
+             "nullable": False, "checks": {"levels": ["a", "b", "c"]}}
+        ],
+    ],
+
+    # UserWarning cases
+    [1, UserWarning],
+    ["foo", UserWarning],
+    [{"foo": "bar"}, UserWarning],
+    [["foo", "bar"], UserWarning],
+    [pd.Series(["foo", "bar"]), UserWarning],
+    [pd.DataFrame({"column": ["foo", "bar"]}), UserWarning],
+])
+def test_infer_index_statistics(index, expectation):
+    """Test that index statistics are correctly inferred."""
+    if expectation is UserWarning:
+        with pytest.warns(UserWarning, match="^index type .+ not recognized"):
+            schema_inference.infer_index_statistics(index)
+    else:
+        assert schema_inference.infer_index_statistics(index) == expectation

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -9,8 +9,8 @@ from pandera import schema_inference
 from pandera import dtypes, PandasDtype
 
 
-DEFAULT_INT = PandasDtype.from_str_alias(dtypes._DEFAULT_INT_TYPE)
-DEFAULT_FLOAT = PandasDtype.from_str_alias(dtypes._DEFAULT_FLOAT_TYPE)
+DEFAULT_INT = PandasDtype.from_str_alias(dtypes._DEFAULT_PANDAS_INT_TYPE)
+DEFAULT_FLOAT = PandasDtype.from_str_alias(dtypes._DEFAULT_PANDAS_FLOAT_TYPE)
 
 
 def _create_dataframe(multi_index=False, nullable=False):

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -121,7 +121,12 @@ def test_infer_dataframe_statistics(multi_index, nullable):
 ])
 def test_parse_check_statistics(check_stats, expectation):
     """Test that Checks are correctly parsed from check statistics."""
-    assert schema_inference._parse_check_statistics(check_stats) == expectation
+    if expectation is None:
+        expectation = []
+    checks = schema_inference._parse_check_statistics(check_stats)
+    if checks is None:
+        checks = []
+    assert set(checks) == set(expectation)
 
 
 def test_infer_dataframe_schema():


### PR DESCRIPTION
fixes #163, #93

this PR adds schema inference functionality. The `infer_schema` function is
now available in the top-level `pandera` name space, and can be used to
create `DataFrameSchema` and `SeriesSchema` objects from `DataFrame` and
`Series` inputs, respectively.

The `schema_inference` module implements logic for inference of dataframe/series
statistics (see `infer_*_statistics` functions).

Some additional changes in this PR:
- add additional methods to the `PandasDtype` enum class in service of schema inference functionality.
- implement `DataFrameSchema.update_column` method and `SeriesSchema.set_checks`
  methods that produce modified copies with updated properties.
- Add `Column.properties` attribute.