### PR TITLE
built-in python scalar types are supported: int, float, str, bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ df = pd.DataFrame({
 
 # define schema
 schema = pa.DataFrameSchema({
-    "column1": pa.Column(pa.Int, checks=pa.Check.less_than_or_equal_to(10)),
-    "column2": pa.Column(pa.Float, checks=pa.Check.less_than(-1.2)),
-    "column3": pa.Column(pa.String, checks=[
+    "column1": pa.Column(int, checks=pa.Check.less_than_or_equal_to(10)),
+    "column2": pa.Column(float, checks=pa.Check.less_than(-1.2)),
+    "column3": pa.Column(str, checks=[
         pa.Check.str_startswith("value_"),
         # define custom checks as functions that take a series as input and
         # outputs a boolean or boolean Series
@@ -79,7 +79,7 @@ schema = pa.DataFrameSchema({
     ]),
 })
 
-validated_df = schema.validate(df)
+validated_df = schema(df)
 print(validated_df)
 
 #     column1  column2  column3

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,7 +67,7 @@ Quick Start
         ]),
     })
 
-    validated_df = schema.validate(df)
+    validated_df = schema(df)
     print(validated_df)
 
 .. testoutput:: quick_start
@@ -79,22 +79,23 @@ Quick Start
     3       10    -10.1  value_2
     4        9    -20.4  value_1
 
-
-Alternatively, you can pass strings representing the
-`legal pandas datatypes <https://pandas.pydata.org/pandas-docs/stable/getting_started/basics.html#dtypes>`_:
+Alternatively, you can pass the built-in python types that are supported by
+pandas, or strings representing the
+`legal pandas datatypes <https://pandas.pydata.org/pandas-docs/stable/user_guide/basics.html#basics-dtypes>`_:
 
 .. testcode:: quick_start
 
     schema = pa.DataFrameSchema({
-        "column1": pa.Column("int64", checks=pa.Check.less_than_or_equal_to(10)),
-        "column2": pa.Column("float64", checks=pa.Check.less_than(-1.2)),
-        # use "string" as of pandas >= 1.0
-        "column3": pa.Column("object", checks=[
-            pa.Check.str_startswith("value_"),
-            # define custom checks as functions that take a series as input and
-            # outputs a boolean or boolean Series
-            pa.Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
-        ]),
+        # built-in python types
+        "int_column": pa.Column(int),
+        "float_column": pa.Column(float),
+        "str_column": pa.Column(str),
+
+        # pandas dtype string aliases
+        "int_column2": pa.Column("int64"),
+        "float_column2": pa.Column("float64"),
+        # pandas > 1.0.0 support native "string" type
+        "str_column2": pa.Column("object"),
     })
 
 For more details on data types, see :py:class:`pandera.PandasDtype`
@@ -126,7 +127,7 @@ In the case that a validation ``Check`` is violated:
         "column1": [-20, 5, 10, 30],
     })
 
-    simple_schema.validate(fail_check_df)
+    simple_schema(fail_check_df)
 
 
 .. testoutput:: informative_errors

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -168,7 +168,7 @@ class PandasDtype(Enum):
         }.get(str_alias)
 
         if pandas_dtype is None:
-            raise ValueError(
+            raise TypeError(
                 "pandas dtype string alias '%s' not recognized" %
                 str_alias
             )
@@ -198,6 +198,27 @@ class PandasDtype(Enum):
             "timedelta64": cls.Timedelta,
             "timedelta": cls.Timedelta,
         }.get(pandas_api_type)
+
+    @classmethod
+    def from_python_type(cls, python_type: type) -> "PandasDtype":
+        """Get PandasDtype enum from built-in python type.
+
+        :param python_type: built-in python type. Allowable types are:
+            str, int, float, list, dict
+        """
+        pandas_dtype = {
+            str: cls.String,
+            int: cls.Int,
+            float: cls.Float,
+        }.get(python_type)
+
+        if pandas_dtype is None:
+            raise TypeError(
+                "python type '%s' not recognized as pandas data type" %
+                python_type
+            )
+
+        return pandas_dtype
 
     def __eq__(self, other):
         # pylint: disable=comparison-with-callable,too-many-return-statements

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -183,8 +183,7 @@ class PandasDtype(Enum):
         return pandas_dtype
 
     @classmethod
