### PR TITLE
add check_io decorator

### DIFF
--- a/docs/source/API_reference.rst
+++ b/docs/source/API_reference.rst
@@ -62,6 +62,7 @@ Decorators
 
    check_input
    check_output
+   check_io
 
 
 Schema Inference

--- a/docs/source/decorators.rst
+++ b/docs/source/decorators.rst
@@ -130,3 +130,47 @@ DataFrame/Series of the decorated function.
     zero_column_1_arg(preprocessed_df)
     zero_column_1_dict(preprocessed_df)
     zero_column_1_custom(preprocessed_df)
+
+
+Check IO
+~~~~~~~~
+
+For convenience, you can also use the :py:func:`check_io` decorator where
+you can specify input and output schemas more concisely:
+
+.. testcode:: check_io
+
+    import pandas as pd
+    import pandera as pa
+
+    from pandera import DataFrameSchema, Column, Check, check_input
+
+
+    df = pd.DataFrame({
+       "column1": [1, 4, 0, 10, 9],
+       "column2": [-1.3, -1.4, -2.9, -10.1, -20.4],
+    })
+
+    in_schema = DataFrameSchema({
+       "column1": Column(int),
+       "column2": Column(float),
+    })
+
+    out_schema = in_schema.add_columns({"column3": Column(float)})
+
+    @pa.check_io(df1=in_schema, df2=in_schema, out=out_schema)
+    def preprocessor(df1, df2):
+        return (df1 + df2).assign(column3=lambda x: x.column1 + x.column2)
+
+    preprocessed_df = preprocessor(df, df)
+    print(preprocessed_df)
+
+
+.. testoutput:: check_io
+
+       column1  column2  column3
+    0        2     -2.6     -0.6
+    1        8     -2.8      5.2
+    2        0     -5.8     -5.8
+    3       20    -20.2     -0.2
+    4       18    -40.8    -22.8

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -3,7 +3,7 @@
 from . import errors, constants
 from .checks import Check
 from .hypotheses import Hypothesis
-from .decorators import check_input, check_output
+from .decorators import check_input, check_output, check_io
 from .dtypes import PandasDtype
 from .schemas import DataFrameSchema, SeriesSchema
 from .schema_components import Column, Index, MultiIndex

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -14,6 +14,11 @@ from . import schemas
 from . import errors
 
 
+Schemas = Union[schemas.DataFrameSchema, schemas.SeriesSchema]
+InputGetter = Union[str, int]
+OutputGetter = Union[int, str, Callable]
+
+
 def _get_fn_argnames(fn: Callable) -> List[str]:
     """Get argument names of a function.
 
@@ -30,7 +35,7 @@ def _get_fn_argnames(fn: Callable) -> List[str]:
 
 def _handle_schema_error(
         fn: Callable,
-        schema: Union[schemas.DataFrameSchema, schemas.SeriesSchema],
+        schema: Schemas,
         arg_df: pd.DataFrame,
         schema_error: errors.SchemaError) -> NoReturn:
     """Reraise schema validation error with decorator context.
