### PR TITLE
add `check_output` to the `CheckResult` namedtuple

### DIFF
--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -323,16 +323,20 @@ class _CheckBase():
         :param column: for dataframe checks, apply the check function to this
             column.
         :returns: CheckResult tuple containing:
-            - check_output: boolean scalar, Series or DataFrame indicating
-              which elements passed the check
-            - check_passed: boolean scalar that indicating whether the check
-              passed overall.
-            - checked_object: the checked object itself. Depending on the
-              options provided to the ``Check``, this will be a pandas Series,
-              DataFrame, or if the ``groupby`` option is specified, a
-              ``Dict[str, Series]`` or ``Dict[str, DataFrame]`` where the keys
-              are distinct groups.
-            - failure_cases: subset of the check_object that failed.
+
+            ``check_output``: boolean scalar, ``Series`` or ``DataFrame``
+            indicating which elements passed the check.
+
+            ``check_passed``: boolean scalar that indicating whether the check
+            passed overall.
+
+            ``checked_object``: the checked object itself. Depending on the
+            options provided to the ``Check``, this will be a pandas Series,
+            DataFrame, or if the ``groupby`` option is specified, a
+            ``Dict[str, Series]`` or ``Dict[str, DataFrame]`` where the keys
+            are distinct groups.
+
+            ``failure_cases``: subset of the check_object that failed.
         """
         df_or_series = self._handle_na(df_or_series, column)
 


### PR DESCRIPTION
the reason for this is to fulfill the use case where the
user wants to use `Check` objects by themselves and access
the boolean scalar, Series, or DataFrame that the `check_fn`
function outputs for downstream purposes like visualization
or boolean indexing