### PR TITLE
mod: README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ df = pd.DataFrame({
 
 # define schema
 schema = pa.DataFrameSchema({
-    "column1": pa.Column(int, checks=pa.Check.less_than_or_equal_to(10)),
-    "column2": pa.Column(float, checks=pa.Check.less_than(-1.2)),
-    "column3": pa.Column(str, checks=[
+    "column1": pa.Column(pa.Int, checks=pa.Check.less_than_or_equal_to(10)),
+    "column2": pa.Column(pa.Float, checks=pa.Check.less_than(-1.2)),
+    "column3": pa.Column(pa.String, checks=[
         pa.Check.str_startswith("value_"),
         # define custom checks as functions that take a series as input and
         # outputs a boolean or boolean Series


### PR DESCRIPTION
Panderas installed by pip or conda does not support types such as 'int'. Therefore, the current README needs to be modified. The specific errors are as follows:
>TypeError: type of `pandas_dtype` argument not recognized: <class 'type'>