@@ -55,8 +60,8 @@ def _handle_schema_error(
 
 
 def check_input(
-        schema: Union[schemas.DataFrameSchema, schemas.SeriesSchema],
-        obj_getter: Optional[Union[str, int]] = None,
+        schema: Schemas,
+        obj_getter: Optional[InputGetter] = None,
         head: Optional[int] = None,
         tail: Optional[int] = None,
         sample: Optional[int] = None,
@@ -194,8 +199,8 @@ def check_input(
 
 
 def check_output(
-        schema: Union[schemas.DataFrameSchema, schemas.SeriesSchema],
-        obj_getter: Optional[Union[int, str, Callable]] = None,
+        schema: Schemas,
+        obj_getter: Optional[OutputGetter] = None,
         head: Optional[int] = None,
         tail: Optional[int] = None,
         sample: Optional[int] = None,
@@ -310,5 +315,83 @@ def check_output(
             )
 
         return out
+
+    return _wrapper
+
+
+def check_io(
+        head: int = None,
+        tail: int = None,
+        sample: int = None,
+        random_state: int = None,
+        lazy: bool = False,
+        out: Union[
+            Schemas,
+            Tuple[OutputGetter, Schemas],
+            List[Tuple[OutputGetter, Schemas]],
+        ] = None,
+        **inputs: Dict[InputGetter, Schemas]) -> Callable:
+    """Check schema for multiple inputs and outputs.
+
+    :param head: validate the first n rows. Rows overlapping with `tail` or
+        `sample` are de-duplicated.
+    :param tail: validate the last n rows. Rows overlapping with `head` or
+        `sample` are de-duplicated.
+    :param sample: validate a random sample of n rows. Rows overlapping
+        with `head` or `tail` are de-duplicated.
+    :param random_state: random seed for the ``sample`` argument.
+    :param lazy: if True, lazily evaluates dataframe against all validation
+        checks and raises a ``SchemaErrorReport``. Otherwise, raise
+        ``SchemaError`` as soon as one occurs.
+    :param out: this should be a schema object if the function outputs a single
+        dataframe/series. It can be a two-tuple, where the first element is
+        a string, integer, or callable that fetches the pandas data structure
+        in the output, and the second element is the schema to validate
+        against. For multiple outputs, specify a list of two-tuples following
+        the above structure.
+    :param inputs: kwargs keys should be the argument name in the decorated
+        function and values should be the schema used to validate the pandas
+        data structure referenced by the argument name.
+    :returns: wrapped function
+    """
+    check_args = (head, tail, sample, random_state, lazy)
+    out_schemas = out
+    if isinstance(out, list):
+        out_schemas = out
+    elif isinstance(out, (schemas.DataFrameSchema, schemas.SeriesSchema)):
+        out_schemas = [(None, out)]  # type: ignore
+    elif isinstance(out, tuple):
+        out_schemas = [out]
+    else:
+        raise TypeError(f"type of out argument not recognized: {type(out)}")
+
+    @wrapt.decorator
+    def _wrapper(
+            fn: Callable,
+            instance: Union[None, Any],
+            args: Union[List[Any], Tuple[Any]],
+            kwargs: Dict[str, Any]):
+        """Check pandas DataFrame or Series before calling the function.
+
+        :param fn: check the DataFrame or Series output of this function
+        :param instance: the object to which the wrapped function was bound
+            when it was called. Only applies to methods.
+        :param args: the list of positional arguments supplied when the
+            decorated function was called.
+        :param kwargs: the dictionary of keyword arguments supplied when the
+            decorated function was called.
+        """
+        wrapped_fn = fn
+        for input_getter, input_schema in inputs.items():
+            wrapped_fn = check_input(
+                input_schema, input_getter, *check_args  # type: ignore
+            )(wrapped_fn)
+
+        for out_getter, out_schema in out_schemas:  # type: ignore
+            wrapped_fn = check_output(
+                out_schema, out_getter, *check_args
+            )(wrapped_fn)
+
+        return wrapped_fn(*args, **kwargs)
 
     return _wrapper

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -333,6 +333,8 @@ def check_io(
         **inputs: Dict[InputGetter, Schemas]) -> Callable:
     """Check schema for multiple inputs and outputs.
 
+    See :ref:`here<decorators>` for more usage details.
+
     :param head: validate the first n rows. Rows overlapping with `tail` or
         `sample` are de-duplicated.
     :param tail: validate the last n rows. Rows overlapping with `head` or
@@ -368,7 +370,7 @@ def check_io(
     @wrapt.decorator
     def _wrapper(
             fn: Callable,
-            instance: Union[None, Any],
+            instance: Union[None, Any],  # pylint: disable=unused-argument
             args: Union[List[Any], Tuple[Any]],
             kwargs: Dict[str, Any]):
         """Check pandas DataFrame or Series before calling the function.
@@ -383,10 +385,12 @@ def check_io(
         """
         wrapped_fn = fn
         for input_getter, input_schema in inputs.items():
+            # pylint: disable=no-value-for-parameter
             wrapped_fn = check_input(
                 input_schema, input_getter, *check_args  # type: ignore
             )(wrapped_fn)
 
+        # pylint: disable=no-value-for-parameter
         for out_getter, out_schema in out_schemas:  # type: ignore
             wrapped_fn = check_output(
                 out_schema, out_getter, *check_args

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -326,5 +326,8 @@ def test_check_io():
         else:
             assert result == out
 
-        with pytest.raises(errors.SchemaError):
+        expected_error = (
+            errors.SchemaErrors if fn is validate_lazy else errors.SchemaError
+        )
+        with pytest.raises(expected_error):
             fn(*invalid)


### PR DESCRIPTION
this PR adds a new `check_io` decorator for specifying both input and output schemas