### PR TITLE
Fix check_input decorator when df passed in kwargs

### DIFF
--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -142,7 +142,7 @@ def check_input(
                 args = list(args_dict.values())
         elif obj_getter is None:
             try:
-                if len(args) == 0:
+                if not args:
                     # get the first key in the same order specified in the
                     # function argument.
                     args_names = _get_fn_argnames(fn)

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -154,7 +154,7 @@ def check_input(
                     check=e.check,
                     check_index=e.check_index,
                 )
-        elif obj_getter is None and kwargs:
+        elif obj_getter is None and len(kwargs) == 1:
             try:
                 # assume that the first keyword argument is the dataframe we want to validate
                 # since the dicts are ordered in python 3.6+

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -169,7 +169,7 @@ def check_input(
                     (fn.__name__, e)
                 )
                 raise errors.SchemaError(
-                    schema, args_names[0], msg,
+                    schema, kwargs[args_names[0]], msg,
                     failure_cases=e.failure_cases,
                     check=e.check,
                     check_index=e.check_index,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -50,34 +50,27 @@ def test_check_function_decorators():
         # what is being tested.
         return dataframe.assign(f=["a", "b", "a"])
 
-    # case 2: simplest path test - df is first and the only argument and function returns
-    # single dataframe as output.
-    @check_input(in_schema)
-    @check_output(out_schema)
-    def test_func2(dataframe):
-        return dataframe.assign(f=["a", "b", "a"])
-
-    # case 3: input and output validation using positional arguments
+    # case 2: input and output validation using positional arguments
     @check_input(in_schema, 1)
     @check_output(out_schema, 0)
-    def test_func3(x, dataframe):
+    def test_func2(x, dataframe):
         return dataframe.assign(f=["a", "b", "a"]), x
 
-    # case 4: dataframe to validate is called as a keyword argument and the
+    # case 3: dataframe to validate is called as a keyword argument and the
     # output is in a dictionary
     @check_input(in_schema, "in_dataframe")
     @check_output(out_schema, "out_dataframe")
-    def test_func4(x, in_dataframe=None):
+    def test_func3(x, in_dataframe=None):
         return {
             "x": x,
             "out_dataframe": in_dataframe.assign(f=["a", "b", "a"]),
         }
 
-    # case 5: dataframe is a positional argument but the obj_getter in the
+    # case 4: dataframe is a positional argument but the obj_getter in the
     # check_input decorator refers to the argument name of the dataframe
     @check_input(in_schema, "dataframe")
     @check_output(out_schema)
-    def test_func5(x, dataframe):
+    def test_func4(x, dataframe):
         # pylint: disable=W0613
         # disables unused-arguments because handling the second argument is
         # what is being tested.
@@ -96,26 +89,30 @@ def test_check_function_decorators():
     df = test_func1(df, "foo")
     assert isinstance(df, pd.DataFrame)
 
-    # call function with a dataframe passed as a keyword argument
-    df = test_func2(dataframe=df)
+    # call function with a dataframe passed as a first keyword argument
+    df = test_func1(dataframe=df, x="foo")
     assert isinstance(df, pd.DataFrame)
 
-    df, x = test_func3("foo", df)
+    # call function with a dataframe passed as a second keyword argument
+    df = test_func1(x="foo", dataframe=df)
+    assert isinstance(df, pd.DataFrame)
+
+    df, x = test_func2("foo", df)
     assert x == "foo"
     assert isinstance(df, pd.DataFrame)
 
-    result = test_func4("foo", in_dataframe=df)
+    result = test_func3("foo", in_dataframe=df)
     assert result["x"] == "foo"
     assert isinstance(df, pd.DataFrame)
 
     # case 5: even if the pandas object to validate is called as a positional
     # argument, the check_input decorator should still be able to handle
     # it.
-    result = test_func4("foo", df)
+    result = test_func3("foo", df)
     assert result["x"] == "foo"
     assert isinstance(df, pd.DataFrame)
 
-    df = test_func5("foo", df)
+    df = test_func4("foo", df)
     assert x == "foo"
     assert isinstance(df, pd.DataFrame)
 
@@ -209,6 +206,11 @@ def test_check_input_method_decorators():
         def transform_first_arg(self, df):
             return _transform_helper(df)
 
+        @check_input(in_schema)
+        @check_output(out_schema)
+        def transform_first_arg_with_two_func_args(self, df, x):
+            return _transform_helper(df)
+
         @check_input(in_schema, 0)
         @check_output(out_schema)
         def transform_first_arg_with_list_getter(self, df):
@@ -233,8 +235,11 @@ def test_check_input_method_decorators():
     # call method with a dataframe passed as a positional argument
     _assert_expectation(transformer.transform_first_arg(dataframe))
 
-    # call method with a dataframe passed as a keyword argument
+    # call method with a dataframe passed as a first keyword argument
     _assert_expectation(transformer.transform_first_arg(df=dataframe))
+
+    # call method with a dataframe passed as a second keyword argument
+    _assert_expectation(transformer.transform_first_arg_with_two_func_args(x="foo", df=dataframe))
 
     _assert_expectation(
         transformer.transform_first_arg_with_list_getter(dataframe))

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -84,7 +84,13 @@ def test_check_function_decorators():
               pd.Timestamp("2018-01-02")],
         "d": [np.nan, 1.0, 2.0],
     })
