### PR TITLE
add pandas 0.25.3 to continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,12 @@ os:
   - windows
 
 env:
-  - PYTHON_VERSION=3.6
-  - PYTHON_VERSION=3.7
-  - PYTHON_VERSION=3.8
+  - PYTHON_VERSION=3.6 ENV_FILE=ci/environment_pandas_latest.yml
+  - PYTHON_VERSION=3.7 ENV_FILE=ci/environment_pandas_latest.yml
+  - PYTHON_VERSION=3.8 ENV_FILE=ci/environment_pandas_latest.yml
+  - PYTHON_VERSION=3.6 ENV_FILE=ci/environment_pandas_0_25_3.yml
+  - PYTHON_VERSION=3.7 ENV_FILE=ci/environment_pandas_0_25_3.yml
+  - PYTHON_VERSION=3.8 ENV_FILE=ci/environment_pandas_0_25_3.yml
 
 before_install:
   - |
@@ -70,7 +73,7 @@ install:
   # Setup Conda Envs
   - |
     conda create -n pandera python=$PYTHON_VERSION || exit 1
-    conda env update -n pandera -f environment.yml
+    conda env update -n pandera -f $ENV_FILE
     conda create -n pandera-core python=$PYTHON_VERSION pytest
     conda list
   - source activate pandera && pip install .[all]

--- a/ci/environment_pandas_0_25_3.yml
+++ b/ci/environment_pandas_0_25_3.yml
@@ -1,0 +1,38 @@
+name: pandera-dev
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  # environment management
+  - pip
+
+  # documentation
+  - sphinx
+  - sphinx_rtd_theme
+
+  # testing
+  - codecov
+  - mypy
+  - pylint>=2.4.4
+  - pytest
+  - pytest-cov
+
+  # packaging
+  - twine
+
+  # performance testing
+  - asv
+
+  # optional
+  - pre_commit
+
+  # pandera dependencies
+  - black
+  - numpy
+  - pandas==0.25.3
+  - scipy
+  - wrapt
+  - pyyaml
+
+  - pip:
+    - sphinx_autodoc_typehints

--- a/ci/environment_pandas_latest.yml
+++ b/ci/environment_pandas_latest.yml
@@ -1,0 +1,38 @@
+name: pandera-dev
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  # environment management
+  - pip
+
+  # documentation
+  - sphinx
+  - sphinx_rtd_theme
+
+  # testing
+  - codecov
+  - mypy
+  - pylint>=2.4.4
+  - pytest
+  - pytest-cov
+
+  # packaging
+  - twine
+
+  # performance testing
+  - asv
+
+  # optional
+  - pre_commit
+
+  # pandera dependencies
+  - black
+  - numpy
+  - pandas
+  - scipy
+  - wrapt
+  - pyyaml
+
+  - pip:
+    - sphinx_autodoc_typehints


### PR DESCRIPTION
this adds pandas==0.25.3 to continuous integration so that all 0.25-specific functionality and tests are run.