-    def from_pandas_api_type(
-            cls, pandas_api_type: str) -> "PandasDtype":
+    def from_pandas_api_type(cls, pandas_api_type: str) -> "PandasDtype":
         """Get PandasDtype enum from pandas api type.
 
         :param pandas_api_type: string output from

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -7,9 +7,11 @@ from typing import Union, Optional, Tuple, Any, List, Dict
 import numpy as np
 import pandas as pd
 
-from . import errors, dtypes
+from . import errors
 from .dtypes import PandasDtype
-from .schemas import DataFrameSchema, SeriesSchemaBase, CheckList
+from .schemas import (
+    DataFrameSchema, SeriesSchemaBase, CheckList, PandasDtypeInputTypes
+)
 
 
 def _is_valid_multiindex_tuple_str(x: Tuple[Any]) -> bool:
@@ -22,8 +24,7 @@ class Column(SeriesSchemaBase):
 
     def __init__(
             self,
-            pandas_dtype: Union[
-                str, PandasDtype, dtypes.PandasExtensionType] = None,
+            pandas_dtype: PandasDtypeInputTypes = None,
             checks: CheckList = None,
             nullable: bool = False,
             allow_duplicates: bool = True,
@@ -241,13 +242,13 @@ class Index(SeriesSchemaBase):
 
     def __init__(
             self,
-            pandas_dtype: Union[
-                str, PandasDtype, dtypes.PandasExtensionType] = None,
+            pandas_dtype: PandasDtypeInputTypes = None,
             checks: CheckList = None,
             nullable: bool = False,
             allow_duplicates: bool = True,
             coerce: bool = False,
             name: str = None) -> None:
+        # pylint: disable=useless-super-delegation
         """Create Index validator.
 
         :param pandas_dtype: datatype of the column. A ``PandasDtype`` for

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -319,6 +319,38 @@ def test_python_builtin_types():
 
 @pytest.mark.parametrize("python_type", [list, dict, set])
 def test_python_builtin_types_not_supported(python_type):
-    """Test unsupport python data types raise a type error."""
+    """Test unsupported python data types raise a type error."""
     with pytest.raises(TypeError):
         Column(python_type)
+
+
+@pytest.mark.parametrize(
+    "pandas_api_type,pandas_dtype", [
+        ["string", PandasDtype.String],
+        ["floating", PandasDtype.Float],
+        ["integer", PandasDtype.Int],
+        ["categorical", PandasDtype.Category],
+        ["boolean", PandasDtype.Bool],
+        ["datetime64", PandasDtype.DateTime],
+        ["datetime", PandasDtype.DateTime],
+        ["timedelta64", PandasDtype.Timedelta],
+        ["timedelta", PandasDtype.Timedelta],
+    ]
+)
+def test_pandas_api_types(pandas_api_type, pandas_dtype):
+    """Test pandas api type conversion."""
+    assert PandasDtype.from_pandas_api_type(pandas_api_type) is pandas_dtype
+
+
+@pytest.mark.parametrize(
+    "invalid_pandas_api_type", [
+        "foo",
+        "bar",
+        "baz",
+        "this is not a type",
+    ]
+)
+def test_pandas_api_type_exception(invalid_pandas_api_type):
+    """Test unsupported values for pandas api type conversion."""
+    with pytest.raises(TypeError):
+        PandasDtype.from_pandas_api_type(invalid_pandas_api_type)

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -302,16 +302,19 @@ def test_python_builtin_types():
         "int_col": Column(int),
         "float_col": Column(float),
         "str_col": Column(str),
+        "bool_col": Column(bool),
     })
     df = pd.DataFrame({
         "int_col": [1, 2, 3],
         "float_col": [1., 2., 3.],
         "str_col": list("abc"),
+        "bool_col": [True, False, True],
     })
     assert isinstance(schema(df), pd.DataFrame)
     assert schema.dtype["int_col"] == PandasDtype.Int.str_alias
     assert schema.dtype["float_col"] == PandasDtype.Float.str_alias
     assert schema.dtype["str_col"] == PandasDtype.String.str_alias
+    assert schema.dtype["bool_col"] == PandasDtype.Bool.str_alias
 
 
 @pytest.mark.parametrize("python_type", [list, dict, set])

--- a/tests/test_schema_components.py
+++ b/tests/test_schema_components.py
@@ -474,7 +474,7 @@ def test_column_type_can_be_set():
     assert column_a.dtype == changed_type.str_alias
 
     for invalid_dtype in ("foobar", "bar"):
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             column_a.pandas_dtype = invalid_dtype
 
     for invalid_dtype in (1, 2.2, ["foo", 1, 1.1], {"b": 1}):


### PR DESCRIPTION
fixes #221: This PR adds support for python built-in types that are natively interpretted by the pandas API: str, int, float, bool. This enables users to easily specify a schema using these commonly-used types without having to know anything about numpy types, pandas types, or the `pandera.PandasDtype` enum.