### PR TITLE
bugfix: caching __schema__ breaks schemas that inherit

### DIFF
--- a/pandera/model.py
+++ b/pandera/model.py
@@ -36,6 +36,9 @@ SchemaIndex = Union[schema_components.Index, schema_components.MultiIndex]
 _CONFIG_KEY = "Config"
 
 
+MODEL_CACHE: Dict[Type["SchemaModel"], DataFrameSchema] = {}
+
+
 class BaseConfig:  # pylint:disable=R0903
     """Define DataFrameSchema-wide options."""
 
@@ -72,6 +75,9 @@ class SchemaModel:
     @classmethod
     def to_schema(cls) -> DataFrameSchema:
         """Create DataFrameSchema from the SchemaModel."""
+        if cls in MODEL_CACHE:
+            return MODEL_CACHE[cls]
+
         cls.__field_annotations__ = cls._collect_field_annotations()
 
         check_infos = cast(List[FieldCheckInfo], cls._collect_check_infos(CHECK_KEY))
@@ -100,6 +106,8 @@ class SchemaModel:
             strict=cls.__config__.strict,
             name=cls.__config__.name,
         )
+        if cls not in MODEL_CACHE:
+            MODEL_CACHE[cls] = cls.__schema__
         return cls.__schema__
 
     @classmethod

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -72,9 +72,6 @@ class SchemaModel:
     @classmethod
     def to_schema(cls) -> DataFrameSchema:
         """Create DataFrameSchema from the SchemaModel."""
-        if cls.__schema__:
-            return cls.__schema__
-
         cls.__field_annotations__ = cls._collect_field_annotations()
 
         check_infos = cast(List[FieldCheckInfo], cls._collect_check_infos(CHECK_KEY))


### PR DESCRIPTION
schemas that inherit from base schema don't work as intended
in the `check_types` decorator because the __schema__ class
attribute is cached and used by the child class.