### PR TITLE
implement ignore_na in Check objects

### DIFF
--- a/docs/source/checks.rst
+++ b/docs/source/checks.rst
@@ -93,6 +93,20 @@ checks.
 
 .. _grouping:
 
+Handling Null Values
+--------------------
+
+By default, ``pandera`` drops null values before passing the objects to
+validate into the check function. For ``Series`` objects null elements are
+dropped (this also applies to columns), and for ``DataFrame`` objects, rows
+with any null value are dropped.
+
+If you want to check the properties of a pandas data structure while preserving
+null values, specify ``Check(..., ignore_na=False)`` when defining a check.
+
+Note that this is different from the ``nullable`` argument in :py:class:`Column`
+objects, which simply checks for null values in a column.
+
 Column Check Groups
 -------------------
 
@@ -106,7 +120,7 @@ Specifying ``groupby`` as a column name, list of column names, or
 callable changes the expected signature of the :py:class:`Check`
 function argument to:
 
-``Dict[Any, pd.Series] -> Union[bool, pd.Series]``
+``Callable[Dict[Any, pd.Series] -> Union[bool, pd.Series]``
 
 where the dict keys are the discrete keys in the ``groupby`` columns.
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -651,7 +651,9 @@ def test_lazy_dataframe_validation_error():
             "str_col": Column(String, Check.isin(["foo", "bar"])),
             "not_in_dataframe": Column(Int),
         },
-        checks=Check(lambda df: df != 1, error="dataframe_not_equal_1"),
+        checks=Check(
+            lambda df: df != 1, error="dataframe_not_equal_1", ignore_na=False
+        ),
         index=Index(String, name="str_index"),
         strict=True,
     )


### PR DESCRIPTION
this PR introduces the `ignore_na` keyword arg to the `Check` object.

- by default it's `True`, which means null elements are dropped from Series objects and rows containing any nulls are dropped from DataFrame objects before the object to validate is passed to the `check_fn`.
- if `False`, all elements are preserved, including nulls.