+
+    # call function with a dataframe passed as a positional argument
     df = test_func1(df, "foo")
+    assert isinstance(df, pd.DataFrame)
+
+    # call function with a dataframe passed as a keyword argument
+    df = test_func1(dataframe=df, x="foo")
     assert isinstance(df, pd.DataFrame)
 
     df, x = test_func2("foo", df)
@@ -211,7 +217,13 @@ def test_check_input_method_decorators():
         assert "column2" in result_df.columns
 
     transformer = TransformerClass()
+
+    # call method with a dataframe passed as a positional argument
     _assert_expectation(transformer.transform_first_arg(dataframe))
+
+    # call method with a dataframe passed as a keyword argument
+    _assert_expectation(transformer.transform_first_arg(df=dataframe))
+
     _assert_expectation(
         transformer.transform_first_arg_with_list_getter(dataframe))
     _assert_expectation(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -136,6 +136,11 @@ def test_check_function_decorator_errors():
 
     with pytest.raises(
             errors.SchemaError,
+            match=r"^error in check_input decorator of function"):
+        test_func(df=pd.DataFrame({"column2": ["a", "b", "c"]}))
+
+    with pytest.raises(
+            errors.SchemaError,
             match=r"^error in check_output decorator of function"):
         test_func(pd.DataFrame({"column1": [1, 2, 3]}))
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -50,27 +50,34 @@ def test_check_function_decorators():
         # what is being tested.
         return dataframe.assign(f=["a", "b", "a"])
 
-    # case 2: input and output validation using positional arguments
+    # case 2: simplest path test - df is first and the only argument and function returns
+    # single dataframe as output.
+    @check_input(in_schema)
+    @check_output(out_schema)
+    def test_func2(dataframe):
+        return dataframe.assign(f=["a", "b", "a"])
+
+    # case 3: input and output validation using positional arguments
     @check_input(in_schema, 1)
     @check_output(out_schema, 0)
-    def test_func2(x, dataframe):
+    def test_func3(x, dataframe):
         return dataframe.assign(f=["a", "b", "a"]), x
 
-    # case 3: dataframe to validate is called as a keyword argument and the
+    # case 4: dataframe to validate is called as a keyword argument and the
     # output is in a dictionary
     @check_input(in_schema, "in_dataframe")
     @check_output(out_schema, "out_dataframe")
-    def test_func3(x, in_dataframe=None):
+    def test_func4(x, in_dataframe=None):
         return {
             "x": x,
             "out_dataframe": in_dataframe.assign(f=["a", "b", "a"]),
         }
 
-    # case 4: dataframe is a positional argument but the obj_getter in the
+    # case 5: dataframe is a positional argument but the obj_getter in the
     # check_input decorator refers to the argument name of the dataframe
     @check_input(in_schema, "dataframe")
     @check_output(out_schema)
-    def test_func4(x, dataframe):
+    def test_func5(x, dataframe):
         # pylint: disable=W0613
         # disables unused-arguments because handling the second argument is
         # what is being tested.
@@ -90,25 +97,25 @@ def test_check_function_decorators():
     assert isinstance(df, pd.DataFrame)
 
     # call function with a dataframe passed as a keyword argument
-    df = test_func1(dataframe=df, x="foo")
+    df = test_func2(dataframe=df)
     assert isinstance(df, pd.DataFrame)
 
-    df, x = test_func2("foo", df)
+    df, x = test_func3("foo", df)
     assert x == "foo"
     assert isinstance(df, pd.DataFrame)
 
-    result = test_func3("foo", in_dataframe=df)
+    result = test_func4("foo", in_dataframe=df)
     assert result["x"] == "foo"
     assert isinstance(df, pd.DataFrame)
 
     # case 5: even if the pandas object to validate is called as a positional
     # argument, the check_input decorator should still be able to handle
     # it.
-    result = test_func3("foo", df)
+    result = test_func4("foo", df)
     assert result["x"] == "foo"
     assert isinstance(df, pd.DataFrame)
 
-    df = test_func4("foo", df)
+    df = test_func5("foo", df)
     assert x == "foo"
     assert isinstance(df, pd.DataFrame)
 


### PR DESCRIPTION
When we call a function/method wrapped in @check_input like so:

    @check_input(in_schema)
    def decorated_function(df):
        return df

    decorated_function(df)  # passes
    decorated_function(df=df)  # fails

then the decorator fails as it doesn't expect the keyword argument. It's
counterintuitive for the final user of this API.

This patch assumes that the first keyword argument is the dataframe to
validate.