### PR TITLE
add validate(..., inplace=False) keyword to prevent mutation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,11 +27,13 @@ repos:
     rev: v5.6.4
     hooks:
       - id: isort
+        args: ["--line-length=79"]
 
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:
       - id: black
+        args: ["--line-length=79"]
 
   - repo: https://github.com/pycqa/pylint
     rev: pylint-2.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,8 @@ script:
   # Check that requirements-dev.text is generated exclusively by environment.yml
   - python ./scripts/generate_pip_deps_from_conda.py --compare
   # Formatting
-  - isort --check-only pandera tests
-  - black --check pandera tests
+  - isort --line-length=79 --check-only pandera tests
+  - black --line-length=79 --check pandera tests
   # Linting
   - pylint pandera tests
   # Type checking

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,8 @@ script:
   # Check that requirements-dev.text is generated exclusively by environment.yml
   - python ./scripts/generate_pip_deps_from_conda.py --compare
   # Formatting
-  - isort --line-length=79 --check-only pandera tests
-  - black --line-length=79 --check pandera tests
+  - isort --check-only pandera tests
+  - black --check pandera tests
   # Linting
   - pylint pandera tests
   # Type checking

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -22,7 +22,9 @@ CheckResult = namedtuple(
 )
 
 
-GroupbyObject = Union[pd.core.groupby.SeriesGroupBy, pd.core.groupby.DataFrameGroupBy]
+GroupbyObject = Union[
+    pd.core.groupby.SeriesGroupBy, pd.core.groupby.DataFrameGroupBy
+]
 
 SeriesCheckObj = Union[pd.Series, Dict[str, pd.Series]]
 DataFrameCheckObj = Union[pd.DataFrame, Dict[str, pd.DataFrame]]
@@ -177,7 +179,9 @@ class _CheckBase:
         """
 
         if element_wise and groupby is not None:
-            raise errors.SchemaInitError("Cannot use groupby when element_wise=True.")
+            raise errors.SchemaInitError(
+                "Cannot use groupby when element_wise=True."
+            )
         self._check_fn = check_fn
         self._check_kwargs = check_kwargs
         self.element_wise = element_wise
@@ -236,11 +240,15 @@ class _CheckBase:
                 "key. Valid group keys: %s" % (invalid_groups, group_keys)
             )
         return {
-            group_key: group for group_key, group in groupby_obj if group_key in groups
+            group_key: group
+            for group_key, group in groupby_obj
+            if group_key in groups
         }
 
     def _prepare_series_input(
-        self, series: pd.Series, dataframe_context: Optional[pd.DataFrame] = None
+        self,
+        series: pd.Series,
+        dataframe_context: Optional[pd.DataFrame] = None,
     ) -> SeriesCheckObj:
         """Prepare input for Column check.
 
@@ -260,13 +268,15 @@ class _CheckBase:
             ).groupby(self.groupby)[series.name]
             return self._format_groupby_input(groupby_obj, self.groups)
         if callable(self.groupby):
-            groupby_obj = self.groupby(pd.concat([series, dataframe_context], axis=1))[
-                series.name
-            ]
+            groupby_obj = self.groupby(
+                pd.concat([series, dataframe_context], axis=1)
+            )[series.name]
             return self._format_groupby_input(groupby_obj, self.groups)
         raise TypeError("Type %s not recognized for `groupby` argument.")
 
-    def _prepare_dataframe_input(self, dataframe: pd.DataFrame) -> DataFrameCheckObj:
+    def _prepare_dataframe_input(
+        self, dataframe: pd.DataFrame
+    ) -> DataFrameCheckObj:
         """Prepare input for DataFrameSchema check.
 
         :param dataframe: dataframe to validate.
@@ -279,7 +289,9 @@ class _CheckBase:
         return self._format_groupby_input(groupby_obj, self.groups)
 
     def _handle_na(
-        self, df_or_series: Union[pd.DataFrame, pd.Series], column: Optional[str] = None
+        self,
+        df_or_series: Union[pd.DataFrame, pd.Series],
+        column: Optional[str] = None,
     ):
         """Handle nan values before passing object to check function."""
         if not self.ignore_na:
@@ -294,14 +306,19 @@ class _CheckBase:
             for col in self.groupby:
                 # raise schema definition error if column is not in the
                 # validated dataframe
-                if isinstance(df_or_series, pd.DataFrame) and col not in df_or_series:
+                if (
+                    isinstance(df_or_series, pd.DataFrame)
+                    and col not in df_or_series
+                ):
                     raise errors.SchemaDefinitionError(
                         "`groupby` column '%s' not found" % col
                     )
             drop_na_columns.extend(self.groupby)
 
         if drop_na_columns:
-            return df_or_series.loc[df_or_series[drop_na_columns].dropna().index]
+            return df_or_series.loc[
+                df_or_series[drop_na_columns].dropna().index
+            ]
         return df_or_series.dropna()
 
     def __call__(
@@ -335,7 +352,9 @@ class _CheckBase:
 
         column_dataframe_context = None
         if column is not None and isinstance(df_or_series, pd.DataFrame):
-            column_dataframe_context = df_or_series.drop(column, axis="columns")
+            column_dataframe_context = df_or_series.drop(
+                column, axis="columns"
+            )
             df_or_series = df_or_series[column].copy()
 
         # prepare check object
@@ -389,7 +408,8 @@ class _CheckBase:
             )
         else:
             raise TypeError(
-                "output type of check_fn not recognized: %s" % type(check_output)
+                "output type of check_fn not recognized: %s"
+                % type(check_output)
             )
 
         check_passed = (
@@ -400,7 +420,9 @@ class _CheckBase:
             else check_output
         )
 
-        return CheckResult(check_output, check_passed, check_obj, failure_cases)
+        return CheckResult(
+            check_output, check_passed, check_obj, failure_cases
+        )
 
     def __eq__(self, other):
         are_fn_objects_equal = (
@@ -609,7 +631,9 @@ class Check(_CheckBase):
     le = less_than_or_equal_to
 
     @classmethod
-    @register_check_statistics(["min_value", "max_value", "include_min", "include_max"])
+    @register_check_statistics(
+        ["min_value", "max_value", "include_min", "include_max"]
+    )
     def in_range(
         cls, min_value, max_value, include_min=True, include_max=True, **kwargs
     ) -> "Check":
@@ -683,7 +707,8 @@ class Check(_CheckBase):
             allowed_values = frozenset(allowed_values)
         except TypeError as exc:
             raise ValueError(
-                "Argument allowed_values must be iterable. Got %s" % allowed_values
+                "Argument allowed_values must be iterable. Got %s"
+                % allowed_values
             ) from exc
 
         def _isin(series: pd.Series) -> pd.Series:
@@ -722,7 +747,8 @@ class Check(_CheckBase):
             forbidden_values = frozenset(forbidden_values)
         except TypeError as exc:
             raise ValueError(
-                "Argument forbidden_values must be iterable. Got %s" % forbidden_values
+                "Argument forbidden_values must be iterable. Got %s"
+                % forbidden_values
             ) from exc
 
         def _notin(series: pd.Series) -> pd.Series:
@@ -753,7 +779,8 @@ class Check(_CheckBase):
             regex = re.compile(pattern)
         except TypeError as exc:
             raise ValueError(
-                'pattern="%s" cannot be compiled as regular expression' % pattern
+                'pattern="%s" cannot be compiled as regular expression'
+                % pattern
             ) from exc
 
         def _match(series: pd.Series) -> pd.Series:
@@ -786,7 +813,8 @@ class Check(_CheckBase):
             regex = re.compile(pattern)
         except TypeError as exc:
             raise ValueError(
-                'pattern="%s" cannot be compiled as regular expression' % pattern
+                'pattern="%s" cannot be compiled as regular expression'
+                % pattern
             ) from exc
 
         def _contains(series: pd.Series) -> pd.Series:
@@ -859,7 +887,8 @@ class Check(_CheckBase):
         """
         if min_value is None and max_value is None:
             raise ValueError(
-                "At least a minimum or a maximum need to be specified. Got " "None."
+                "At least a minimum or a maximum need to be specified. Got "
+                "None."
             )
         if max_value is None:
 
@@ -877,7 +906,9 @@ class Check(_CheckBase):
 
             def _str_length(series: pd.Series) -> pd.Series:
                 """Check for both, minimum and maximum string length"""
