### PR TITLE
add viewcode sphinx extension to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
-    'sphinx_autodoc_typehints'
+    'sphinx_autodoc_typehints',
+    'sphinx.ext.viewcode',
 ]
 
 doctest_global_setup = """


### PR DESCRIPTION
this PR improves documentation significantly by providing links and pages for source code associated with the API reference.