### PR TITLE
fix error in Column.pandas_dtype

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.4.4
+    rev: pylint-2.5.0
     hooks:
     -   id: pylint
         args: ["--disable=import-error"]
         exclude: (^docs/|^scripts|setup.py)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
+    rev: v0.782
     hooks:
     -   id: mypy
         entry: mypy pandera tests

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -76,11 +76,10 @@ class Column(SeriesSchemaBase):
             raise ValueError(
                 "You cannot specify a non-string name when setting regex=True")
         self.required = required
-        self.pandas_dtype = pandas_dtype
         self._name = name
         self._regex = regex
 
-        if coerce and pandas_dtype is None:
+        if coerce and self._pandas_dtype is None:
             raise errors.SchemaInitError(
                 "Must specify dtype if coercing a Column's type")
 
@@ -98,7 +97,7 @@ class Column(SeriesSchemaBase):
     def properties(self) -> Dict[str, Any]:
         """Get column properties."""
         return {
-            "pandas_dtype": self.pandas_dtype,
+            "pandas_dtype": self._pandas_dtype,
             "checks": self._checks,
             "nullable": self._nullable,
             "allow_duplicates": self._allow_duplicates,

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -609,7 +609,6 @@ class DataFrameSchema():
         return new_schema
 
 
-
 class SeriesSchemaBase():
     """Base series validator object."""
 
@@ -715,6 +714,26 @@ class SeriesSchemaBase():
         return self._name
 
     @property
+    def pandas_dtype(self) -> Union[
+            str,
+            dtypes.PandasDtype,
+            dtypes.PandasExtensionType]:
+        """Get the pandas dtype"""
+        return self._pandas_dtype
+
+    @pandas_dtype.setter
+    def pandas_dtype(self, value: Union[
+            str,
+            dtypes.PandasDtype,
+            dtypes.PandasExtensionType]) -> None:
+        """Set the pandas dtype"""
+        self._pandas_dtype = value
+        try:
+            self.dtype
+        except TypeError:
+            raise
+
+    @property
     def dtype(self) -> Union[str, None]:
         """String representation of the dtype."""
         try:
@@ -735,8 +754,10 @@ class SeriesSchemaBase():
             dtype = self._pandas_dtype.str_alias
         else:
             raise TypeError(
-                "type of `pandas_dtype` argument not recognized: %s" %
-                type(self._pandas_dtype)
+                "type of `pandas_dtype` argument not recognized: %s "
+                "Please specify a pandera PandasDtype enum, legal pandas data "
+                "type, pandas data type string alias, or numpy data type "
+                "string alias" % type(self._pandas_dtype)
             )
         return dtype
 

--- a/tests/test_schema_components.py
+++ b/tests/test_schema_components.py
@@ -460,3 +460,23 @@ def test_rename_columns():
     assert all([col_name in rename_dict.values() for col_name in schema_renamed.columns])
     # Check if original schema didn't change in the process
     assert all([col_name in schema_original.columns for col_name in rename_dict])
+
+
+def test_column_type_can_be_set():
+    """Test that the Column dtype can be edited during schema construction."""
+
+    column_a = Column(Int, name="a")
+    changed_type = Float
+
+    column_a.pandas_dtype = Float
+
+    assert column_a.pandas_dtype == changed_type
+    assert column_a.dtype == changed_type.str_alias
+
+    for invalid_dtype in ("foobar", "bar"):
+        with pytest.raises(ValueError):
+            column_a.pandas_dtype = invalid_dtype
+
+    for invalid_dtype in (1, 2.2, ["foo", 1, 1.1], {"b": 1}):
+        with pytest.raises(TypeError):
+            column_a.pandas_dtype = invalid_dtype


### PR DESCRIPTION
This PR fixes the error reported in #192 where `Column`s had its own `pandas_dtype` property. This diff adds a `pandas_dtype` getter and setter to the `SeriesSchemaBase` class for consistency.