### PR TITLE
Fix SchemaModel dtype example

### DIFF
--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -166,7 +166,7 @@ however, a couple of gotchas:
 
 :green:`✔` Good:
 
-.. code-block::
+.. testcode:: dataframe_schema_model
     :skipif: SKIP_PANDAS_LT_V1
 
     import pandas as pd


### PR DESCRIPTION
In the documentation of schema models, the [second note about supported dtypes ](https://pandera.readthedocs.io/en/stable/schema_models.html#supported-dtypes) is not rendered properly.

![image](https://user-images.githubusercontent.com/16199817/97109054-73b2b680-16d1-11eb-8f28-72bd69ccc694.png)

I changed the directive from `code-block` to `testcode` because `:skipif:` is not supported by `code-block`.