### PR TITLE
feature/lazy-validation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,6 +7,8 @@ good-names=
     e,
     x,
     f,
+    k,
+    v,
     fp,
     _IS_INFERRED,
 

--- a/ci/deps/env_35.yml
+++ b/ci/deps/env_35.yml
@@ -24,6 +24,7 @@ dependencies:
 
   # pandera dependencies
   - numpy
+  
   - pandas
   - scipy
   - wrapt

--- a/docs/source/API_reference.rst
+++ b/docs/source/API_reference.rst
@@ -94,5 +94,6 @@ Errors
    :nosignatures:
 
    errors.SchemaError
+   errors.SchemaErrors
    errors.SchemaInitError
    errors.SchemaDefinitionError

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,10 +36,13 @@ extensions = [
 ]
 
 doctest_global_setup = """
+import sys
 import pandas as pd
 import numpy as np
 pd.options.display.max_columns = None # For Travis on macOS
 pd.options.display.max_rows = None # For Travis on macOS
+
+SKIP = sys.version_info < (3, 6)
 """
 
 doctest_default_flags = (

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,4 +97,4 @@ autosummary_generate = ["API_reference.rst"]
 
 
 def setup(app):
-    app.add_stylesheet('default.css')
+    app.add_css_file('default.css')

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -658,6 +658,7 @@ data pipeline:
         columns={
             "col1": "<Schema Column: 'col1' type=int>"
         },
+        checks=[],
         index=None,
         transformer=None,
         coerce=False,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -196,6 +196,7 @@ Submit issues, feature requests or bugfixes on
    hypothesis
    decorators
    schema_inference
+   lazy_validation
    API_reference
 
 Indices and tables

--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -1,0 +1,150 @@
+.. currentmodule:: pandera
+
+.. _lazy_validation:
+
+Lazy Validation
+===============
+
+*new in 0.4.0*
+
+By default, when you call the ``validate`` method on schema or schema component
+objects, a :py:class:`errors.SchemaError` is raised as soon as one of the
+assumptions specified in the schema is falsified. For example, for a
+:py:class:`DataFrameSchema` object, the following situations will raise an
+exception:
+
+* a column specified in the schema is not present in the dataframe.
+* if ``strict=True``, a column in the dataframe is not specified in the schema.
+* the ``pandas_dtype`` does not match.
+* if ``coerce=True``, the dataframe column cannot be coerced into the specified
+  ``pandas_dtype``.
+* the :py:class:`Check` specified in one of the columns returns ``False`` or
+  a boolean series containing at least one ``False`` value.
+
+
+For example:
+
+.. testcode:: non_lazy_validation
+
+   import pandas as pd
+   import pandera as pa
+
+   from pandera import Check, Column, DataFrameSchema
+
+   df = pd.DataFrame({"column": ["a", "b", "c"]})
+
+   schema = pa.DataFrameSchema({"column": Column(pa.Int)})
+   schema.validate(df)
+
+.. testoutput:: non_lazy_validation
+
+    Traceback (most recent call last):
+    ...
+    SchemaError: expected series 'column' to have type int64, got object
+
+
+For more complex cases, it is useful to see all of the errors raised during
+the ``validate`` call so that you can debug the causes of errors on different
+columns and checks. The ``lazy`` keyword argument in the ``validate`` method
+of all schemas and schema components gives you the option of doing just this:
+
+.. testcode:: lazy_validation
+
+    import pandas as pd
+    import pandera as pa
+    
+    from pandera import Check, Column, DataFrameSchema
+
+    schema = pa.DataFrameSchema(
+        columns={
+            "int_column": Column(pa.Int),
+            "float_column": Column(pa.Float, Check.greater_than(0)),
+            "str_column": Column(pa.String, Check.equal_to("a")),
+            "date_column": Column(pa.DateTime),
+        },
+        strict=True
+    )
+    
+    df = pd.DataFrame({
+        "int_column": ["a", "b", "c"],
+        "float_column": [0, 1, 2],
+        "str_column": ["a", "b", "d"],
+        "unknown_column": None,
+    })
+    
+    schema.validate(df, lazy=True)
+
+.. testoutput:: lazy_validation
+    :options: +IGNORE_EXCEPTION_DETAIL
+
+    Traceback (most recent call last):
+    ...
+    pandera.errors.SchemaErrors: A total of 5 schema errors were found.
+
+    Error Counts
+    ------------
+    - column_not_in_schema: 1
+    - column_not_in_dataframe: 1
+    - schema_component_check: 3
+
+    Schema Error Summary
+    --------------------
+                                                             failure_cases  n_failure_cases
+    schema_context  column       check
+    DataFrameSchema <NA>         column_in_dataframe         [date_column]                1
+                                 column_in_schema         [unknown_column]                1
+    Column          float_column pandas_dtype('float64')           [int64]                1
+                    int_column   pandas_dtype('int64')            [object]                1
+                    str_column   equal_to(a)                        [b, d]                2
+
+    Usage Tip
+    ---------
+
+    Directly inspect all errors by catching the exception:
+
+    ```
+    try:
+        schema.validate(dataframe, lazy=True)
+    except SchemaErrors as err:
+        err.schema_errors  # dataframe of schema errors
+        err.data  # invalid dataframe
+    ```
+
+As you can see from the output above, a :py:class:`errors.SchemaErrors`
+exception is raised with a summary of the error counts and failure cases
+caught by the schema. You can also see from the **Usage Tip** that you can
+catch these errors and inspect the failure cases in a more granular form:
+
+
+.. testcode:: lazy_validation
+    
+    try:
+        schema.validate(df, lazy=True)
+    except pa.errors.SchemaErrors as err:
+        print("Schema errors and failure cases:")
+        print(err.schema_errors.head())
+        print("\nDataFrame object that failed validation:")
+        print(err.data.head())
+
+.. testoutput:: lazy_validation
+
+    Schema errors and failure cases:
+        schema_context        column                    check check_number  \
+    0  DataFrameSchema          None         column_in_schema         None
+    1  DataFrameSchema          None      column_in_dataframe         None
+    2           Column    int_column    pandas_dtype('int64')         None
+    3           Column  float_column  pandas_dtype('float64')         None
+    4           Column    str_column              equal_to(a)            0
+
+         failure_case index
+    0  unknown_column  None
+    1     date_column  None
+    2          object  None
+    3           int64  None
+    4               b     1
+
+    DataFrame object that failed validation:
+      int_column  float_column str_column unknown_column
+    0          a             0          a           None
+    1          b             1          b           None
+    2          c             2          d           None

--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -127,6 +127,7 @@ catch these errors and inspect the failure cases in a more granular form:
         print(err.data.head())
 
 .. testoutput:: lazy_validation
+    :pyversion: >= 3.6
 
     Schema errors and failure cases:
         schema_context        column                    check check_number  \

--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -75,7 +75,6 @@ of all schemas and schema components gives you the option of doing just this:
     schema.validate(df, lazy=True)
 
 .. testoutput:: lazy_validation
-    :options: +IGNORE_EXCEPTION_DETAIL
 
     Traceback (most recent call last):
     ...
@@ -117,6 +116,7 @@ catch these errors and inspect the failure cases in a more granular form:
 
 
 .. testcode:: lazy_validation
+    :skipif: SKIP
     
     try:
         schema.validate(df, lazy=True)
@@ -127,7 +127,7 @@ catch these errors and inspect the failure cases in a more granular form:
         print(err.data.head())
 
 .. testoutput:: lazy_validation
-    :pyversion: >= 3.6
+    :skipif: SKIP
 
     Schema errors and failure cases:
         schema_context        column                    check check_number  \

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -5,13 +5,15 @@
 Schema Inference
 ================
 
+*new in 0.4.0*
+
 .. warning::
    
    This functionality is experimental and not feature-complete, use with
    caution!
 
-The :py:func:`infer_schema` enables you to quickly infer a draft schema from
-a pandas dataframe or series.
+The :py:func:`infer_schema` function enables you to quickly infer a draft
+schema from a pandas dataframe or series.
 
 
 .. testcode:: infer_dataframe_schema

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -13,7 +13,11 @@ from . import errors, constants
 
 
 CheckResult = namedtuple(
-    "CheckResult", ["check_passed", "checked_object", "failure_cases"])
+    "CheckResult", [
+        "check_passed",
+        "checked_object",
+        "failure_cases",
+    ])
 
 
 GroupbyObject = Union[
@@ -279,12 +283,12 @@ class _CheckBase():
         """Validate pandas DataFrame or Series.
 
         :param df_or_series: pandas DataFrame of Series to validate.
-        :param column: apply the check function to this column.
+        :param column: for dataframe checks, apply the check function to this
+            column.
         :returns: CheckResult tuple containing checked object,
             check validation result, and failure cases from the checked object.
         """
-        if column is not None \
-                and isinstance(df_or_series, pd.DataFrame):
+        if column is not None and isinstance(df_or_series, pd.DataFrame):
             column_dataframe_context = df_or_series.drop(
                 column, axis="columns")
             df_or_series = df_or_series[column].copy()
@@ -305,6 +309,7 @@ class _CheckBase():
 
         # apply check function to check object
         check_fn = partial(self._check_fn, **self._check_kwargs)
+
         if self.element_wise:
             check_result = check_obj.apply(check_fn, axis=1) if \
                 isinstance(check_obj, pd.DataFrame) else \
@@ -318,7 +323,7 @@ class _CheckBase():
         # series that matches the shape and index of the check_obj
         if isinstance(check_obj, dict) or \
                 isinstance(check_result, bool) or \
-                not isinstance(check_result, pd.Series) or \
+                not isinstance(check_result, (pd.Series, pd.DataFrame)) or \
                 check_obj.shape[0] != check_result.shape[0] or \
                 (check_obj.index != check_result.index).all():
             failure_cases = None
@@ -605,7 +610,7 @@ class Check(_CheckBase):
         return cls(
             _isin,
             name=cls.isin.__name__,
-            error="isin(%s)" % allowed_values,
+            error="isin(%s)" % set(allowed_values),
             raise_warning=raise_warning,
         )
 
@@ -646,7 +651,7 @@ class Check(_CheckBase):
         return cls(
             _notin,
             name=cls.notin.__name__,
-            error="notin(%s)" % forbidden_values,
+            error="notin(%s)" % set(forbidden_values),
             raise_warning=raise_warning,
         )
 

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -110,7 +110,7 @@ def check_input(
             try:
                 args[obj_getter] = schema.validate(args[obj_getter])
             except IndexError as e:
-                raise errors.SchemaError(
+                raise IndexError(
                     "error in check_input decorator of function '%s': the "
                     "index '%s' was supplied to the check but this "
                     "function accepts '%s' arguments, so the maximum "
@@ -118,7 +118,7 @@ def check_input(
                     (fn.__name__,
                      obj_getter,
                      len(_get_fn_argnames(fn)),
-                     max(0, len(_get_fn_argnames(fn))-1),
+                     max(0, len(_get_fn_argnames(fn)) - 1),
                      e
                      )
                     )
@@ -137,6 +137,7 @@ def check_input(
                     args[0], head, tail, sample, random_state)
             except errors.SchemaError as e:
                 raise errors.SchemaError(
+                    schema, args[0],
                     "error in check_input decorator of function '%s': %s" %
                     (fn.__name__, e))
         else:
@@ -248,6 +249,7 @@ def check_output(
             schema.validate(obj, head, tail, sample, random_state)
         except errors.SchemaError as e:
             raise errors.SchemaError(
+                schema, obj,
                 "error in check_output decorator of function '%s': %s" %
                 (fn.__name__, e))
 

--- a/pandera/error_handlers.py
+++ b/pandera/error_handlers.py
@@ -1,0 +1,43 @@
+"""Handle schema errors."""
+
+from typing import List
+
+from .errors import SchemaError
+
+
+class SchemaErrorHandler():
+    """Handler for SchemaError objects during validation."""
+
+    def __init__(self, lazy: bool):
+        """Initialize SchemaErrorHandler.
+
+        :param lazy: if True, lazily evaluates schema checks and stores
+            SchemaError objects. Otherwise raise a SchemaError immediately.
+        """
+        self._lazy = lazy
+        self._collected_errors = []  # type: ignore
+
+    def collect_error(self, reason_code: str, schema_error: SchemaError):
+        """Collect schema error, raising exception if lazy is False.
+
+        :param reason_code: string representing reason for error
+        :param schema_error: ``SchemaError`` object.
+        """
+        if not self._lazy:
+            raise schema_error
+
+        # delete data of validated object from SchemaError object to prevent
+        # storing copies of the validated DataFrame/Series for every
+        # SchemaError collected.
+        del schema_error.data
+        schema_error.data = None
+
+        self._collected_errors.append({
+            "reason_code": reason_code,
+            "error": schema_error,
+        })
+
+    @property
+    def collected_errors(self) -> List[SchemaError]:
+        """Retrieve SchemaError objects collected during lazy validation."""
+        return self._collected_errors

--- a/pandera/error_handlers.py
+++ b/pandera/error_handlers.py
@@ -8,7 +8,7 @@ from .errors import SchemaError
 class SchemaErrorHandler():
     """Handler for SchemaError objects during validation."""
 
-    def __init__(self, lazy: bool):
+    def __init__(self, lazy: bool) -> None:
         """Initialize SchemaErrorHandler.
 
         :param lazy: if True, lazily evaluates schema checks and stores

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -1,5 +1,21 @@
 """pandera-specific errors."""
 
+from collections import defaultdict, namedtuple
+from typing import Any, Dict, List
+
+import pandas as pd
+
+
+ErrorData = namedtuple(
+    "ErrorData", [
+        "data",
+        "error_counts",
+        "column_errors",
+        "type_errors",
+        "check_errors",
+    ]
+)
+
 
 class SchemaInitError(Exception):
     """Raised when schema initialization fails."""
@@ -11,3 +27,127 @@ class SchemaDefinitionError(Exception):
 
 class SchemaError(Exception):
     """Raised when object does not pass schema validation constraints."""
+
+    def __init__(
+            self, schema, data, message,
+            failure_cases=None, check=None, check_index=None):
+        super(SchemaError, self).__init__(message)
+        self.schema = schema
+        self.data = data
+        self.failure_cases = failure_cases
+        self.check = check
+        self.check_index = check_index
+
+
+SCHEMA_ERRORS_SUFFIX = """
+
+Usage Tip
+---------
+
+Directly inspect all errors by catching the exception:
+
+```
+try:
+    schema.validate(dataframe)
+except SchemaErrors as err:
+    err.schema_errors  # dataframe of schema errors
+    err.data  # invalid dataframe
+```
+"""
+
+
+class SchemaErrors(Exception):
+    """Raised when multiple schema are lazily collected into one error."""
+
+    def __init__(self, schema_error_dicts, data):
+        error_counts, schema_errors = self._parse_schema_errors(
+            schema_error_dicts)
+        super(SchemaErrors, self).__init__(
+            self._message(error_counts, schema_errors)
+        )
+        self._schema_error_dicts = schema_error_dicts
+        self.error_counts = error_counts
+        self.schema_errors = schema_errors
+        self.data = data
+
+    @staticmethod
+    def _message(error_counts, schema_errors):
+        """Format error message."""
+        msg = "A total of %s schema errors were found.\n" % \
+            sum(error_counts.values())
+
+        msg += "\nError Counts"
+        msg += "\n------------\n"
+        for k, v in error_counts.items():
+            msg += "- %s: %d\n" % (k, v)
+
+        def failure_cases(x):
+            return list(set(x))
+
+        agg_schema_errors = (
+            schema_errors
+            .fillna({"column": "<NA>"})
+            .groupby(["schema_context", "column", "check"])
+            .failure_case.agg([failure_cases, len])
+            .rename(columns={
+                "len": "n_failure_cases",
+            })
+            .sort_index(
+                level=["schema_context", "column"],
+                ascending=[False, True],
+            )
+        )
+
+        msg += "\nSchema Error Summary"
+        msg += "\n--------------------\n"
+        with pd.option_context("display.max_colwidth", 100):
+            msg += agg_schema_errors.to_string()
+        msg += SCHEMA_ERRORS_SUFFIX
+
+        return msg
+
+    @staticmethod
+    def _parse_schema_errors(schema_error_dicts: List[Dict[str, Any]]):
+        """Parse schema error dicts to produce data for error message."""
+        error_counts = defaultdict(int)  # type: ignore
+        check_failure_cases = []
+
+        column_order = [
+            "schema_context", "column", "check", "check_number",
+            "failure_case", "index",
+        ]
+
+        for schema_error_dict in schema_error_dicts:
+            reason_code = schema_error_dict["reason_code"]
+            err = schema_error_dict["error"]
+
+            error_counts[reason_code] += 1
+            check_identifier = None if err.check is None \
+                else err.check if isinstance(err.check, str) \
+                else err.check.error if err.check.error is not None \
+                else err.check.name if err.check.name is not None \
+                else str(err.check)
+
+            if err.failure_cases is not None:
+                if "column" in err.failure_cases:
+                    column = err.failure_cases["column"]
+                else:
+                    column = (
+                        err.schema.name
+                        if reason_code == "schema_component_check"
+                        else None
+                    )
+
+                failure_cases = err.failure_cases.assign(
+                    schema_context=err.schema.__class__.__name__,
+                    check=check_identifier,
+                    check_number=err.check_index,
+                    column=column
+                )
+                check_failure_cases.append(failure_cases[column_order])
+
+        schema_errors = (
+            pd.concat(check_failure_cases).reset_index(drop=True)
+            .sort_values("schema_context", ascending=False)
+        )
+        return error_counts, schema_errors

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -48,7 +48,7 @@ Directly inspect all errors by catching the exception:
 
 ```
 try:
-    schema.validate(dataframe)
+    schema.validate(dataframe, lazy=True)
 except SchemaErrors as err:
     err.schema_errors  # dataframe of schema errors
     err.data  # invalid dataframe

--- a/pandera/hypotheses.py
+++ b/pandera/hypotheses.py
@@ -191,7 +191,7 @@ class Hypothesis(_CheckBase):
         """
         if isinstance(relationship, str):
             if relationship not in self.RELATIONSHIPS:
-                raise errors.SchemaError(
+                raise errors.SchemaInitError(
                     "The relationship %s isn't a built in method"
                     % relationship)
             relationship = self.RELATIONSHIPS[relationship]
@@ -312,7 +312,7 @@ class Hypothesis(_CheckBase):
 
         """
         if relationship not in cls.RELATIONSHIPS:
-            raise errors.SchemaError(
+            raise errors.SchemaInitError(
                 "relationship must be one of %s" % set(cls.RELATIONSHIPS))
         return cls(
             test=stats.ttest_ind,
@@ -391,7 +391,7 @@ class Hypothesis(_CheckBase):
 
         """
         if relationship not in cls.RELATIONSHIPS:
-            raise errors.SchemaError(
+            raise errors.SchemaInitError(
                 "relationship must be one of %s" % set(cls.RELATIONSHIPS))
         return cls(
             test=stats.ttest_1samp,

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -133,7 +133,9 @@ def test_check_groups():
         ]),
         "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
     })
-    with pytest.raises(KeyError, match="^'bar'"):
+    with pytest.raises(
+            errors.SchemaError,
+            match=r'Error while executing check function: KeyError\("bar"\)'):
         schema_fail_key_error.validate(df)
 
     # raise KeyError when the group does not exist in the groupby column when
@@ -144,7 +146,9 @@ def test_check_groups():
         ]),
         "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
     })