-                return (series.str.len() <= max_value) & (series.str.len() >= min_value)
+                return (series.str.len() <= max_value) & (
+                    series.str.len() >= min_value
+                )
 
         return cls(
             _str_length,

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -70,6 +70,7 @@ def check_input(
     sample: Optional[int] = None,
     random_state: Optional[int] = None,
     lazy: bool = False,
+    inplace: bool = False,
 ) -> Callable:
     # pylint: disable=duplicate-code
     """Validate function argument when function is called.
@@ -95,6 +96,8 @@ def check_input(
     :param lazy: if True, lazily evaluates dataframe against all validation
         checks and raises a ``SchemaErrorReport``. Otherwise, raise
         ``SchemaError`` as soon as one occurs.
+    :param inplace: if True, applies coercion to the object of validation,
+        otherwise creates a copy of the data.
     :returns: wrapped function
 
     :example:
@@ -208,6 +211,7 @@ def check_output(
     sample: Optional[int] = None,
     random_state: Optional[int] = None,
     lazy: bool = False,
+    inplace: bool = False,
 ) -> Callable:
     # pylint: disable=duplicate-code
     """Validate function output.
@@ -233,6 +237,8 @@ def check_output(
     :param lazy: if True, lazily evaluates dataframe against all validation
         checks and raises a ``SchemaErrorReport``. Otherwise, raise
         ``SchemaError`` as soon as one occurs.
+    :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
     :returns: wrapped function
 
     :example:
@@ -311,6 +317,7 @@ def check_io(
     sample: int = None,
     random_state: int = None,
     lazy: bool = False,
+    inplace: bool = False,
     out: Union[
         Schemas,
         Tuple[OutputGetter, Schemas],
@@ -332,6 +339,8 @@ def check_io(
     :param lazy: if True, lazily evaluates dataframe against all validation
         checks and raises a ``SchemaErrorReport``. Otherwise, raise
         ``SchemaError`` as soon as one occurs.
+    :param inplace: if True, applies coercion to the object of validation,
+        otherwise creates a copy of the data.
     :param out: this should be a schema object if the function outputs a single
         dataframe/series. It can be a two-tuple, where the first element is
         a string, integer, or callable that fetches the pandas data structure
@@ -396,6 +405,7 @@ def check_types(
     sample: Optional[int] = None,
     random_state: Optional[int] = None,
     lazy: bool = False,
+    inplace: bool = False,
 ) -> Callable:
     """Validate function inputs and output based on type annotations.
 
@@ -411,6 +421,8 @@ def check_types(
     :param lazy: if True, lazily evaluates dataframe against all validation
         checks and raises a ``SchemaErrorReport``. Otherwise, raise
         ``SchemaError`` as soon as one occurs.
+    :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
     """
     if wrapped is None:
         return functools.partial(

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -197,7 +197,9 @@ class PandasDtype(Enum):
         }.get(str_alias)
 
         if pandas_dtype is None:
-            raise TypeError("pandas dtype string alias '%s' not recognized" % str_alias)
+            raise TypeError(
+                "pandas dtype string alias '%s' not recognized" % str_alias
+            )
 
         return pandas_dtype
 
@@ -225,7 +227,9 @@ class PandasDtype(Enum):
         }.get(pandas_api_type)
 
         if pandas_dtype is None:
-            raise TypeError("pandas api type '%s' not recognized" % pandas_api_type)
+            raise TypeError(
+                "pandas api type '%s' not recognized" % pandas_api_type
+            )
 
         return pandas_dtype
 
@@ -247,7 +251,8 @@ class PandasDtype(Enum):
 
         if pandas_dtype is None:
             raise TypeError(
-                "python type '%s' not recognized as pandas data type" % python_type
+                "python type '%s' not recognized as pandas data type"
+                % python_type
             )
 
         return pandas_dtype

--- a/pandera/error_formatters.py
+++ b/pandera/error_formatters.py
@@ -18,7 +18,11 @@ def format_generic_error_message(
     :param check: check that generated error.
     :param check_index: The validator that failed.
     """
-    return "%s failed series validator %d:\n%s" % (parent_schema, check_index, check)
+    return "%s failed series validator %d:\n%s" % (
+        parent_schema,
+        check_index,
+        check,
+    )
 
 
 def format_vectorized_error_message(
@@ -36,11 +40,15 @@ def format_vectorized_error_message(
         element-wise or vectorized validator.
 
     """
-    return "%s failed element-wise validator %d:\n" "%s\nfailure cases:\n%s" % (
-        parent_schema,
-        check_index,
-        check,
-        reshaped_failure_cases,
+    return (
+        "%s failed element-wise validator %d:\n"
+        "%s\nfailure cases:\n%s"
+        % (
+            parent_schema,
+            check_index,
+            check,
+            reshaped_failure_cases,
+        )
     )
 
 
@@ -82,7 +90,9 @@ def reshape_failure_cases(
             failure_cases.rename("failure_case")
             .to_frame()
             .assign(
-                index=lambda df: (df.index.to_frame().apply(tuple, axis=1).astype(str))
+                index=lambda df: (
+                    df.index.to_frame().apply(tuple, axis=1).astype(str)
+                )
             )[["failure_case", "index"]]
             .reset_index(drop=True)
         )
@@ -96,11 +106,18 @@ def reshape_failure_cases(
         )
     elif isinstance(failure_cases, pd.Series):
         reshaped_failure_cases = (
-            failure_cases.rename("failure_case").rename_axis("index").reset_index()
+            failure_cases.rename("failure_case")
+            .rename_axis("index")
+            .reset_index()
         )
     else:
         raise TypeError(
-            "type of failure_cases argument not understood: %s" % type(failure_cases)
+            "type of failure_cases argument not understood: %s"
+            % type(failure_cases)
         )
 
-    return reshaped_failure_cases.dropna() if ignore_na else reshaped_failure_cases
+    return (
+        reshaped_failure_cases.dropna()
+        if ignore_na
+        else reshaped_failure_cases
+    )

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -29,7 +29,13 @@ class SchemaError(Exception):
     """Raised when object does not pass schema validation constraints."""
 
     def __init__(
-        self, schema, data, message, failure_cases=None, check=None, check_index=None
+        self,
+        schema,
+        data,
+        message,
+        failure_cases=None,
+        check=None,
+        check_index=None,
     ):
         super().__init__(message)
         self.schema = schema
@@ -60,7 +66,9 @@ class SchemaErrors(Exception):
     """Raised when multiple schema are lazily collected into one error."""
 
     def __init__(self, schema_error_dicts, data):
-        error_counts, schema_errors = self._parse_schema_errors(schema_error_dicts)
+        error_counts, schema_errors = self._parse_schema_errors(
+            schema_error_dicts
+        )
         super().__init__(self._message(error_counts, schema_errors))
         self._schema_error_dicts = schema_error_dicts
         self.error_counts = error_counts
@@ -70,7 +78,9 @@ class SchemaErrors(Exception):
     @staticmethod
     def _message(error_counts, schema_errors):
         """Format error message."""
-        msg = "A total of %s schema errors were found.\n" % sum(error_counts.values())
+        msg = "A total of %s schema errors were found.\n" % sum(
+            error_counts.values()
+        )
 
         msg += "\nError Counts"
         msg += "\n------------\n"

--- a/pandera/hypotheses.py
+++ b/pandera/hypotheses.py
@@ -25,12 +25,16 @@ class Hypothesis(_CheckBase):
     #: Relationships available for built-in hypothesis tests.
     RELATIONSHIPS = {
         "greater_than": (
-            lambda stat, pvalue, alpha=DEFAULT_ALPHA: stat > 0 and pvalue / 2 < alpha
+            lambda stat, pvalue, alpha=DEFAULT_ALPHA: stat > 0
+            and pvalue / 2 < alpha
         ),
         "less_than": (
-            lambda stat, pvalue, alpha=DEFAULT_ALPHA: stat < 0 and pvalue / 2 < alpha
+            lambda stat, pvalue, alpha=DEFAULT_ALPHA: stat < 0
+            and pvalue / 2 < alpha
         ),
-        "not_equal": (lambda stat, pvalue, alpha=DEFAULT_ALPHA: pvalue < alpha),
+        "not_equal": (
+            lambda stat, pvalue, alpha=DEFAULT_ALPHA: pvalue < alpha
+        ),
         "equal": (lambda stat, pvalue, alpha=DEFAULT_ALPHA: pvalue >= alpha),
     }
 
@@ -172,7 +176,9 @@ class Hypothesis(_CheckBase):
         self.groups = self.samples
         return super()._prepare_series_input(series, dataframe_context)
 
-    def _prepare_dataframe_input(self, dataframe: pd.DataFrame) -> DataFrameCheckObj:
+    def _prepare_dataframe_input(
+        self, dataframe: pd.DataFrame
+    ) -> DataFrameCheckObj:
         """Prepare input for DataFrameSchema Hypothesis check."""
         if self.groupby is not None:
             raise errors.SchemaDefinitionError(
@@ -197,7 +203,8 @@ class Hypothesis(_CheckBase):
         if isinstance(relationship, str):
             if relationship not in self.RELATIONSHIPS:
                 raise errors.SchemaInitError(
-                    "The relationship %s isn't a built in method" % relationship
+                    "The relationship %s isn't a built in method"
+                    % relationship
                 )
             relationship = self.RELATIONSHIPS[relationship]
         elif not callable(relationship):
@@ -207,7 +214,9 @@ class Hypothesis(_CheckBase):
             )
         return relationship
 
-    def _hypothesis_check(self, check_obj: Union[pd.Series, Dict[str, pd.Series]]):
+    def _hypothesis_check(
+        self, check_obj: Union[pd.Series, Dict[str, pd.Series]]
+    ):
         """Create a function fn which is checked via the Check parent class.
 
         :param dict check_obj: a dictionary of pd.Series to be used by
@@ -216,7 +225,9 @@ class Hypothesis(_CheckBase):
         """
         if isinstance(check_obj, pd.Series):
             return self.relationship(*self.test(check_obj))
-        return self.relationship(*self.test(*[check_obj.get(s) for s in self.samples]))
+        return self.relationship(
+            *self.test(*[check_obj.get(s) for s in self.samples])
+        )
 
     @classmethod
     def two_sample_ttest(
@@ -333,7 +344,8 @@ class Hypothesis(_CheckBase):
             test_kwargs={"equal_var": equal_var, "nan_policy": nan_policy},
             relationship_kwargs={"alpha": alpha},
             name="two_sample_ttest",
-            error="failed two sample ttest between '%s' and '%s'" % (sample1, sample2),
+            error="failed two sample ttest between '%s' and '%s'"
+            % (sample1, sample2),
             raise_warning=raise_warning,
         )
 

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -70,7 +70,13 @@ def _serialize_component_stats(component_stats):
         "checks": serialized_checks,
         **{
             key: component_stats.get(key)
-            for key in ["name", "allow_duplicates", "coerce", "required", "regex"]
+            for key in [
+                "name",
+                "allow_duplicates",
+                "coerce",
+                "required",
+                "regex",
+            ]
             if key in component_stats
         },
     }
@@ -137,7 +143,9 @@ def _deserialize_component_stats(serialized_component_stats):
             _deserialize_check_stats(
                 getattr(Check, check_name), check_stats, pandas_dtype
             )
-            for check_name, check_stats in serialized_component_stats["checks"].items()
+            for check_name, check_stats in serialized_component_stats[
+                "checks"
+            ].items()
         ]
     return {
         "pandas_dtype": pandas_dtype,
@@ -145,7 +153,13 @@ def _deserialize_component_stats(serialized_component_stats):
         "checks": checks,
         **{
             key: serialized_component_stats.get(key)
-            for key in ["name", "allow_duplicates", "coerce", "required", "regex"]
+            for key in [
+                "name",
+                "allow_duplicates",
+                "coerce",
+                "required",
+                "regex",
+            ]
             if key in serialized_component_stats
         },
     }
@@ -269,7 +283,8 @@ def _format_checks(checks_dict):
             )
         else:
             args = ", ".join(
-                "{}={}".format(k, v.__repr__()) for k, v in check_kwargs.items()
+                "{}={}".format(k, v.__repr__())
+                for k, v in check_kwargs.items()
             )
             checks.append("Check.{}({})".format(check_name, args))
     return "[{}]".format(", ".join(checks))
@@ -279,7 +294,9 @@ def _format_index(index_statistics):
     index = []
     for properties in index_statistics:
         index_code = INDEX_TEMPLATE.format(
-            pandas_dtype="PandasDtype.{}".format(properties["pandas_dtype"].name),
+            pandas_dtype="PandasDtype.{}".format(
+                properties["pandas_dtype"].name
+            ),
             checks=(
                 "None"
                 if properties["checks"] is None
@@ -319,7 +336,9 @@ def to_script(dataframe_schema, path_or_buf=None):
     columns = {}
     for colname, properties in statistics["columns"].items():
         column_code = COLUMN_TEMPLATE.format(
-            pandas_dtype="PandasDtype.{}".format(properties["pandas_dtype"].name),
+            pandas_dtype="PandasDtype.{}".format(
+                properties["pandas_dtype"].name
+            ),
             checks=_format_checks(properties["checks"]),
             nullable=properties["nullable"],
             allow_duplicates=properties["allow_duplicates"],
@@ -329,7 +348,11 @@ def to_script(dataframe_schema, path_or_buf=None):
         )
         columns[colname] = column_code.strip()
 
-    index = None if statistics["index"] is None else _format_index(statistics["index"])
+    index = (
+        None
+        if statistics["index"] is None
+        else _format_index(statistics["index"])
+    )
 
     column_str = ", ".join("'{}': {}".format(k, v) for k, v in columns.items())
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -57,12 +57,16 @@ class BaseConfig:  # pylint:disable=R0903
     multiindex_strict: bool = False
 
 
-_config_options = [attr for attr in vars(BaseConfig) if not attr.startswith("_")]
+_config_options = [
+    attr for attr in vars(BaseConfig) if not attr.startswith("_")
+]
 
 
 def _extract_config_options(config: Type) -> Dict[str, Any]:
     return {
-        name: value for name, value in vars(config).items() if name in _config_options
+        name: value
+        for name, value in vars(config).items()
+        if name in _config_options
     }
 
 
@@ -92,7 +96,9 @@ class SchemaModel:
 
         cls.__field_annotations__ = cls._collect_field_annotations()
 
-        check_infos = cast(List[FieldCheckInfo], cls._collect_check_infos(CHECK_KEY))
+        check_infos = cast(
+            List[FieldCheckInfo], cls._collect_check_infos(CHECK_KEY)
+        )
         field_names = list(cls.__field_annotations__.keys())
         cls.__checks__ = cls._extract_checks(check_infos, field_names)
 
@@ -162,7 +168,9 @@ class SchemaModel:
 
             field_checks = checks.get(field_name, [])
             if annotation_info.origin is Series:
-                col_constructor = field.to_column if field else schema_components.Column
+                col_constructor = (
+                    field.to_column if field else schema_components.Column
+                )
                 columns[field_name] = col_constructor(  # type: ignore
                     annotation_info.arg,
                     required=not annotation_info.optional,
@@ -171,8 +179,12 @@ class SchemaModel:
                 )
             elif annotation_info.origin is Index:
                 if annotation_info.optional:
-                    raise SchemaInitError(f"Index '{field_name}' cannot be Optional.")
-                index_constructor = field.to_index if field else schema_components.Index
+                    raise SchemaInitError(
+                        f"Index '{field_name}' cannot be Optional."
+                    )
+                index_constructor = (
+                    field.to_index if field else schema_components.Index
+                )
                 index = index_constructor(  # type: ignore
                     annotation_info.arg, checks=field_checks, name=field_name
                 )

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -15,7 +15,12 @@ from typing import (
 )
 
 from .checks import Check
-from .schema_components import Column, Index, PandasDtypeInputTypes, SeriesSchemaBase
+from .schema_components import (
+    Column,
+    Index,
+    PandasDtypeInputTypes,
+    SeriesSchemaBase,
+)
 
 AnyCallable = Callable[..., Any]
 SchemaComponent = TypeVar("SchemaComponent", bound=SeriesSchemaBase)
@@ -194,7 +199,9 @@ class CheckInfo:  # pylint:disable=too-few-public-methods
         """Create a Check from metadata."""
         name = self.check_kwargs.pop("name", None)
         if not name:
-            name = getattr(self.check_fn, "__name__", self.check_fn.__class__.__name__)
+            name = getattr(
+                self.check_fn, "__name__", self.check_fn.__class__.__name__
+            )
 
         def _adapter(arg: Any) -> Union[bool, Iterable[bool]]:
             return self.check_fn(model_cls, arg)
@@ -272,7 +279,11 @@ def dataframe_check(_fn=None, **check_kwargs) -> ClassCheck:
 
     def _wrapper(fn: Union[classmethod, AnyCallable]) -> classmethod:
         check_fn, check_method = _to_function_and_classmethod(fn)
-        setattr(check_method, DATAFRAME_CHECK_KEY, CheckInfo(check_fn, **check_kwargs))
+        setattr(
+            check_method,
+            DATAFRAME_CHECK_KEY,
+            CheckInfo(check_fn, **check_kwargs),
+        )
         return check_method
 
     if _fn:

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -8,7 +8,12 @@ import pandas as pd
 
 from . import errors
 from .dtypes import PandasDtype
-from .schemas import CheckList, DataFrameSchema, PandasDtypeInputTypes, SeriesSchemaBase
+from .schemas import (
+    CheckList,
+    DataFrameSchema,
+    PandasDtypeInputTypes,
+    SeriesSchemaBase,
+)
 
 
 def _is_valid_multiindex_tuple_str(x: Tuple[Any]) -> bool:
@@ -65,7 +70,9 @@ class Column(SeriesSchemaBase):
 
         See :ref:`here<column>` for more usage details.
         """
-        super().__init__(pandas_dtype, checks, nullable, allow_duplicates, coerce)
+        super().__init__(
+            pandas_dtype, checks, nullable, allow_duplicates, coerce
+        )
         if (
             name is not None
             and not isinstance(name, str)
@@ -165,13 +172,17 @@ class Column(SeriesSchemaBase):
             )
 
         column_keys_to_check = (
-            self.get_regex_columns(check_obj.columns) if self._regex else [self._name]
+            self.get_regex_columns(check_obj.columns)
+            if self._regex
+            else [self._name]
         )
 
         check_results = []
         for column_name in column_keys_to_check:
             if self.coerce:
-                check_obj[column_name] = self.coerce_dtype(check_obj[column_name])
+                check_obj[column_name] = self.coerce_dtype(
+                    check_obj[column_name]
+                )
             check_results.append(
                 isinstance(
                     super(Column, copy(self).set_name(column_name)).validate(
@@ -202,9 +213,9 @@ class Column(SeriesSchemaBase):
                 )
             matches = np.ones(len(columns)).astype(bool)
             for i, name in enumerate(self.name):
-                matched = pd.Index(columns.get_level_values(i).str.match(name)).fillna(
-                    False
-                )
+                matched = pd.Index(
+                    columns.get_level_values(i).str.match(name)
+                ).fillna(False)
                 matches = matches & np.array(matched.tolist())
             column_keys_to_check = columns[matches]
         else:
@@ -240,7 +251,10 @@ class Column(SeriesSchemaBase):
 
     def __eq__(self, other):
         def _compare_dict(obj):
-            return {k: v if k != "_checks" else set(v) for k, v in obj.__dict__.items()}
+            return {
+                k: v if k != "_checks" else set(v)
+                for k, v in obj.__dict__.items()
+            }
 
         return _compare_dict(self) == _compare_dict(other)
 
@@ -424,7 +438,9 @@ class MultiIndex(DataFrameSchema):
                 index_array = index.coerce_dtype(index_array)
             _coerced_multi_index.append(index_array)
 
-        return pd.MultiIndex.from_arrays(_coerced_multi_index, names=multi_index.names)
+        return pd.MultiIndex.from_arrays(
+            _coerced_multi_index, names=multi_index.names
+        )
 
     def validate(
         self,

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -133,6 +133,7 @@ class Column(SeriesSchemaBase):
         sample: Optional[int] = None,
         random_state: Optional[int] = None,
         lazy: bool = False,
+        inplace: bool = False,
     ) -> pd.DataFrame:
         """Validate a Column in a DataFrame object.
 
@@ -147,9 +148,12 @@ class Column(SeriesSchemaBase):
         :param lazy: if True, lazily evaluates dataframe against all validation
             checks and raises a ``SchemaErrorReport``. Otherwise, raise
             ``SchemaError`` as soon as one occurs.
+        :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
         :returns: validated DataFrame.
         """
-        check_obj = check_obj.copy()
+        if not inplace:
+            check_obj = check_obj.copy()
 
         if self._name is None:
             raise errors.SchemaError(
@@ -271,6 +275,7 @@ class Index(SeriesSchemaBase):
         sample: Optional[int] = None,
         random_state: Optional[int] = None,
         lazy: bool = False,
+        inplace: bool = False,
     ) -> Union[pd.DataFrame, pd.Series]:
         """Validate DataFrameSchema or SeriesSchema Index.
 
@@ -282,6 +287,11 @@ class Index(SeriesSchemaBase):
         :param sample: validate a random sample of n rows. Rows overlapping
             with `head` or `tail` are de-duplicated.
         :param random_state: random seed for the ``sample`` argument.
+        :param lazy: if True, lazily evaluates dataframe against all validation
+            checks and raises a ``SchemaErrorReport``. Otherwise, raise
+            ``SchemaError`` as soon as one occurs.
+        :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
         :returns: validated DataFrame or Series.
         """
 
@@ -296,6 +306,7 @@ class Index(SeriesSchemaBase):
                 sample,
                 random_state,
                 lazy,
+                inplace,
             ),
             pd.Series,
         )
@@ -423,6 +434,7 @@ class MultiIndex(DataFrameSchema):
         sample: Optional[int] = None,
         random_state: Optional[int] = None,
         lazy: bool = False,
+        inplace: bool = False,
     ) -> Union[pd.DataFrame, pd.Series]:
         """Validate DataFrame or Series MultiIndex.
 
@@ -437,6 +449,8 @@ class MultiIndex(DataFrameSchema):
         :param lazy: if True, lazily evaluates dataframe against all validation
             checks and raises a ``SchemaErrorReport``. Otherwise, raise
             ``SchemaError`` as soon as one occurs.
+        :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
         :returns: validated DataFrame or Series.
         """
 
@@ -451,6 +465,7 @@ class MultiIndex(DataFrameSchema):
                 sample,
                 random_state,
                 lazy,
+                inplace,
             )
         except errors.SchemaErrors as err:
             # This is a hack to re-raise the SchemaErrors exception and change

--- a/pandera/schema_statistics.py
+++ b/pandera/schema_statistics.py
@@ -71,13 +71,15 @@ def infer_index_statistics(index: Union[pd.Index, pd.MultiIndex]):
 
     if isinstance(index, pd.MultiIndex):
         index_statistics = [
-            _index_stats(index.get_level_values(i)) for i in range(index.nlevels)
+            _index_stats(index.get_level_values(i))
+            for i in range(index.nlevels)
         ]
     elif isinstance(index, pd.Index):
         index_statistics = [_index_stats(index)]
     else:
         warnings.warn(
-            "index type %s not recognized, skipping index inference" % type(index),
+            "index type %s not recognized, skipping index inference"
+            % type(index),
             UserWarning,
         )
         index_statistics = []
@@ -167,12 +169,12 @@ def parse_checks(checks) -> Union[Dict[str, Any], None]:
         "greater_than_or_equal_to" in check_statistics
         and "less_than_or_equal_to" in check_statistics
     ):
-        min_value = check_statistics.get("greater_than_or_equal_to", float("-inf"))[
-            "min_value"
-        ]
-        max_value = check_statistics.get("less_than_or_equal_to", float("inf"))[
-            "max_value"
-        ]
+        min_value = check_statistics.get(
+            "greater_than_or_equal_to", float("-inf")
+        )["min_value"]
+        max_value = check_statistics.get(
+            "less_than_or_equal_to", float("inf")
+        )["max_value"]
         if min_value > max_value:
             raise ValueError(
                 "checks %s and %s are incompatible, reason: "
@@ -198,7 +200,9 @@ def _get_array_type(x):
     return dtype
 
 
-def _get_array_check_statistics(x, dtype: PandasDtype) -> Union[Dict[str, Any], None]:
+def _get_array_check_statistics(
+    x, dtype: PandasDtype
+) -> Union[Dict[str, Any], None]:
     """Get check statistics from an array-like object."""
     if dtype is PandasDtype.DateTime:
         check_stats = {

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -25,7 +25,9 @@ from .hypotheses import Hypothesis
 
 N_INDENT_SPACES = 4
 
-CheckList = Optional[Union[Union[Check, Hypothesis], List[Union[Check, Hypothesis]]]]
+CheckList = Optional[
+    Union[Union[Check, Hypothesis], List[Union[Check, Hypothesis]]]
+]
 
 PandasDtypeInputTypes = Union[str, type, PandasDtype, PandasExtensionType]
 
@@ -36,7 +38,10 @@ if version.parse(pd.__version__).major < 1:  # type: ignore
     def is_extension_array_dtype(arr_or_dtype):
         # pylint: disable=missing-function-docstring
         dtype = getattr(arr_or_dtype, "dtype", arr_or_dtype)
-        return isinstance(dtype, ExtensionDtype) or registry.find(dtype) is not None
+        return (
+            isinstance(dtype, ExtensionDtype)
+            or registry.find(dtype) is not None
+        )
 
 
 else:
@@ -138,7 +143,9 @@ class DataFrameSchema:
 
         if coerce:
             missing_pandas_type = [
-                name for name, col in self.columns.items() if col.pandas_dtype is None
+                name
+                for name, col in self.columns.items()
+                if col.pandas_dtype is None
             ]
             if missing_pandas_type:
                 raise errors.SchemaInitError(
@@ -221,7 +228,9 @@ class DataFrameSchema:
 
         :returns: dictionary of columns and their associated dtypes.
         """
-        regex_columns = [name for name, col in self.columns.items() if col.regex]
+        regex_columns = [
+            name for name, col in self.columns.items() if col.regex
+        ]
         if regex_columns:
             warnings.warn(
                 "Schema has columns specified as regex column names: %s "
@@ -323,7 +332,8 @@ class DataFrameSchema:
                 "This %s is an inferred schema that hasn't been "
                 "modified. It's recommended that you refine the schema "
                 "by calling `add_columns`, `remove_columns`, or "
-                "`update_columns` before using it to validate data." % type(self),
+                "`update_columns` before using it to validate data."
+                % type(self),
                 UserWarning,
             )
 
@@ -348,7 +358,8 @@ class DataFrameSchema:
                         pass
 
             expanded_column_names = frozenset(
-                [n for n, c in self.columns.items() if not c.regex] + col_regex_matches
+                [n for n, c in self.columns.items() if not c.regex]
+                + col_regex_matches
             )
 
             for column in check_obj:
@@ -373,7 +384,9 @@ class DataFrameSchema:
         for colname, col_schema in self.columns.items():
             if col_schema.regex:
                 try:
-                    matched_columns = col_schema.get_regex_columns(check_obj.columns)
+                    matched_columns = col_schema.get_regex_columns(
+                        check_obj.columns
+                    )
                 except errors.SchemaError:
                     matched_columns = pd.Index([])
 
@@ -390,7 +403,10 @@ class DataFrameSchema:
                     # error_handler and should raise a SchemaErrors exception
                     # at the end of the `validate` method.
                     lazy_exclude_columns.append(colname)
-                msg = "column '%s' not in dataframe\n%s" % (colname, check_obj.head())
+                msg = "column '%s' not in dataframe\n%s" % (
+                    colname,
+                    check_obj.head(),
+                )
                 error_handler.collect_error(
                     "column_not_in_dataframe",
                     errors.SchemaError(
@@ -403,7 +419,9 @@ class DataFrameSchema:
                 )
 
             elif col_schema.coerce or self.coerce:
-                check_obj.loc[:, colname] = col_schema.coerce_dtype(check_obj[colname])
+                check_obj.loc[:, colname] = col_schema.coerce_dtype(
+                    check_obj[colname]
+                )
 
         schema_components = [
             col
@@ -509,7 +527,9 @@ class DataFrameSchema:
             None
             if self.checks is None
             else _format_multiline(
-                json.dumps([str(x) for x in self.checks], indent=N_INDENT_SPACES),
+                json.dumps(
+                    [str(x) for x in self.checks], indent=N_INDENT_SPACES
+                ),
                 "checks",
             )
         )
@@ -533,14 +553,18 @@ class DataFrameSchema:
 
     def __eq__(self, other):
         def _compare_dict(obj):
-            return {k: v for k, v in obj.__dict__.items() if k != "_IS_INFERRED"}
+            return {
+                k: v for k, v in obj.__dict__.items() if k != "_IS_INFERRED"
+            }
 
         # if _compare_dict(self) != _compare_dict(other):
         #     import ipdb; ipdb.set_trace()
         return _compare_dict(self) == _compare_dict(other)
 
     @_inferred_schema_guard
-    def add_columns(self, extra_schema_cols: Dict[str, Any]) -> "DataFrameSchema":
+    def add_columns(
+        self, extra_schema_cols: Dict[str, Any]
+    ) -> "DataFrameSchema":
         """Create a copy of the DataFrameSchema with extra columns.
 
         :param extra_schema_cols: Additional columns of the format
@@ -585,7 +609,9 @@ class DataFrameSchema:
             raise ValueError("column '%s' not in %s" % (column_name, self))
         schema_copy = copy.deepcopy(self)
         column_copy = copy.deepcopy(self.columns[column_name])
-        new_column = column_copy.__class__(**{**column_copy.properties, **kwargs})
+        new_column = column_copy.__class__(
+            **{**column_copy.properties, **kwargs}
+        )
         schema_copy.columns.update({column_name: new_column})
         return schema_copy
 
@@ -601,7 +627,9 @@ class DataFrameSchema:
         # that exist in the rename_dict
         new_schema = copy.deepcopy(self)
         new_columns = {
-            (rename_dict[col_name] if col_name in rename_dict else col_name): col_attrs
+            (
+                rename_dict[col_name] if col_name in rename_dict else col_name
+            ): col_attrs
             for col_name, col_attrs in self.columns.items()
         }
 
@@ -822,7 +850,9 @@ class SeriesSchemaBase:
             "string alias" % type(self._pandas_dtype)
         )
 
-    def coerce_dtype(self, series_or_index: Union[pd.Series, pd.Index]) -> pd.Series:
+    def coerce_dtype(
+        self, series_or_index: Union[pd.Series, pd.Index]
+    ) -> pd.Series:
         """Coerce type of a pd.Series by type specified in pandas_dtype.
 
         :param pd.Series series: One-dimensional ndarray with axis labels
@@ -838,7 +868,10 @@ class SeriesSchemaBase:
         try:
             return series_or_index.astype(self.dtype)
         except TypeError as exc:
-            msg = "Error while coercing '%s' to type %s" % (self.name, self.dtype)
+            msg = "Error while coercing '%s' to type %s" % (
+                self.name,
+                self.dtype,
+            )
             raise TypeError(msg) from exc
         except ValueError as exc:
             msg = "Error while coercing '%s' to type %s: %s" % (
@@ -898,7 +931,8 @@ class SeriesSchemaBase:
         error_handler = SchemaErrorHandler(lazy)
 
         check_obj = _pandas_obj_to_validate(
-            check_obj, head, tail, sample, random_state)
+            check_obj, head, tail, sample, random_state
+        )
 
         series = (
             check_obj
@@ -934,7 +968,8 @@ class SeriesSchemaBase:
                     # casting to int results in equal values.
                     msg = (
                         "after dropping null values, expected values in "
-                        "series '%s' to be int, found: %s" % (series.name, set(series))
+                        "series '%s' to be int, found: %s"
+                        % (series.name, set(series))
                     )
                     error_handler.collect_error(
                         "unexpected_nullable_integer_type",
@@ -942,7 +977,9 @@ class SeriesSchemaBase:
                             self,
                             check_obj,
                             msg,
-                            failure_cases=reshape_failure_cases(series_no_nans),
+                            failure_cases=reshape_failure_cases(
+                                series_no_nans
+                            ),
                             check="nullable_integer",
                         ),
                     )
@@ -972,7 +1009,9 @@ class SeriesSchemaBase:
             if any(duplicates):
                 msg = "series '%s' contains duplicate values: %s" % (
                     series.name,
-                    series[duplicates].head(constants.N_FAILURE_CASES).to_dict(),
+                    series[duplicates]
+                    .head(constants.N_FAILURE_CASES)
+                    .to_dict(),
                 )
                 error_handler.collect_error(
                     "series_contains_duplicates",
@@ -980,7 +1019,9 @@ class SeriesSchemaBase:
                         self,
                         check_obj,
                         msg,
-                        failure_cases=reshape_failure_cases(series[duplicates]),
+                        failure_cases=reshape_failure_cases(
+                            series[duplicates]
+                        ),
                         check="no_duplicates",
                     ),
                 )
@@ -1040,7 +1081,9 @@ class SeriesSchemaBase:
                 )
 
         if lazy and error_handler.collected_errors:
-            raise errors.SchemaErrors(error_handler.collected_errors, check_obj)
+            raise errors.SchemaErrors(
+                error_handler.collected_errors, check_obj
+            )
 
         assert all(check_results)
         return check_obj
@@ -1095,7 +1138,9 @@ class SeriesSchema(SeriesSchemaBase):
         :param allow_duplicates:
         :type allow_duplicates: bool
         """
-        super().__init__(pandas_dtype, checks, nullable, allow_duplicates, coerce, name)
+        super().__init__(
+            pandas_dtype, checks, nullable, allow_duplicates, coerce, name
+        )
         self.index = index
 
     @property
@@ -1156,7 +1201,9 @@ class SeriesSchema(SeriesSchemaBase):
 
         """
         if not isinstance(check_obj, pd.Series):
-            raise TypeError("expected %s, got %s" % (pd.Series, type(check_obj)))
+            raise TypeError(
+                "expected %s, got %s" % (pd.Series, type(check_obj))
+            )
 
         if self.coerce:
             check_obj = self.coerce_dtype(check_obj)
@@ -1232,7 +1279,9 @@ def _handle_check_results(
         if check_result.failure_cases is None:
             # encode scalar False values explicitly
             failure_cases = scalar_failure_case(check_result.check_passed)
-            error_msg = format_generic_error_message(schema, check, check_index)
+            error_msg = format_generic_error_message(
+                schema, check, check_index
+            )
         else:
             failure_cases = reshape_failure_cases(
                 check_result.failure_cases, check.ignore_na

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -99,7 +99,11 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
     """Captures extra information about an annotation."""
 
     def __init__(
-        self, origin: Optional[Type], arg: Optional[Type], optional: bool, literal=False
+        self,
+        origin: Optional[Type],
+        arg: Optional[Type],
+        optional: bool,
+        literal=False,
     ) -> None:
         self.origin = origin
         self.arg = arg
@@ -136,12 +140,16 @@ def parse_annotation(raw_annotation: Type) -> AnnotationInfo:
     if literal:
         arg = typing_inspect.get_args(arg)[0]
 
-    return AnnotationInfo(origin=origin, arg=arg, optional=optional, literal=literal)
+    return AnnotationInfo(
+        origin=origin, arg=arg, optional=optional, literal=literal
+    )
 
 
 Bool = Literal[PandasDtype.Bool]  #: ``"bool"`` numpy dtype
 DateTime = Literal[PandasDtype.DateTime]  #: ``"datetime64[ns]"`` numpy dtype
-Timedelta = Literal[PandasDtype.Timedelta]  #: ``"timedelta64[ns]"`` numpy dtype
+Timedelta = Literal[
+    PandasDtype.Timedelta
+]  #: ``"timedelta64[ns]"`` numpy dtype
 Category = Literal[PandasDtype.Category]  #: pandas ``"categorical"`` datatype
 Float = Literal[PandasDtype.Float]  #: ``"float"`` numpy dtype
 Float16 = Literal[PandasDtype.Float16]  #: ``"float16"`` numpy dtype
@@ -160,10 +168,18 @@ INT8 = Literal[PandasDtype.INT8]  #: ``"Int8"`` pandas dtype:: pandas 0.24.0+
 INT16 = Literal[PandasDtype.INT16]  #: ``"Int16"`` pandas dtype: pandas 0.24.0+
 INT32 = Literal[PandasDtype.INT32]  #: ``"Int32"`` pandas dtype: pandas 0.24.0+
 INT64 = Literal[PandasDtype.INT64]  #: ``"Int64"`` pandas dtype: pandas 0.24.0+
-UINT8 = Literal[PandasDtype.UINT8]  #: ``"UInt8"`` pandas dtype:: pandas 0.24.0+
-UINT16 = Literal[PandasDtype.UINT16]  #: ``"UInt16"`` pandas dtype: pandas 0.24.0+
-UINT32 = Literal[PandasDtype.UINT32]  #: ``"UInt32"`` pandas dtype: pandas 0.24.0+
-UINT64 = Literal[PandasDtype.UINT64]  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
+UINT8 = Literal[
+    PandasDtype.UINT8
+]  #: ``"UInt8"`` pandas dtype:: pandas 0.24.0+
+UINT16 = Literal[
+    PandasDtype.UINT16
+]  #: ``"UInt16"`` pandas dtype: pandas 0.24.0+
+UINT32 = Literal[
+    PandasDtype.UINT32
+]  #: ``"UInt32"`` pandas dtype: pandas 0.24.0+
+UINT64 = Literal[
+    PandasDtype.UINT64
+]  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
 Object = Literal[PandasDtype.Object]  #: ``"object"`` numpy dtype
 
 #: The string datatype doesn't map to the first-class pandas datatype and

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -122,7 +122,9 @@ if __name__ == "__main__":
         help="compare whether the two files are equivalent",
     )
     argparser.add_argument(
-        "--azure", action="store_true", help="show the output in azure-pipelines format"
+        "--azure",
+        action="store_true",
+        help="show the output in azure-pipelines format",
     )
     args = argparser.parse_args()
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -44,10 +44,12 @@ def test_check_groupby():
                     Check(lambda s: s["foo"] > 10, groupby="col2"),
                     Check(lambda s: s["bar"] < 10, groupby=["col2"]),
                     Check(
-                        lambda s: s["foo"] > 10, groupby=lambda df: df.groupby("col2")
+                        lambda s: s["foo"] > 10,
+                        groupby=lambda df: df.groupby("col2"),
                     ),
                     Check(
-                        lambda s: s["bar"] < 10, groupby=lambda df: df.groupby("col2")
+                        lambda s: s["bar"] < 10,
+                        groupby=lambda df: df.groupby("col2"),
                     ),
                 ],
             ),
@@ -137,8 +139,12 @@ def test_check_groups():
             "col1": Column(
                 Int,
                 [
-                    Check(lambda s: s["foo"] > 10, groupby="col2", groups=["foo"]),
-                    Check(lambda s: s["foo"] > 10, groupby="col2", groups="foo"),
+                    Check(
+                        lambda s: s["foo"] > 10, groupby="col2", groups=["foo"]
+                    ),
+                    Check(
+                        lambda s: s["foo"] > 10, groupby="col2", groups="foo"
+                    ),
                 ],
             ),
             "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
@@ -163,7 +169,9 @@ def test_check_groups():
             "col1": Column(
                 Int,
                 [
-                    Check(lambda s: s["bar"] > 10, groupby="col2", groups="foo"),
+                    Check(
+                        lambda s: s["bar"] > 10, groupby="col2", groups="foo"
+                    ),
                 ],
             ),
             "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
@@ -182,7 +190,9 @@ def test_check_groups():
             "col1": Column(
                 Int,
                 [
-                    Check(lambda s: s["baz"] > 10, groupby="col2", groups=["foo"]),
+                    Check(
+                        lambda s: s["baz"] > 10, groupby="col2", groups=["foo"]
+                    ),
                 ],
             ),
             "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
@@ -200,7 +210,9 @@ def test_check_groups():
             "col1": Column(
                 Int,
                 [
-                    Check(lambda s: s["foo"] > 10, groupby="col2", groups=["baz"]),
+                    Check(
+                        lambda s: s["foo"] > 10, groupby="col2", groups=["baz"]
+                    ),
                 ],
             ),
             "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
@@ -221,17 +233,22 @@ def test_groupby_init_exceptions():
                     Int,
                     [
                         Check(
-                            lambda s: s["foo"] > 10, element_wise=True, groupby=["col2"]
+                            lambda s: s["foo"] > 10,
+                            element_wise=True,
+                            groupby=["col2"],
                         ),
                     ],
                 ),
-                "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+                "col2": Column(
+                    String, Check(lambda s: s.isin(["foo", "bar"]))
+                ),
             }
         )
 
     # can't use groupby in Checks where element_wise == True
     with pytest.raises(
-        errors.SchemaInitError, match=r"^Cannot use groupby when element_wise=True."
+        errors.SchemaInitError,
+        match=r"^Cannot use groupby when element_wise=True.",
     ):
         init_schema_element_wise()
 
