### PR TITLE
enhancement: make failure case error reporting more intuitive

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -133,13 +133,12 @@ In the case that a validation ``Check`` is violated:
 
     Traceback (most recent call last):
     ...
-    pandera.SchemaError: <Schema Column: 'column1' type=int64> failed element-wise validator 0:
-    <lambda>: range checker [0, 10]
+    SchemaError: <Schema Column: 'column1' type=int> failed element-wise validator 0:
+    <Check <lambda>: range checker [0, 10]>
     failure cases:
-                 index  count
-    failure_case
-    -20            [0]      1
-     30            [3]      1
+       index  failure_case
+    0      0           -20
+    1      3            30
 
 
 And in the case of a mis-specified column name:

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -370,7 +370,12 @@ class _CheckBase():
         elif isinstance(check_result, pd.DataFrame):
             # check results consisting of a boolean dataframe should be
             # reported at the most granular level.
-            failure_cases = check_obj.unstack()[~check_result.unstack()]
+            failure_cases = (
+                check_obj.unstack()[~check_result.unstack()]
+                .rename("failure_case")
+                .rename_axis(["column", "index"])
+                .reset_index()
+            )
         else:
             raise TypeError(
                 f"output type of check_fn not recognized: {type(check_result)}"

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -358,6 +358,7 @@ class _CheckBase():
 
         # failure cases only apply when the check function returns a boolean
         # series that matches the shape and index of the check_obj
+        # pylint: disable=too-many-branches
         if isinstance(check_obj, dict) or \
                 isinstance(check_result, bool) or \
                 not isinstance(check_result, (pd.Series, pd.DataFrame)) or \
@@ -369,12 +370,7 @@ class _CheckBase():
         elif isinstance(check_result, pd.DataFrame):
             # check results consisting of a boolean dataframe should be
             # reported at the most granular level.
-            failure_cases = (
-                check_obj.unstack()[~check_result.unstack()]
-                .rename("failure_case")
-                .rename_axis(["column", "index"])
-                .reset_index()
-            )
+            failure_cases = check_obj.unstack()[~check_result.unstack()]
         else:
             raise TypeError(
                 f"output type of check_fn not recognized: {type(check_result)}"

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -315,6 +315,7 @@ class _CheckBase():
             df_or_series: Union[pd.DataFrame, pd.Series],
             column: Optional[str] = None,
     ) -> CheckResult:
+        # pylint: disable=too-many-branches
         """Validate pandas DataFrame or Series.
 
         :param df_or_series: pandas DataFrame of Series to validate.
@@ -323,7 +324,6 @@ class _CheckBase():
         :returns: CheckResult tuple containing checked object,
             check validation result, and failure cases from the checked object.
         """
-        # pylint: disable=too-many-branches
         df_or_series = self._handle_na(df_or_series, column)
 
         column_dataframe_context = None
@@ -358,7 +358,6 @@ class _CheckBase():
 
         # failure cases only apply when the check function returns a boolean
         # series that matches the shape and index of the check_obj
-        # pylint: disable=too-many-branches
         if isinstance(check_obj, dict) or \
                 isinstance(check_result, bool) or \
                 not isinstance(check_result, (pd.Series, pd.DataFrame)) or \

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -378,7 +378,8 @@ class _CheckBase():
             )
         else:
             raise TypeError(
-                f"output type of check_fn not recognized: {type(check_result)}"
+                "output type of check_fn not recognized: %s" %
+                type(check_result)
             )
 
         # handle check_result return types

--- a/pandera/error_formatters.py
+++ b/pandera/error_formatters.py
@@ -76,7 +76,13 @@ def reshape_failure_cases(
 
     """
     if "column" in failure_cases and "failure_case" in failure_cases:
-        reshaped_failure_cases = failure_cases
+        # handle case where failure cases occur at the index-column level
+        reshaped_failure_cases = (
+            failure_cases
+            .rename("failure_case")
+            .rename_axis(["column", "index"])
+            .reset_index()
+        )
     elif hasattr(failure_cases, "index") and \
             isinstance(failure_cases.index, pd.MultiIndex):
         reshaped_failure_cases = (

--- a/pandera/error_formatters.py
+++ b/pandera/error_formatters.py
@@ -77,12 +77,7 @@ def reshape_failure_cases(
     """
     if "column" in failure_cases and "failure_case" in failure_cases:
         # handle case where failure cases occur at the index-column level
-        reshaped_failure_cases = (
-            failure_cases
-            .rename("failure_case")
-            .rename_axis(["column", "index"])
-            .reset_index()
-        )
+        reshaped_failure_cases = failure_cases
     elif hasattr(failure_cases, "index") and \
             isinstance(failure_cases.index, pd.MultiIndex):
         reshaped_failure_cases = (

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1085,7 +1085,7 @@ def _handle_check_results(
                 schema, check, check_index)
         else:
             failure_cases = reshape_failure_cases(
-                check_result.failure_cases)
+                check_result.failure_cases, check.ignore_na)
             error_msg = format_vectorized_error_message(
                 schema, check, check_index, failure_cases)
 


### PR DESCRIPTION
the way `SchemaError`s report failure cases is not very intuitive.
this diff simplifies this by skipping the aggregation step and
formatting the raw `reshaped_failure_cases` dataframe, which
it turns out is easier to read.

Add logic in `checks.py` that handles the case where the output
of `check_fn` is a boolean `DataFrame`. This allows for failure_cases
to be reported as tidy data at the `index` and `column` level.