-    with pytest.raises(KeyError, match="^'baz'"):
+    with pytest.raises(
+            errors.SchemaError,
+            match=r'Error while executing check function: KeyError\("baz"\)'):
         schema_fail_nonexistent_key_in_fn.validate(df)
 
     # raise KeyError when the group does not exist in the groups argument.
@@ -154,7 +158,7 @@ def test_check_groups():
         ]),
         "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
     })
-    with pytest.raises(KeyError):
+    with pytest.raises(errors.SchemaError):
         schema_fail_nonexistent_key_in_groups.validate(df)
 
 
@@ -256,16 +260,16 @@ def test_dataframe_checks():
     assert isinstance(element_wise_check_schema.validate(df), pd.DataFrame)
 
 
-def test_format_failure_case_exceptions():
-    """Tests that the format_failure_cases method correctly produces a
+def test_reshape_failure_cases_exceptions():
+    """Tests that the reshape_failure_cases method correctly produces a
     TypeError."""
-    # pylint: disable=W0212
+    # pylint: disable=W0212, E1121
     # disabling pylint because this function should be private to the class and
     # it's ok to access it because the function needs to be tested.
     check = Check(lambda x: x.isna().sum() == 0)
     for data in [1, "foobar", 1.0, {"key": "value"}, list(range(10))]:
         with pytest.raises(TypeError):
-            error_formatters.format_failure_cases(data, check.n_failure_cases)
+            error_formatters.reshape_failure_cases(data, check.n_failure_cases)
 
 
 def test_check_equality_operators():

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -133,7 +133,7 @@ def test_check_function_decorator_errors():
         return df
 
     with pytest.raises(
-            errors.SchemaError,
+            IndexError,
             match=r"^error in check_input decorator of function"):
         test_incorrect_check_input_index(pd.DataFrame({"column1": [1, 2, 3]})
                                          )

--- a/tests/test_hypotheses.py
+++ b/tests/test_hypotheses.py
@@ -200,7 +200,7 @@ def test_two_sample_ttest_hypothesis_relationships():
         assert isinstance(schema, DataFrameSchema)
 
     for relationship in ["foo", "bar", 1, 2, 3, None]:
-        with pytest.raises(errors.SchemaError):
+        with pytest.raises(errors.SchemaInitError):
             DataFrameSchema({
                 "height_in_feet": Column(Float, [
                     Hypothesis.two_sample_ttest(

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -732,7 +732,9 @@ def test_lazy_dataframe_validation_error():
                     # check name -> failure cases
                     "greater_than(0)": [
                         "TypeError(\"'>' not supported between instances of "
-                        "'str' and 'int'\")"
+                        "'str' and 'int'\")",
+                        # TypeError raised in python=3.5
+                        "TypeError(\"unorderable types: str() > int()\")"
                     ],
                     "pandas_dtype('int64')": ['object'],
                 },


### PR DESCRIPTION
Fixes #122

This PR adds lazy validation to schema and schema component classes. This keyword argument is passed into the `validate` method and is `False` by default. If `True`, the method will collect all `SchemaError` object that are raised during validation and raise a `SchemaErrors` exception.

- `SchemaError` objects now contain the validated data, check object, and failure cases that gave rise the error.
- `SchemaErrors` objects contain the collect schema errors raised during validation.