@@ -357,7 +374,9 @@ def test_raise_warning_series():
     """Test that checks with raise_warning=True raise a warning."""
     data = pd.Series([-1, -2, -3])
     error_schema = SeriesSchema(checks=Check(lambda s: s > 0))
-    warning_schema = SeriesSchema(checks=Check(lambda s: s > 0, raise_warning=True))
+    warning_schema = SeriesSchema(
+        checks=Check(lambda s: s > 0, raise_warning=True)
+    )
 
     with pytest.raises(errors.SchemaError):
         error_schema(data)
@@ -393,10 +412,14 @@ def test_dataframe_schema_check():
     """Test that DataFrameSchema-level Checks work properly."""
     data = pd.DataFrame([range(10) for _ in range(10)])
 
-    schema_check_return_bool = DataFrameSchema(checks=Check(lambda df: (df < 10).all()))
+    schema_check_return_bool = DataFrameSchema(
+        checks=Check(lambda df: (df < 10).all())
+    )
     assert isinstance(schema_check_return_bool.validate(data), pd.DataFrame)
 
-    schema_check_return_series = DataFrameSchema(checks=Check(lambda df: df[0] < 10))
+    schema_check_return_series = DataFrameSchema(
+        checks=Check(lambda df: df[0] < 10)
+    )
     assert isinstance(schema_check_return_series.validate(data), pd.DataFrame)
 
     schema_check_return_df = DataFrameSchema(checks=Check(lambda df: df < 10))

