### PR TITLE
Bugfix io.to_script and to_yaml: Ignoring serializing Checks with lambda functions #246

### DIFF
--- a/pandera/io.py
+++ b/pandera/io.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 from pathlib import Path
+import warnings
 
 import pandas as pd
 try:
@@ -260,10 +261,13 @@ def _format_checks(checks_dict):
 
     checks = []
     for check_name, check_kwargs in checks_dict.items():
-        args = ", ".join(
-            "{}={}".format(k, v.__repr__()) for k, v in check_kwargs.items()
-        )
-        checks.append("Check.{}({})".format(check_name, args))
+        if check_kwargs is None:
+            warnings.warn(f"Check {check_name} cannot be serialized. This check will be ignored")
+        else:
+            args = ", ".join(
+                "{}={}".format(k, v.__repr__()) for k, v in check_kwargs.items()
+            )
+            checks.append("Check.{}({})".format(check_name, args))
     return "[{}]".format(', '.join(checks))
 
 

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -54,12 +54,15 @@ def _serialize_component_stats(component_stats):
     """
     serialized_checks = None
     if component_stats["checks"] is not None:
-        serialized_checks = {
-            check_name: _serialize_check_stats(
-                check_stats, component_stats["pandas_dtype"]
-            )
-            for check_name, check_stats in component_stats["checks"].items()
-        }
+        serialized_checks = {}
+        for check_name, check_stats in component_stats["checks"].items():
+            if check_stats is None:
+                warnings.warn(f"Check {check_name} cannot be serialized. This check will be "
+                              f"ignored")
+            else:
+                serialized_checks[check_name] = _serialize_check_stats(
+                    check_stats, component_stats["pandas_dtype"]
+                )
     return {
         "pandas_dtype": component_stats["pandas_dtype"].value,
         "nullable": component_stats["nullable"],

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -360,3 +360,16 @@ def test_to_script(index):
         exec(f.read(), globals(), local_dict)
         schema = local_dict["schema"]
         assert schema == schema_to_write
+
+
+def test_to_script_lambda_check():
+    """Test writing DataFrameSchema to a script with lambda check."""
+    schema = pa.DataFrameSchema({
+        "a": pa.Column(
+            pa.Int,
+            checks=pa.Check(lambda s: s.mean() > 5, element_wise=False)
+        ),
+    })
+
+    with pytest.warns(UserWarning):
+        pa.io.to_script(schema)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -375,13 +375,13 @@ def test_to_script_lambda_check():
         pa.io.to_script(schema)
 
 def test_to_yaml_lambda_check():
-        """Test writing DataFrameSchema to a yaml with lambda check."""
-        schema = pa.DataFrameSchema({
-            "a": pa.Column(
-                pa.Int,
-                checks=pa.Check(lambda s: s.mean() > 5, element_wise=False)
-            ),
-        })
+    """Test writing DataFrameSchema to a yaml with lambda check."""
+    schema = pa.DataFrameSchema({
+        "a": pa.Column(
+            pa.Int,
+            checks=pa.Check(lambda s: s.mean() > 5, element_wise=False)
+        ),
+    })
 
-        with pytest.warns(UserWarning):
-            pa.io.to_yaml(schema)
+    with pytest.warns(UserWarning):
+        pa.io.to_yaml(schema)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -373,3 +373,15 @@ def test_to_script_lambda_check():
 
     with pytest.warns(UserWarning):
         pa.io.to_script(schema)
+
+def test_to_yaml_lambda_check():
+        """Test writing DataFrameSchema to a yaml with lambda check."""
+        schema = pa.DataFrameSchema({
+            "a": pa.Column(
+                pa.Int,
+                checks=pa.Check(lambda s: s.mean() > 5, element_wise=False)
+            ),
+        })
+
+        with pytest.warns(UserWarning):
+            pa.io.to_yaml(schema)


### PR DESCRIPTION
Serializing checks with lambda functions are ignored but a UserWarning is raised. 