### PR TITLE
Throw SchemaError with column name instead of ValueError for nulls in int series

### DIFF
--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -153,7 +153,7 @@ checks.
 
     Traceback (most recent call last):
     ...
-    ValueError: cannot convert float NaN to integer
+    pandera.errors.SchemaError: Error while coercing 'column1' to type int64: Cannot convert non-finite values (NA or inf) to integer
 
 
 The best way to handle this case is to simply specify the column as a

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -817,6 +817,11 @@ class SeriesSchemaBase():
                 self.name, self.dtype
             )
             raise TypeError(msg) from exc
+        except ValueError as exc:
+            msg = "Error while coercing '%s' to type %s: %s" % (
+                self.name, self.dtype, exc
+            )
+            raise errors.SchemaError(self, None, msg) from exc
 
     @property
     def _allow_groupby(self):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -300,7 +300,10 @@ def test_coerce_dtype_in_dataframe():
         # make sure that correct error is raised when null values are present
         # in a float column that's coerced to an int
         schema = DataFrameSchema({"column4": Column(Int, coerce=True)})
-        with pytest.raises(ValueError):
+        with pytest.raises(
+                errors.SchemaError,
+                match=r"^Error while coercing .* to type u{0,1}int[0-9]{1,2}: "
+                r"Cannot convert non-finite values \(NA or inf\) to integer"):
             schema.validate(df)
 
 


### PR DESCRIPTION
As reported in #294, when a null is present in a int column of a DataFrame, the error created does not include the column name. This PR changes that ValueError to a SchemaError with the column name within it.