--- a/tests/test_checks_builtin.py
+++ b/tests/test_checks_builtin.py
@@ -49,7 +49,9 @@ def check_none_failures(values, check):
     series = pd.Series(values)
     check_result = check(series)
     assert not check_result.check_passed, "Check should fail due to None value"
-    assert check_result.checked_object is series, "Wrong checked_object returned"
+    assert (
+        check_result.checked_object is series
+    ), "Wrong checked_object returned"
     assert (
         check_result.failure_cases.isnull().all()
     ), "Only null values should be failure cases"
@@ -153,14 +155,18 @@ class TestGreaterThanOrEqualTo:
     """Tests for Check.greater_than_or_equal_to"""
 
     @staticmethod
-    @pytest.mark.parametrize("check_fn", [Check.greater_than_or_equal_to, Check.ge])
+    @pytest.mark.parametrize(
+        "check_fn", [Check.greater_than_or_equal_to, Check.ge]
+    )
     def test_argument_check(check_fn):
         """Test if None is accepted as boundary"""
         with pytest.raises(ValueError):
             check_fn(min_value=None)
 
     @staticmethod
-    @pytest.mark.parametrize("check_fn", [Check.greater_than_or_equal_to, Check.ge])
+    @pytest.mark.parametrize(
+        "check_fn", [Check.greater_than_or_equal_to, Check.ge]
+    )
     @pytest.mark.parametrize(
         "values, min_val",
         [
@@ -182,7 +188,9 @@ class TestGreaterThanOrEqualTo:
         check_values(values, check_fn(min_val), {})
 
     @staticmethod
-    @pytest.mark.parametrize("check_fn", [Check.greater_than_or_equal_to, Check.ge])
+    @pytest.mark.parametrize(
+        "check_fn", [Check.greater_than_or_equal_to, Check.ge]
+    )
     @pytest.mark.parametrize(
         "values, min_val, failure_cases",
         [
@@ -207,7 +215,9 @@ class TestGreaterThanOrEqualTo:
         check_raise_error_or_warning(values, check_fn(min_val))
 
     @staticmethod
-    @pytest.mark.parametrize("check_fn", [Check.greater_than_or_equal_to, Check.ge])
+    @pytest.mark.parametrize(
+        "check_fn", [Check.greater_than_or_equal_to, Check.ge]
+    )
     @pytest.mark.parametrize(
         "values, min_val",
         [
@@ -297,14 +307,18 @@ class TestLessThanOrEqualTo:
     """Tests for Check.less_than_or_equal_to"""
 
     @staticmethod
-    @pytest.mark.parametrize("check_fn", [Check.less_than_or_equal_to, Check.le])
+    @pytest.mark.parametrize(
+        "check_fn", [Check.less_than_or_equal_to, Check.le]
+    )
     def test_argument_check(check_fn):
         """Test if None is accepted as boundary"""
         with pytest.raises(ValueError):
             check_fn(max_value=None)
 
     @staticmethod
-    @pytest.mark.parametrize("check_fn", [Check.less_than_or_equal_to, Check.le])
+    @pytest.mark.parametrize(
+        "check_fn", [Check.less_than_or_equal_to, Check.le]
+    )
     @pytest.mark.parametrize(
         "values, max_value",
         [
@@ -326,7 +340,9 @@ class TestLessThanOrEqualTo:
         check_values(values, check_fn(max_value), {})
 
     @staticmethod
-    @pytest.mark.parametrize("check_fn", [Check.less_than_or_equal_to, Check.le])
+    @pytest.mark.parametrize(
+        "check_fn", [Check.less_than_or_equal_to, Check.le]
+    )
     @pytest.mark.parametrize(
         "values, max_value, failure_cases",
         [
@@ -351,7 +367,9 @@ class TestLessThanOrEqualTo:
         check_raise_error_or_warning(values, check_fn(max_value))
 
     @staticmethod
-    @pytest.mark.parametrize("check_fn", [Check.less_than_or_equal_to, Check.le])
+    @pytest.mark.parametrize(
+        "check_fn", [Check.less_than_or_equal_to, Check.le]
+    )
     @pytest.mark.parametrize(
         "values, max_value",
         [
@@ -370,7 +388,8 @@ class TestInRange:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "args", [(None, 1), (1, None), (2, 1), (1, 1, False), (1, 1, True, False)]
+        "args",
+        [(None, 1), (1, None), (2, 1), (1, 1, False), (1, 1, True, False)],
     )
     def test_argument_check(args):
         """Test invalid arguments"""
@@ -443,7 +462,9 @@ class TestInRange:
     )
     def test_failing_with_none(values, check_args):
         """Validate the check works also on dataframes with None values"""
-        check_none_failures(values, Check.in_range(*check_args, ignore_na=False))
+        check_none_failures(
+            values, Check.in_range(*check_args, ignore_na=False)
+        )
 
 
 class TestEqualTo:
@@ -753,7 +774,9 @@ class TestStrMatches:
     )
     def test_failing_with_none(series_values, pattern):
         """Validate the check works also on dataframes with None values"""
-        check_none_failures(series_values, Check.str_matches(pattern, ignore_na=False))
+        check_none_failures(
+            series_values, Check.str_matches(pattern, ignore_na=False)
+        )
 
 
 class TestStrContains:
@@ -792,7 +815,9 @@ class TestStrContains:
     def test_failing(series_values, pattern, failure_cases):
         """Run checks which should fail"""
         check_values(series_values, Check.str_contains(pattern), failure_cases)
-        check_raise_error_or_warning(series_values, Check.str_contains(pattern))
+        check_raise_error_or_warning(
+            series_values, Check.str_contains(pattern)
+        )
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -801,7 +826,9 @@ class TestStrContains:
     )
     def test_failing_with_none(series_values, pattern):
         """Validate the check works also on dataframes with None values"""
-        check_none_failures(series_values, Check.str_contains(pattern, ignore_na=False))
+        check_none_failures(
+            series_values, Check.str_contains(pattern, ignore_na=False)
+        )
 
 
 class TestStrStartsWith:
@@ -830,8 +857,12 @@ class TestStrStartsWith:
     )
     def test_failing(series_values, pattern, failure_cases):
         """Run checks which should fail"""
-        check_values(series_values, Check.str_startswith(pattern), failure_cases)
-        check_raise_error_or_warning(series_values, Check.str_startswith(pattern))
+        check_values(
+            series_values, Check.str_startswith(pattern), failure_cases
+        )
+        check_raise_error_or_warning(
+            series_values, Check.str_startswith(pattern)
+        )
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -875,7 +906,9 @@ class TestStrEndsWith:
     def test_failing(series_values, pattern, failure_cases):
         """Run checks which should fail"""
         check_values(series_values, Check.str_endswith(pattern), failure_cases)
-        check_raise_error_or_warning(series_values, Check.str_endswith(pattern))
+        check_raise_error_or_warning(
+            series_values, Check.str_endswith(pattern)
+        )
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -886,7 +919,9 @@ class TestStrEndsWith:
     )
     def test_failing_with_none(series_values, pattern):
         """Run checks which should succeed"""
-        check_none_failures(series_values, Check.str_endswith(pattern, ignore_na=False))
+        check_none_failures(
+            series_values, Check.str_endswith(pattern, ignore_na=False)
+        )
 
 
 class TestStrLength:
@@ -922,8 +957,12 @@ class TestStrLength:
     )
     def test_failing(series_values, min_len, max_len, failure_cases):
         """Run checks which should fail"""
-        check_values(series_values, Check.str_length(min_len, max_len), failure_cases)
-        check_raise_error_or_warning(series_values, Check.str_length(min_len, max_len))
+        check_values(
+            series_values, Check.str_length(min_len, max_len), failure_cases
+        )
+        check_raise_error_or_warning(
+            series_values, Check.str_length(min_len, max_len)
+        )
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -40,11 +40,15 @@ def test_check_function_decorators():
                 ],
             ),
             "b": Column(
-                String, Check(lambda x: x in ["x", "y", "z"], element_wise=True)
+                String,
+                Check(lambda x: x in ["x", "y", "z"], element_wise=True),
             ),
             "c": Column(
                 DateTime,
-                Check(lambda x: pd.Timestamp("2018-01-01") <= x, element_wise=True),
+                Check(
+                    lambda x: pd.Timestamp("2018-01-01") <= x,
+                    element_wise=True,
+                ),
             ),
             "d": Column(
                 Float,
@@ -56,7 +60,9 @@ def test_check_function_decorators():
     out_schema = DataFrameSchema(
         {
             "e": Column(String, Check(lambda s: s == "foo")),
-            "f": Column(String, Check(lambda x: x in ["a", "b"], element_wise=True)),
+            "f": Column(
+                String, Check(lambda x: x in ["a", "b"], element_wise=True)
+            ),
         }
     )
 
@@ -151,17 +157,20 @@ def test_check_function_decorator_errors():
         return df
 
     with pytest.raises(
-        errors.SchemaError, match=r"^error in check_input decorator of function"
+        errors.SchemaError,
+        match=r"^error in check_input decorator of function",
     ):
         test_func(pd.DataFrame({"column2": ["a", "b", "c"]}))
 
     with pytest.raises(
-        errors.SchemaError, match=r"^error in check_input decorator of function"
+        errors.SchemaError,
+        match=r"^error in check_input decorator of function",
     ):
         test_func(df=pd.DataFrame({"column2": ["a", "b", "c"]}))
 
     with pytest.raises(
-        errors.SchemaError, match=r"^error in check_output decorator of function"
+        errors.SchemaError,
+        match=r"^error in check_output decorator of function",
     ):
         test_func(pd.DataFrame({"column1": [1, 2, 3]}))
 
@@ -237,10 +246,14 @@ def test_check_input_method_decorators():
 
     # call method with a dataframe passed as a second keyword argument
     _assert_expectation(
-        transformer.transform_first_arg_with_two_func_args(x="foo", df=dataframe)
+        transformer.transform_first_arg_with_two_func_args(
+            x="foo", df=dataframe
+        )
     )
 
-    _assert_expectation(transformer.transform_first_arg_with_list_getter(dataframe))
+    _assert_expectation(
+        transformer.transform_first_arg_with_list_getter(dataframe)
+    )
     _assert_expectation(
         transformer.transform_secord_arg_with_list_getter(None, dataframe)
     )
@@ -267,7 +280,9 @@ def test_check_io():
     def multiple_outputs_tuple(df):
         return df, df
 
-    @check_io(out=[(0, schema), ("foo", schema), (lambda x: x[2]["bar"], schema)])
+    @check_io(
+        out=[(0, schema), ("foo", schema), (lambda x: x[2]["bar"], schema)]
+    )
     def multiple_outputs_dict(df):
         return {0: df, "foo": df, 2: {"bar": df}}
 
@@ -327,7 +342,9 @@ def test_check_io():
             fn(*invalid)
 
 
-@pytest.mark.parametrize("obj_getter", [1.5, 0.1, ["foo"], {1, 2, 3}, {"foo": "bar"}])
+@pytest.mark.parametrize(
+    "obj_getter", [1.5, 0.1, ["foo"], {1, 2, 3}, {"foo": "bar"}]
+)
 def test_check_input_output_unrecognized_obj_getter(obj_getter):
     """
     Test that check_input and check_output raise correct errors on unrecognized
@@ -431,7 +448,8 @@ def test_check_types_unchanged():
 
     @check_types
     def transform(
-        df: DataFrame[OnlyZeroesSchema], notused: int  # pylint: disable=unused-argument
+        df: DataFrame[OnlyZeroesSchema],
+        notused: int,  # pylint: disable=unused-argument
     ) -> DataFrame[OnlyZeroesSchema]:
         return df
 
@@ -470,7 +488,9 @@ def test_check_types_multiple_inputs():
     transform(correct, correct)
 
     wrong = pd.DataFrame({"b": [1]})
-    with pytest.raises(errors.SchemaError, match="column 'a' not in dataframe"):
+    with pytest.raises(
+        errors.SchemaError, match="column 'a' not in dataframe"
+    ):
         transform(correct, wrong)
 
 
@@ -482,7 +502,9 @@ def test_check_types_error_input():
         return df
 
     df = pd.DataFrame({"b": [1]})
-    with pytest.raises(errors.SchemaError, match="column 'a' not in dataframe"):
+    with pytest.raises(
+        errors.SchemaError, match="column 'a' not in dataframe"
+    ):
         transform(df)
 
 
@@ -496,7 +518,9 @@ def test_check_types_error_output(out_schema_cls):
     def transform(df: DataFrame[InSchema]) -> DataFrame[out_schema_cls]:
         return df
 
-    with pytest.raises(errors.SchemaError, match="column 'b' not in dataframe"):
+    with pytest.raises(
+        errors.SchemaError, match="column 'b' not in dataframe"
+    ):
         transform(df)
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -286,6 +286,10 @@ def test_check_io():
     @check_io(df=schema, out=schema, lazy=True)
     def validate_lazy(df):
         return df
+    
+    @check_io(df=schema, out=schema, inplace=True)
+    def validate_inplace(df):
+        return df
 
     df1 = pd.DataFrame({"col": [1, 1, 1]})
     df2 = pd.DataFrame({"col": [2, 2, 2]})
@@ -306,6 +310,7 @@ def test_check_io():
         (validate_tail, [df1], [invalid_df], df1),
         (validate_sample, [df1], [invalid_df], df1),
         (validate_lazy, [df1], [invalid_df], df1),
+        (validate_inplace, [df1], [invalid_df], df1),
     ]:
         result = fn(*valid)
         if isinstance(result, pd.Series):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -286,7 +286,7 @@ def test_check_io():
     @check_io(df=schema, out=schema, lazy=True)
     def validate_lazy(df):
         return df
-    
+
     @check_io(df=schema, out=schema, inplace=True)
     def validate_inplace(df):
         return df

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -57,8 +57,12 @@ def test_default_numeric_dtypes():
 
     assert str(pd.Series([1.0]).dtype) == _DEFAULT_PANDAS_FLOAT_TYPE
     assert pa.Float.str_alias == _DEFAULT_PANDAS_FLOAT_TYPE
-    assert str(pd.Series([1.0], dtype=float).dtype) == _DEFAULT_NUMPY_FLOAT_TYPE
-    assert str(pd.Series([1.0], dtype="float").dtype) == _DEFAULT_NUMPY_FLOAT_TYPE
+    assert (
+        str(pd.Series([1.0], dtype=float).dtype) == _DEFAULT_NUMPY_FLOAT_TYPE
+    )
+    assert (
+        str(pd.Series([1.0], dtype="float").dtype) == _DEFAULT_NUMPY_FLOAT_TYPE
+    )
 
 
 def test_numeric_dtypes():
@@ -76,7 +80,9 @@ def test_numeric_dtypes():
             )
             for schema in [
                 DataFrameSchema({"col": Column(dtype, nullable=False)}),
-                DataFrameSchema({"col": Column(dtype.str_alias, nullable=False)}),
+                DataFrameSchema(
+                    {"col": Column(dtype.str_alias, nullable=False)}
+                ),
             ]
         )
 
@@ -93,7 +99,9 @@ def test_numeric_dtypes():
             )
             for schema in [
                 DataFrameSchema({"col": Column(dtype, nullable=False)}),
-                DataFrameSchema({"col": Column(dtype.str_alias, nullable=False)}),
+                DataFrameSchema(
+                    {"col": Column(dtype.str_alias, nullable=False)}
+                ),
             ]
         )
 
@@ -101,13 +109,17 @@ def test_numeric_dtypes():
         assert all(
             isinstance(
                 schema.validate(
-                    pd.DataFrame({"col": [1, 777, 5, 123, 9000]}, dtype=dtype.str_alias)
+                    pd.DataFrame(
+                        {"col": [1, 777, 5, 123, 9000]}, dtype=dtype.str_alias
+                    )
                 ),
                 pd.DataFrame,
             )
             for schema in [
                 DataFrameSchema({"col": Column(dtype, nullable=False)}),
-                DataFrameSchema({"col": Column(dtype.str_alias, nullable=False)}),
+                DataFrameSchema(
+                    {"col": Column(dtype.str_alias, nullable=False)}
+                ),
             ]
         )
 
@@ -144,7 +156,9 @@ def test_pandas_nullable_int_dtype(dtype, coerce):
             pd.DataFrame,
         )
         for schema in [
-            DataFrameSchema({"col": Column(dtype, nullable=False)}, coerce=coerce),
+            DataFrameSchema(
+                {"col": Column(dtype, nullable=False)}, coerce=coerce
+            ),
             DataFrameSchema(
                 {"col": Column(dtype.str_alias, nullable=False)}, coerce=coerce
             ),
@@ -167,7 +181,9 @@ def test_category_dtype():
                 pa.Category,
                 checks=[
                     Check(lambda s: set(s) == {"A", "B", "C"}),
-                    Check(lambda s: s.cat.categories.tolist() == ["A", "B", "C"]),
+                    Check(
+                        lambda s: s.cat.categories.tolist() == ["A", "B", "C"]
+                    ),
                     Check(lambda s: s.isin(["A", "B", "C"])),
                 ],
                 nullable=False,
@@ -176,7 +192,9 @@ def test_category_dtype():
         coerce=False,
     )
     validated_df = schema.validate(
-        pd.DataFrame({"col": pd.Series(["A", "B", "A", "B", "C"], dtype="category")})
+        pd.DataFrame(
+            {"col": pd.Series(["A", "B", "A", "B", "C"], dtype="category")}
+        )
     )
     assert isinstance(validated_df, pd.DataFrame)
 
@@ -194,11 +212,15 @@ def test_category_dtype_coerce():
 
     with pytest.raises(SchemaError):
         DataFrameSchema(columns=columns, coerce=False).validate(
-            pd.DataFrame({"col": pd.Series(["A", "B", "A", "B", "C"], dtype="object")})
+            pd.DataFrame(
+                {"col": pd.Series(["A", "B", "A", "B", "C"], dtype="object")}
+            )
         )
 
     validated_df = DataFrameSchema(columns=columns, coerce=True).validate(
-        pd.DataFrame({"col": pd.Series(["A", "B", "A", "B", "C"], dtype="object")})
+        pd.DataFrame(
+            {"col": pd.Series(["A", "B", "A", "B", "C"], dtype="object")}
+        )
     )
     assert isinstance(validated_df, pd.DataFrame)
 
@@ -326,7 +348,11 @@ def test_pandas_extension_types():
             None,
         ),
         (pd.Int64Dtype(), pd.Series(range(10), dtype="Int64"), None),
-        (pd.StringDtype(), pd.Series(["foo", "bar", "baz"], dtype="string"), None),
+        (
+            pd.StringDtype(),
+            pd.Series(["foo", "bar", "baz"], dtype="string"),
+            None,
+        ),
         (
             pd.PeriodDtype(freq="D"),
             pd.Series(pd.period_range("1/1/2019", "1/1/2020", freq="D")),
@@ -425,7 +451,9 @@ def test_pandas_api_type_exception(invalid_pandas_api_type):
         PandasDtype.from_pandas_api_type(invalid_pandas_api_type)
 
 
-@pytest.mark.parametrize("pandas_dtype", (pandas_dtype for pandas_dtype in PandasDtype))
+@pytest.mark.parametrize(
+    "pandas_dtype", (pandas_dtype for pandas_dtype in PandasDtype)
+)
 def test_pandas_dtype_equality(pandas_dtype):
     """Test __eq__ implementation."""
     assert pandas_dtype != None  # pylint:disable=singleton-comparison

--- a/tests/test_hypotheses.py
+++ b/tests/test_hypotheses.py
@@ -3,7 +3,15 @@
 import pandas as pd
 import pytest
 
-from pandera import Column, DataFrameSchema, Float, Hypothesis, Int, String, errors
+from pandera import (
+    Column,
+    DataFrameSchema,
+    Float,
+    Hypothesis,
+    Int,
+    String,
+    errors,
+)
 from pandera.hypotheses import HAS_SCIPY
 
 if HAS_SCIPY:
@@ -85,7 +93,10 @@ def test_hypothesis():
     """Tests the different API calls of Hypothesis."""
     # Example df for tests:
     df = pd.DataFrame(
-        {"height_in_feet": [6.5, 7, 6.1, 5.1, 4], "sex": ["M", "M", "F", "F", "F"]}
+        {
+            "height_in_feet": [6.5, 7, 6.1, 5.1, 4],
+            "sex": ["M", "M", "F", "F", "F"],
+        }
     )
 
     # Initialise the different ways of calling a test:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -30,7 +30,9 @@ SKIP_YAML_TESTS = PYYAML_VERSION is None or PYYAML_VERSION.release < (5, 1, 0)  
 
 
 # skip all tests in module if "io" depends aren't installed
-pytestmark = pytest.mark.skipif(not HAS_IO, reason='needs "io" module dependencies')
+pytestmark = pytest.mark.skipif(
+    not HAS_IO, reason='needs "io" module dependencies'
+)
 
 
 def _create_schema(index="single"):
@@ -373,7 +375,8 @@ def test_to_script_lambda_check():
     schema = pa.DataFrameSchema(
         {
             "a": pa.Column(
-                pa.Int, checks=pa.Check(lambda s: s.mean() > 5, element_wise=False)
+                pa.Int,
+                checks=pa.Check(lambda s: s.mean() > 5, element_wise=False),
             ),
         }
     )
@@ -387,7 +390,8 @@ def test_to_yaml_lambda_check():
     schema = pa.DataFrameSchema(
         {
             "a": pa.Column(
-                pa.Int, checks=pa.Check(lambda s: s.mean() > 5, element_wise=False)
+                pa.Int,
+                checks=pa.Check(lambda s: s.mean() > 5, element_wise=False),
             ),
         }
     )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -55,7 +55,9 @@ def test_invalid_annotations():
     class InvalidDtype(pa.SchemaModel):
         d: Series[Decimal]  # type: ignore
 
-    with pytest.raises(TypeError, match="python type '<class 'decimal.Decimal'>"):
+    with pytest.raises(
+        TypeError, match="python type '<class 'decimal.Decimal'>"
+    ):
         InvalidDtype.to_schema()
 
 
@@ -212,7 +214,9 @@ def test_check_non_existing():
         def int_column_lt_100(cls, series: pd.Series) -> Iterable[bool]:
             return series < 100
 
-    err_msg = "Check int_column_lt_100 is assigned to a non-existing field 'nope'"
+    err_msg = (
+        "Check int_column_lt_100 is assigned to a non-existing field 'nope'"
+    )
     with pytest.raises(pa.errors.SchemaInitError, match=err_msg):
         Schema.to_schema()
 
@@ -260,7 +264,9 @@ def test_check_multiple_columns():
             return series < 100
 
     df = pd.DataFrame({"a": [101], "b": [200]})
-    with pytest.raises(pa.errors.SchemaErrors, match="2 schema errors were found"):
+    with pytest.raises(
+        pa.errors.SchemaErrors, match="2 schema errors were found"
+    ):
         Schema.validate(df, lazy=True)
 
 
@@ -278,7 +284,9 @@ def test_check_regex():
             return series < 100
 
     df = pd.DataFrame({"a": [101], "abc": [1], "cba": [200]})
-    with pytest.raises(pa.errors.SchemaErrors, match="1 schema errors were found"):
+    with pytest.raises(
+        pa.errors.SchemaErrors, match="1 schema errors were found"
+    ):
         Schema.validate(df, lazy=True)
 
 
@@ -364,7 +372,9 @@ def test_dataframe_check():
     assert len(schema.checks) == 2
 
     df = pd.DataFrame({"a": [101, 1], "b": [1, 0]})
-    with pytest.raises(pa.errors.SchemaErrors, match="2 schema errors were found"):
+    with pytest.raises(
+        pa.errors.SchemaErrors, match="2 schema errors were found"
+    ):
         schema.validate(df, lazy=True)
 
 

--- a/tests/test_model_components.py
+++ b/tests/test_model_components.py
@@ -11,7 +11,9 @@ def test_field_to_column():
     """Test that Field outputs the correct column options."""
     for flag in ["nullable", "allow_duplicates", "coerce", "regex"]:
         for value in [True, False]:
-            col = pa.Field(**{flag: value}).to_column(pa.DateTime, required=value)
+            col = pa.Field(**{flag: value}).to_column(
+                pa.DateTime, required=value
+            )
             assert isinstance(col, pa.Column)
             assert col.dtype == pa.DateTime.value
             assert col.properties[flag] == value
@@ -42,13 +44,21 @@ def test_field_no_checks():
         ("ge", 9, pa.Check.greater_than_or_equal_to(9)),
         ("lt", 9, pa.Check.less_than(9)),
         ("le", 9, pa.Check.less_than_or_equal_to(9)),
-        ("in_range", {"min_value": 1, "max_value": 9}, pa.Check.in_range(1, 9)),
+        (
+            "in_range",
+            {"min_value": 1, "max_value": 9},
+            pa.Check.in_range(1, 9),
+        ),
         ("isin", [9, "a"], pa.Check.isin([9, "a"])),
         ("notin", [9, "a"], pa.Check.notin([9, "a"])),
         ("str_contains", "a", pa.Check.str_contains("a")),
         ("str_endswith", "a", pa.Check.str_endswith("a")),
         ("str_matches", "a", pa.Check.str_matches("a")),
-        ("str_length", {"min_value": 1, "max_value": 9}, pa.Check.str_length(1, 9)),
+        (
+            "str_length",
+            {"min_value": 1, "max_value": 9},
+            pa.Check.str_length(1, 9),
+        ),
         ("str_startswith", "a", pa.Check.str_startswith("a")),
     ],
 )

--- a/tests/test_schema_components.py
+++ b/tests/test_schema_components.py
@@ -36,7 +36,9 @@ def test_column():
     column_b = Column(Float, name="b")
     column_c = Column(String, name="c")
 
-    assert isinstance(data.pipe(column_a).pipe(column_b).pipe(column_c), pd.DataFrame)
+    assert isinstance(
+        data.pipe(column_a).pipe(column_b).pipe(column_c), pd.DataFrame
+    )
 
     with pytest.raises(errors.SchemaError):
         Column(Int)(data)
@@ -55,7 +57,10 @@ def test_coerce_nullable_object_column():
     assert pd.isna(validated_df["col"].iloc[-1])
     assert pd.isna(validated_df["col"].iloc[-2])
     for i in range(4):
-        isinstance(validated_df["col"].iloc[i], type(df_objects_with_na["col"].iloc[i]))
+        isinstance(
+            validated_df["col"].iloc[i],
+            type(df_objects_with_na["col"].iloc[i]),
+        )
 
 
 def test_column_in_dataframe_schema():
@@ -131,7 +136,11 @@ def test_multi_index_index():
         index=MultiIndex(
             indexes=[
                 Index(Int, Check(lambda s: (s < 5) & (s >= 0)), name="index0"),
-                Index(String, Check(lambda s: s.isin(["foo", "bar"])), name="index1"),
+                Index(
+                    String,
+                    Check(lambda s: s.isin(["foo", "bar"])),
+                    name="index1",
+                ),
             ]
         ),
     )
@@ -180,7 +189,8 @@ def test_multi_index_schema_coerce():
     validated_df = schema(df)
     for level_i in range(validated_df.index.nlevels):
         assert (
-            validated_df.index.get_level_values(level_i).dtype == indexes[level_i].dtype
+            validated_df.index.get_level_values(level_i).dtype
+            == indexes[level_i].dtype
         )
 
 
@@ -205,7 +215,9 @@ def tests_multi_index_subindex_coerce():
             )
         else:
             # dtype should be string representation of pandas strings
-            assert validated_df.index.get_level_values(level_i).dtype == "object"
+            assert (
+                validated_df.index.get_level_values(level_i).dtype == "object"
+            )
 
     # coerce=True in MultiIndex should override subindex coerce setting
     schema_override = DataFrameSchema(index=MultiIndex(indexes), coerce=True)
@@ -230,10 +242,14 @@ def test_schema_component_equality_operators():
     multi_index = MultiIndex(
         indexes=[
             Index(Int, Check(lambda s: (s < 5) & (s >= 0)), name="index0"),
-            Index(String, Check(lambda s: s.isin(["foo", "bar"])), name="index1"),
+            Index(
+                String, Check(lambda s: s.isin(["foo", "bar"])), name="index1"
+            ),
         ]
     )
-    not_equal_schema = DataFrameSchema({"col1": Column(Int, Check(lambda s: s >= 0))})
+    not_equal_schema = DataFrameSchema(
+        {"col1": Column(Int, Check(lambda s: s >= 0))}
+    )
 
     assert column == copy.deepcopy(column)
     assert column != not_equal_schema
@@ -245,7 +261,9 @@ def test_schema_component_equality_operators():
 
 def test_column_regex():
     """Test that column regex work on single-level column index."""
-    column_schema = Column(Int, Check(lambda s: s >= 0), name="foo_*", regex=True)
+    column_schema = Column(
+        Int, Check(lambda s: s >= 0), name="foo_*", regex=True
+    )
 
     dataframe_schema = DataFrameSchema(
         {
@@ -293,7 +311,9 @@ def test_column_regex_multiindex():
     )
     dataframe_schema = DataFrameSchema(
         {
-            ("foo_*", "baz_*"): Column(Int, Check(lambda s: s >= 0), regex=True),
+            ("foo_*", "baz_*"): Column(
+                Int, Check(lambda s: s >= 0), regex=True
+            ),
         }
     )
 
@@ -390,7 +410,9 @@ def test_column_regex_strict():
             "foo_3": [1, 2, 3],
         }
     )
-    schema = DataFrameSchema(columns={"foo_*": Column(Int, regex=True)}, strict=True)
+    schema = DataFrameSchema(
+        columns={"foo_*": Column(Int, regex=True)}, strict=True
+    )
     assert isinstance(schema.validate(data), pd.DataFrame)
 
     # adding an extra column in the dataframe should cause error
@@ -400,9 +422,9 @@ def test_column_regex_strict():
 
     # adding an extra regex column to the schema should pass the strictness
     # test
-    validated_data = schema.add_columns({"bar_*": Column(Int, regex=True)}).validate(
-        data.assign(bar_1=[1, 2, 3])
-    )
+    validated_data = schema.add_columns(
+        {"bar_*": Column(Int, regex=True)}
+    ).validate(data.assign(bar_1=[1, 2, 3]))
     assert isinstance(validated_data, pd.DataFrame)
 
 

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -54,7 +54,9 @@ def test_infer_schema(pandas_obj, expectation):
         with pytest.raises(TypeError, match="^pandas_obj type not recognized"):
             schema_inference.infer_schema(pandas_obj)
     else:
-        assert isinstance(schema_inference.infer_schema(pandas_obj), expectation)
+        assert isinstance(
+            schema_inference.infer_schema(pandas_obj), expectation
+        )
 
 
 @pytest.mark.parametrize(
@@ -76,7 +78,8 @@ def test_infer_dataframe_schema(multi_index):
         assert isinstance(schema.index, pa.Index)
 
     with pytest.warns(
-        UserWarning, match="^This .+ is an inferred schema that hasn't been modified"
+        UserWarning,
+        match="^This .+ is an inferred schema that hasn't been modified",
     ):
         schema.validate(dataframe)
 
@@ -85,14 +88,16 @@ def test_infer_dataframe_schema(multi_index):
     assert schema._is_inferred
     assert not schema_with_added_cols._is_inferred
     assert isinstance(
-        schema_with_added_cols.validate(dataframe.assign(foo="a")), pd.DataFrame
+        schema_with_added_cols.validate(dataframe.assign(foo="a")),
+        pd.DataFrame,
     )
 
     schema_with_removed_cols = schema.remove_columns(["int"])
     assert schema._is_inferred
     assert not schema_with_removed_cols._is_inferred
     assert isinstance(
-        schema_with_removed_cols.validate(dataframe.drop("int", axis=1)), pd.DataFrame
+        schema_with_removed_cols.validate(dataframe.drop("int", axis=1)),
+        pd.DataFrame,
     )
 
 
@@ -113,12 +118,15 @@ def test_infer_series_schema(series):
     assert isinstance(schema, pa.SeriesSchema)
 
     with pytest.warns(
-        UserWarning, match="^This .+ is an inferred schema that hasn't been modified"
+        UserWarning,
+        match="^This .+ is an inferred schema that hasn't been modified",
     ):
         schema.validate(series)
 
     # modifying an inferred schema should set _is_inferred to False
-    schema_with_new_checks = schema.set_checks([pa.Check(lambda x: x is not None)])
+    schema_with_new_checks = schema.set_checks(
+        [pa.Check(lambda x: x is not None)]
+    )
     assert schema._is_inferred
     assert not schema_with_new_checks._is_inferred
     assert isinstance(schema_with_new_checks.validate(series), pd.Series)

--- a/tests/test_schema_statistics.py
+++ b/tests/test_schema_statistics.py
@@ -105,7 +105,10 @@ def test_infer_dataframe_statistics(multi_index, nullable):
                 "greater_than_or_equal_to": {"min_value": 1},
                 "less_than_or_equal_to": {"max_value": 10},
             },
-            [pa.Check.greater_than_or_equal_to(1), pa.Check.less_than_or_equal_to(10)],
+            [
+                pa.Check.greater_than_or_equal_to(1),
+                pa.Check.less_than_or_equal_to(10),
+            ],
         ],
         [{}, None],
     ],
@@ -137,7 +140,9 @@ def test_parse_check_statistics(check_stats, expectation):
                 },
             ]
             for dtype in (
-                x for x in schema_statistics.NUMERIC_DTYPES if x != PandasDtype.DateTime
+                x
+                for x in schema_statistics.NUMERIC_DTYPES
+                if x != PandasDtype.DateTime
             )
         ],
         [
@@ -218,7 +223,10 @@ INTEGER_TYPES = [
             {
                 "pandas_dtype": DEFAULT_FLOAT,
                 "nullable": True,
-                "checks": {"greater_than_or_equal_to": 0, "less_than_or_equal_to": 1},
+                "checks": {
+                    "greater_than_or_equal_to": 0,
+                    "less_than_or_equal_to": 1,
+                },
                 "name": None,
             },
         ],
@@ -257,7 +265,9 @@ INTEGER_TYPES = [
         ],
     ],
 )
-def test_infer_nullable_series_schema_statistics(null_index, series, expectation):
+def test_infer_nullable_series_schema_statistics(
+    null_index, series, expectation
+):
     """Test nullable series statistics are correctly inferred."""
     series.iloc[null_index] = None
     statistics = schema_statistics.infer_series_statistics(series)
@@ -366,7 +376,9 @@ def test_get_dataframe_schema_statistics():
                     pa.Check.less_than_or_equal_to(100),
                 ],
             ),
-            "str": pa.Column(pa.String, checks=[pa.Check.isin(["foo", "bar", "baz"])]),
+            "str": pa.Column(
+                pa.String, checks=[pa.Check.isin(["foo", "bar", "baz"])]
+            ),
         },
         index=pa.Index(
             pa.Int,
@@ -479,7 +491,9 @@ def test_get_series_schema_statistics():
 )
 def test_get_index_schema_statistics(index_schema_component, expectation):
     """Test that index schema statistics logic is correct."""
-    statistics = schema_statistics.get_index_schema_statistics(index_schema_component)
+    statistics = schema_statistics.get_index_schema_statistics(
+        index_schema_component
+    )
     assert statistics == expectation
 
 
@@ -524,7 +538,12 @@ def test_get_index_schema_statistics(index_schema_component, expectation):
                 ],
                 ValueError,
             ]
-            for min_value, max_value in [(5, 1), (10, 1), (100, 10), (1000, 100)]
+            for min_value, max_value in [
+                (5, 1),
+                (10, 1),
+                (100, 10),
+                (1000, 100),
+            ]
         ],
     ],
 )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1070,16 +1070,14 @@ def test_schema_coerce_inplace_validation(inplace, from_dtype, to_dtype):
     df = pd.DataFrame({"column": pd.Series([1, 2, 6], dtype=from_dtype)})
     schema = DataFrameSchema({"column": Column(to_dtype, coerce=True)})
     validated_df = schema.validate(df, inplace=inplace)
+
+    to_dtype = PandasDtype.from_python_type(to_dtype).str_alias
+    from_dtype = PandasDtype.from_python_type(from_dtype).str_alias
+
     assert validated_df["column"].dtype == to_dtype
     if inplace:
         # inplace mutates original dataframe
-        assert (
-            df["column"].dtype
-            == PandasDtype.from_python_type(to_dtype).str_alias
-        )
+        assert df["column"].dtype == to_dtype
     else:
         # not inplace preserves original dataframe type
-        assert (
-            df["column"].dtype
-            == PandasDtype.from_python_type(from_dtype).str_alias
-        )
+        assert df["column"].dtype == from_dtype

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1067,12 +1067,13 @@ def test_schema_transformer_deprecated():
 )
 def test_schema_coerce_inplace_validation(inplace, from_dtype, to_dtype):
     """Test coercion logic for validation when inplace is True and False"""
-    df = pd.DataFrame({"column": pd.Series([1, 2, 6], dtype=from_dtype)})
-    schema = DataFrameSchema({"column": Column(to_dtype, coerce=True)})
-    validated_df = schema.validate(df, inplace=inplace)
 
     to_dtype = PandasDtype.from_python_type(to_dtype).str_alias
     from_dtype = PandasDtype.from_python_type(from_dtype).str_alias
+
+    df = pd.DataFrame({"column": pd.Series([1, 2, 6], dtype=from_dtype)})
+    schema = DataFrameSchema({"column": Column(to_dtype, coerce=True)})
+    validated_df = schema.validate(df, inplace=inplace)
 
     assert validated_df["column"].dtype == to_dtype
     if inplace:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -38,18 +38,27 @@ def test_dataframe_schema():
     schema = DataFrameSchema(
         {
             "a": Column(Int, Check(lambda x: x > 0, element_wise=True)),
-            "b": Column(Float, Check(lambda x: 0 <= x <= 10, element_wise=True)),
+            "b": Column(
+                Float, Check(lambda x: 0 <= x <= 10, element_wise=True)
+            ),
             "c": Column(String, Check(lambda x: set(x) == {"x", "y", "z"})),
             "d": Column(Bool, Check(lambda x: x.mean() > 0.5)),
-            "e": Column(Category, Check(lambda x: set(x) == {"c1", "c2", "c3"})),
+            "e": Column(
+                Category, Check(lambda x: set(x) == {"c1", "c2", "c3"})
+            ),
             "f": Column(Object, Check(lambda x: x.isin([(1,), (2,), (3,)]))),
             "g": Column(
                 DateTime,
-                Check(lambda x: x >= pd.Timestamp("2015-01-01"), element_wise=True),
+                Check(
+                    lambda x: x >= pd.Timestamp("2015-01-01"),
+                    element_wise=True,
+                ),
             ),
             "i": Column(
                 Timedelta,
-                Check(lambda x: x < pd.Timedelta(10, unit="D"), element_wise=True),
+                Check(
+                    lambda x: x < pd.Timedelta(10, unit="D"), element_wise=True
+                ),
             ),
         }
     )
@@ -112,7 +121,9 @@ def test_dataframe_schema_strict_regex():
     # Raise a SchemaError if schema is strict and a regex pattern yields
     # no matches
     with pytest.raises(errors.SchemaError):
-        schema.validate(pd.DataFrame({"bar_%d" % i: range(10) for i in range(5)}))
+        schema.validate(
+            pd.DataFrame({"bar_%d" % i: range(10) for i in range(5)})
+        )
 
 
 def test_series_schema():
@@ -122,8 +133,12 @@ def test_series_schema():
 
     SeriesSchema("int").validate(pd.Series([1, 2, 3]))
 
-    int_schema = SeriesSchema(Int, Check(lambda x: 0 <= x <= 100, element_wise=True))
-    assert isinstance(int_schema.validate(pd.Series([0, 30, 50, 100])), pd.Series)
+    int_schema = SeriesSchema(
+        Int, Check(lambda x: 0 <= x <= 100, element_wise=True)
+    )
+    assert isinstance(
+        int_schema.validate(pd.Series([0, 30, 50, 100])), pd.Series
+    )
 
     str_schema = SeriesSchema(
         String,
@@ -135,7 +150,8 @@ def test_series_schema():
         str_schema.validate(pd.Series(["foo", "bar", "baz", None])), pd.Series
     )
     assert isinstance(
-        str_schema.validate(pd.Series(["foo", "bar", "baz", np.nan])), pd.Series
+        str_schema.validate(pd.Series(["foo", "bar", "baz", np.nan])),
+        pd.Series,
     )
 
     # error cases
@@ -161,13 +177,18 @@ def test_series_schema():
         errors.SchemaError,
         match=r"^after dropping null values, expected values in series",
     ):
-        SeriesSchema(Int, nullable=True).validate(pd.Series([1.1, 2.3, 5.5, np.nan]))
+        SeriesSchema(Int, nullable=True).validate(
+            pd.Series([1.1, 2.3, 5.5, np.nan])
+        )
 
     # when series contains null values when schema is not nullable
     with pytest.raises(
-        errors.SchemaError, match=r"^non-nullable series .+ contains null values"
+        errors.SchemaError,
+        match=r"^non-nullable series .+ contains null values",
     ):
-        SeriesSchema(Float, nullable=False).validate(pd.Series([1.1, 2.3, 5.5, np.nan]))
+        SeriesSchema(Float, nullable=False).validate(
+            pd.Series([1.1, 2.3, 5.5, np.nan])
+        )
 
 
 def test_series_schema_multiple_validators():
@@ -350,7 +371,9 @@ def test_coerce_dtype_nullable_str():
                 {"col": Column(String, coerce=True, nullable=False)}
             ).validate(df)
 
-    schema = DataFrameSchema({"col": Column(String, coerce=True, nullable=True)})
+    schema = DataFrameSchema(
+        {"col": Column(String, coerce=True, nullable=True)}
+    )
 
     for df in [df_nans, df_nones]:
         validated_df = schema.validate(df)
@@ -435,9 +458,13 @@ def test_head_dataframe_schema():
     """Test that schema can validate head of dataframe, returns entire
     dataframe."""
 
-    df = pd.DataFrame({"col1": list(range(0, 100)) + list(range(-1, -1001, -1))})
+    df = pd.DataFrame(
+        {"col1": list(range(0, 100)) + list(range(-1, -1001, -1))}
+    )
 
-    schema = DataFrameSchema(columns={"col1": Column(Int, Check(lambda s: s >= 0))})
+    schema = DataFrameSchema(
+        columns={"col1": Column(Int, Check(lambda s: s >= 0))}
+    )
 
     # Validating with head of 100 should pass
     assert schema.validate(df, head=100).equals(df)
@@ -447,9 +474,13 @@ def test_head_dataframe_schema():
 
 def test_tail_dataframe_schema():
     """Checks that validating the tail of a dataframe validates correctly."""
-    df = pd.DataFrame({"col1": list(range(0, 100)) + list(range(-1, -1001, -1))})
+    df = pd.DataFrame(
+        {"col1": list(range(0, 100)) + list(range(-1, -1001, -1))}
+    )
 
-    schema = DataFrameSchema(columns={"col1": Column(Int, Check(lambda s: s < 0))})
+    schema = DataFrameSchema(
+        columns={"col1": Column(Int, Check(lambda s: s < 0))}
+    )
 
     # Validating with tail of 1000 should pass
     assert schema.validate(df, tail=1000).equals(df)
@@ -462,7 +493,9 @@ def test_sample_dataframe_schema():
     df = pd.DataFrame({"col1": range(1, 1001)})
 
     # assert all values -1
-    schema = DataFrameSchema(columns={"col1": Column(Int, Check(lambda s: s == -1))})
+    schema = DataFrameSchema(
+        columns={"col1": Column(Int, Check(lambda s: s == -1))}
+    )
 
     for seed in [11, 123456, 9000, 654]:
         sample_index = df.sample(100, random_state=seed).index
@@ -701,7 +734,9 @@ def _boolean_update_column_case(bool_kwarg):
         [Column(Int), "foobar", {}, ValueError],
     ],
 )
-def test_dataframe_schema_update_column(column, column_to_update, update, assertion_fn):
+def test_dataframe_schema_update_column(
+    column, column_to_update, update, assertion_fn
+):
     """Test that DataFrameSchema columns create updated copies."""
     schema = DataFrameSchema({"col": column})
     if assertion_fn is ValueError:
@@ -725,10 +760,15 @@ def test_rename_columns():
 
     # Check if new column names are indeed present in the new schema
     assert all(
-        [col_name in rename_dict.values() for col_name in schema_renamed.columns]
+        [
+            col_name in rename_dict.values()
+            for col_name in schema_renamed.columns
+        ]
     )
     # Check if original schema didn't change in the process
-    assert all([col_name in schema_original.columns for col_name in rename_dict])
+    assert all(
+        [col_name in schema_original.columns for col_name in rename_dict]
+    )
 
 
 @pytest.mark.parametrize(
@@ -861,10 +901,16 @@ def test_lazy_dataframe_validation_nullable():
         schema.validate(df, lazy=True)
     except errors.SchemaErrors as err:
         assert err.schema_errors.failure_case.isna().all()
-        for col, index in [("int_column", 1), ("float_column", 2), ("str_column", 0)]:
+        for col, index in [
+            ("int_column", 1),
+            ("float_column", 2),
+            ("str_column", 0),
+        ]:
             # pylint: disable=cell-var-from-loop
             assert (
-                err.schema_errors.loc[lambda df: df.column == col, "index"].iloc[0]
+                err.schema_errors.loc[
+                    lambda df: df.column == col, "index"
+                ].iloc[0]
                 == index
             )
 
@@ -884,7 +930,9 @@ def test_lazy_dataframe_validation_nullable():
 def test_lazy_dataframe_scalar_false_check(schema_cls, data):
     """Lazy validation handles checks returning scalar False values."""
     # define a check that always returns a scalare False value
-    check = Check(check_fn=lambda _: False, element_wise=False, error="failing check")
+    check = Check(
+        check_fn=lambda _: False, element_wise=False, error="failing check"
+    )
     schema = schema_cls(checks=check)
     with pytest.raises(errors.SchemaErrors):
         schema(data, lazy=True)
@@ -915,7 +963,9 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
         ],
         [
             Column(
-                Int, checks=[Check.greater_than(1), Check.less_than(3)], name="column"
+                Int,
+                checks=[Check.greater_than(1), Check.less_than(3)],
+                name="column",
             ),
             pd.DataFrame({"column": [1, 2, 3]}),
             {
@@ -981,7 +1031,9 @@ def test_lazy_series_validation_error(schema, data, expectation):
         assert err.data.equals(expectation["data"])
 
         # make sure all expected check errors are in schema errors
-        for schema_context, check_failure_cases in expectation["schema_errors"].items():
+        for schema_context, check_failure_cases in expectation[
+            "schema_errors"
+        ].items():
             assert schema_context in err.schema_errors.schema_context.values
             err_df = err.schema_errors.loc[
                 err.schema_errors.schema_context == schema_context
@@ -1021,7 +1073,13 @@ def test_schema_coerce_inplace_validation(inplace, from_dtype, to_dtype):
     assert validated_df["column"].dtype == to_dtype
     if inplace:
         # inplace mutates original dataframe
-        assert df["column"].dtype == PandasDtype.from_python_type(to_dtype).str_alias
+        assert (
+            df["column"].dtype
+            == PandasDtype.from_python_type(to_dtype).str_alias
+        )
     else:
         # not inplace preserves original dataframe type
-        assert df["column"].dtype == PandasDtype.from_python_type(from_dtype).str_alias
+        assert (
+            df["column"].dtype
+            == PandasDtype.from_python_type(from_dtype).str_alias
+        )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,4 +1,5 @@
 """Testing creation and manipulation of DataFrameSchema objects."""
+# pylint: disable=too-many-lines
 
 import copy
 from functools import partial
@@ -19,6 +20,7 @@ from pandera import (
     Int,
     MultiIndex,
     Object,
+    PandasDtype,
     SeriesSchema,
     String,
     Timedelta,
@@ -1001,14 +1003,15 @@ def test_schema_transformer_deprecated():
 
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize(
-    "from_dtype,to_dtype", [
+    "from_dtype,to_dtype",
+    [
         [float, int],
         [int, float],
         [object, int],
         [object, float],
         [int, object],
         [float, object],
-    ]
+    ],
 )
 def test_schema_coerce_inplace_validation(inplace, from_dtype, to_dtype):
     """Test coercion logic for validation when inplace is True and False"""
@@ -1018,7 +1021,7 @@ def test_schema_coerce_inplace_validation(inplace, from_dtype, to_dtype):
     assert validated_df["column"].dtype == to_dtype
     if inplace:
         # inplace mutates original dataframe
-        assert df["column"].dtype == to_dtype
+        assert df["column"].dtype == PandasDtype.from_python_type(to_dtype).str_alias
     else:
         # not inplace preserves original dataframe type
-        assert df["column"].dtype == from_dtype
+        assert df["column"].dtype == PandasDtype.from_python_type(from_dtype).str_alias

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -997,3 +997,28 @@ def test_schema_transformer_deprecated():
     """Using the transformer argument should raise a deprecation warning."""
     with pytest.warns(DeprecationWarning):
         DataFrameSchema(transformer=lambda df: df)
+
+
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize(
+    "from_dtype,to_dtype", [
+        [float, int],
+        [int, float],
+        [object, int],
+        [object, float],
+        [int, object],
+        [float, object],
+    ]
+)
+def test_schema_coerce_inplace_validation(inplace, from_dtype, to_dtype):
+    """Test coercion logic for validation when inplace is True and False"""
+    df = pd.DataFrame({"column": pd.Series([1, 2, 6], dtype=from_dtype)})
+    schema = DataFrameSchema({"column": Column(to_dtype, coerce=True)})
+    validated_df = schema.validate(df, inplace=inplace)
+    assert validated_df["column"].dtype == to_dtype
+    if inplace:
+        # inplace mutates original dataframe
+        assert df["column"].dtype == to_dtype
+    else:
+        # not inplace preserves original dataframe type
+        assert df["column"].dtype == from_dtype

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -122,9 +122,14 @@ class SchemaUINT64(pa.SchemaModel):
     col: Series[pa.typing.UINT64]
 
 
-def _test_literal_pandas_dtype(model: Type[SchemaModel], pandas_dtype: PandasDtype):
+def _test_literal_pandas_dtype(
+    model: Type[SchemaModel], pandas_dtype: PandasDtype
+):
     schema = model.to_schema()
-    assert schema.columns["col"].dtype == pa.Column(pandas_dtype, name="col").dtype
+    assert (
+        schema.columns["col"].dtype
+        == pa.Column(pandas_dtype, name="col").dtype
+    )
 
 
 @pytest.mark.parametrize(
@@ -172,7 +177,9 @@ def test_literal_legacy_pandas_dtype(
         (SchemaUINT64, pa.UINT64),
     ],
 )
-def test_literal_new_pandas_dtype(model: Type[SchemaModel], pandas_dtype: PandasDtype):
+def test_literal_new_pandas_dtype(
+    model: Type[SchemaModel], pandas_dtype: PandasDtype
+):
     """Test literal annotations with the new nullable pandas dtypes."""
     _test_literal_pandas_dtype(model, pandas_dtype)
 
@@ -206,7 +213,9 @@ def _test_pandas_extension_dtype(
             model.to_schema()
     else:
         schema = model.to_schema()
-        assert schema.columns["col"].dtype == pa.Column(dtype(), name="col").dtype
+        assert (
+            schema.columns["col"].dtype == pa.Column(dtype(), name="col").dtype
+        )
 
 
 @pytest.mark.parametrize(
@@ -275,7 +284,9 @@ if not LEGACY_PANDAS:
         ],
     )
     def test_new_pandas_extension_dtype(
-        model, dtype: pd.core.dtypes.base.ExtensionDtype, has_mandatory_args: bool
+        model,
+        dtype: pd.core.dtypes.base.ExtensionDtype,
+        has_mandatory_args: bool,
     ):
         """Test type annotations with the new nullable pandas dtypes."""
         _test_pandas_extension_dtype(model, dtype, has_mandatory_args)


### PR DESCRIPTION
Fixes #301

This diff addresses an issue where schemas mutate the original
df to be validated. By default, the validate method will create
a copy of the dataframe before coercing the type. Users can
still specify inplace=True in cases where mutating the original
dataframe doesn't matter, e.g. at the end of a method chain
where the original df doesn't need to be preserved.