### PR TITLE
add PandasDtype.Str to differentiate native pandas str type

### DIFF
--- a/docs/source/checks.rst
+++ b/docs/source/checks.rst
@@ -31,7 +31,7 @@ Multiple checks can be applied to a column:
 .. testcode:: checks
 
   schema = pa.DataFrameSchema({
-      "column2": pa.Column(pa.String, [
+      "column2": pa.Column(pa.Str, [
           pa.Check(lambda s: s.str.startswith("value")),
           pa.Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
       ]),
@@ -50,7 +50,7 @@ For common validation tasks, built-in checks are available in ``pandera``.
   schema = DataFrameSchema({
       "small_values": Column(pa.Float, Check.less_than(100)),
       "one_to_three": Column(pa.Int, Check.isin([1, 2, 3])),
-      "phone_number": Column(pa.String, Check.str_matches(r'^[a-z0-9-]+$')),
+      "phone_number": Column(pa.Str, Check.str_matches(r'^[a-z0-9-]+$')),
   })
 
 See the :class:`~pandera.checks.Check` API reference for a complete list of built-in checks.
@@ -159,7 +159,7 @@ fly.
             ]),
         "age": pa.Column(pa.Int, pa.Check(lambda s: s > 0)),
         "age_less_than_20": pa.Column(pa.Bool),
-        "sex": pa.Column(pa.String, pa.Check(lambda s: s.isin(["M", "F"])))
+        "sex": pa.Column(pa.Str, pa.Check(lambda s: s.isin(["M", "F"])))
     })
 
     df = (
@@ -203,7 +203,7 @@ columns in a ``DataFrame``. For example, if you want to make assertions about
             pa.Float,
             pa.Check(lambda g: g["A"].mean() < g["B"].mean(), groupby="group")
         ),
-        "group": pa.Column(pa.String)
+        "group": pa.Column(pa.Str)
     })
 
     schema.validate(df)

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -28,7 +28,7 @@ The ``DataFrameSchema`` object consists of |column|_\s and an |index|_.
             "column1": Column(pa.Int),
             "column2": Column(pa.Float, Check(lambda s: s < -1.2)),
             # you can provide a list of validators
-            "column3": Column(pa.String, [
+            "column3": Column(pa.Str, [
                Check(lambda s: s.str.startswith("value")),
                Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
             ]),
@@ -131,7 +131,7 @@ checks.
     from pandera import Column, DataFrameSchema
 
     df = pd.DataFrame({"column1": [1, 2, 3]})
-    schema = DataFrameSchema({"column1": Column(pa.String, coerce=True)})
+    schema = DataFrameSchema({"column1": Column(pa.Str, coerce=True)})
 
     validated_df = schema.validate(df)
     assert isinstance(validated_df.column1.iloc[0], str)
@@ -203,7 +203,7 @@ in the column constructor:
    df = pd.DataFrame({"column2": ["hello", "pandera"]})
    schema = DataFrameSchema({
        "column1": Column(pa.Int, required=False),
-       "column2": Column(pa.String)
+       "column2": Column(pa.Str)
    })
 
    validated_df = schema.validate(df)
@@ -222,7 +222,7 @@ Since ``required=True`` by default, missing columns would raise an error:
 
     schema = DataFrameSchema({
         "column1": Column(pa.Int),
-        "column2": Column(pa.String),
+        "column2": Column(pa.Str),
     })
 
     schema.validate(df)
@@ -256,7 +256,7 @@ objects can also be used to validate columns in a dataframe on its own:
     })
 
     column1_schema = pa.Column(pa.Int, name="column1")
-    column2_schema = pa.Column(pa.String, name="column2")
+    column2_schema = pa.Column(pa.Str, name="column2")
 
     # pass the dataframe as an argument to the Column object callable
     df = column1_schema(df)
@@ -414,7 +414,7 @@ You can also specify an :class:`~pandera.schema_components.Index` in the :class:
     schema = DataFrameSchema(
        columns={"a": Column(pa.Int)},
        index=Index(
-           pa.String,
+           pa.Str,
            Check(lambda x: x.str.startswith("index_"))))
 
     df = pd.DataFrame(
@@ -475,7 +475,7 @@ tuples for each level in the index hierarchy:
 
     schema = DataFrameSchema({
         ("foo", "bar"): Column(pa.Int),
-        ("foo", "baz"): Column(pa.String)
+        ("foo", "baz"): Column(pa.Str)
     })
 
     df = pd.DataFrame({
@@ -512,7 +512,7 @@ indexes by composing a list of ``pandera.Index`` objects.
   schema = DataFrameSchema(
       columns={"column1": Column(pa.Int)},
       index=MultiIndex([
-          Index(pa.String,
+          Index(pa.Str,
                 Check(lambda s: s.isin(["foo", "bar"])),
                 name="index0"),
           Index(pa.Int, name="index1"),
@@ -607,7 +607,7 @@ on a dataframe, therefore requiring additional checks.
         strict=True)
 
     transformed_schema = schema.add_columns({
-        "col2": pa.Column(pa.String, pa.Check(lambda s: s == "value")),
+        "col2": pa.Column(pa.Str, pa.Check(lambda s: s == "value")),
         "col3": pa.Column(pa.Float, pa.Check(lambda x: x == 0.0)),
     })
 
@@ -642,7 +642,7 @@ data pipeline:
     schema = pa.DataFrameSchema(
         columns={
             "col1": pa.Column(pa.Int, pa.Check(lambda s: s >= 0)),
-            "col2": pa.Column(pa.String, pa.Check(lambda x: x <= 0)),
+            "col2": pa.Column(pa.Str, pa.Check(lambda x: x <= 0)),
             "col3": pa.Column(pa.Object, pa.Check(lambda x: x == 0)),
         },
         strict=True,

--- a/docs/source/hypothesis.rst
+++ b/docs/source/hypothesis.rst
@@ -48,7 +48,7 @@ which can be called as in this example of a two-sample t-test:
                     alpha=0.05,
                     equal_var=True),
         ]),
-        "sex": Column(pa.String)
+        "sex": Column(pa.Str)
     })
 
     schema.validate(df)
@@ -99,7 +99,7 @@ Here's an implementation of the two-sample t-test that uses the
                     relationship_kwargs={"alpha": 0.05}
                 )
         ]),
-        "sex": Column(pa.String, checks=Check.isin(["M", "F"]))
+        "sex": Column(pa.Str, checks=Check.isin(["M", "F"]))
     })
 
     schema.validate(df)
@@ -139,7 +139,7 @@ the tidy dataset and schema might look like this:
                 alpha=0.05
             )
         ),
-        "group": Column(pa.String, Check(lambda s: s.isin(["A", "B"])))
+        "group": Column(pa.Str, Check(lambda s: s.isin(["A", "B"])))
     })
 
     schema.validate(df)

--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -59,7 +59,7 @@ of all schemas and schema components gives you the option of doing just this:
         columns={
             "int_column": Column(pa.Int),
             "float_column": Column(pa.Float, Check.greater_than(0)),
-            "str_column": Column(pa.String, Check.equal_to("a")),
+            "str_column": Column(pa.Str, Check.equal_to("a")),
             "date_column": Column(pa.DateTime),
         },
         strict=True

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -41,7 +41,7 @@ is a simple example:
     DataFrameSchema(
         columns={
             "column1": "<Schema Column: 'column1' type=int64>",
-            "column2": "<Schema Column: 'column2' type=string>",
+            "column2": "<Schema Column: 'column2' type=str>",
             "column3": "<Schema Column: 'column3' type=datetime64[ns]>"
         },
         checks=[],
@@ -119,7 +119,7 @@ You can also write your schema to a python script with :func:`~pandera.io.to_scr
                 regex=False,
             ),
             "column2": Column(
-                pandas_dtype=PandasDtype.String,
+                pandas_dtype=PandasDtype.Str,
                 checks=None,
                 nullable=False,
                 allow_duplicates=True,
@@ -196,7 +196,7 @@ is a convenience method for this functionality.
         required: true
         regex: false
       column2:
-        pandas_dtype: string
+        pandas_dtype: str
         nullable: false
         checks: null
         allow_duplicates: true

--- a/docs/source/series_schemas.rst
+++ b/docs/source/series_schemas.rst
@@ -20,7 +20,7 @@ The :class:`~pandera.schemas.SeriesSchema` class allows for the validation of pa
 
     # specify multiple validators
     schema = pa.SeriesSchema(
-        pa.String,
+        pa.Str,
         checks=[
             pa.Check(lambda s: s.str.startswith("foo")),
             pa.Check(lambda s: s.str.endswith("bar")),

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -38,5 +38,6 @@ UINT16 = PandasDtype.UINT16
 UINT32 = PandasDtype.UINT32
 UINT64 = PandasDtype.UINT64
 Object = PandasDtype.Object
+Str = PandasDtype.Str
 String = PandasDtype.String
 Timedelta = PandasDtype.Timedelta

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -6,12 +6,7 @@ import numpy as np
 import pandas as pd
 from packaging import version
 
-# pylint: disable=invalid-name
-try:
-    PandasExtensionType = pd.core.dtypes.base.ExtensionDtype
-except AttributeError:
-    PandasExtensionType = "pd.core.dtypes.base.ExtensionDtype"
-
+PandasExtensionType = pd.core.dtypes.base.ExtensionDtype
 
 LEGACY_PANDAS = version.parse(pd.__version__).major < 1  # type: ignore
 NUMPY_NONNULLABLE_INT_DTYPES = [

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -269,11 +269,11 @@ class Index(SeriesSchemaBase):
             (including time series).
         :returns: ``Index`` with coerced data type
         """
-        if self._pandas_dtype is PandasDtype.String:
+        if self._pandas_dtype is PandasDtype.Str:
+            # only coerce non-null elements to string
             return series_or_index.where(
                 series_or_index.isna(), series_or_index.astype(str)
             )
-            # only coerce non-null elements to string
         return series_or_index.astype(self.dtype)
 
     @property
@@ -308,13 +308,17 @@ class Index(SeriesSchemaBase):
             otherwise creates a copy of the data.
         :returns: validated DataFrame or Series.
         """
-
         if self.coerce:
             check_obj.index = self.coerce_dtype(check_obj.index)
+            # handles case where pandas native string type is not supported
+            # by index.
+            obj_to_validate = pd.Series(check_obj.index).astype(self.dtype)
+        else:
+            obj_to_validate = pd.Series(check_obj.index)
 
         assert isinstance(
             super().validate(
-                pd.Series(check_obj.index),
+                obj_to_validate,
                 head,
                 tail,
                 sample,

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -859,7 +859,7 @@ class SeriesSchemaBase:
             (including time series).
         :returns: ``Series`` with coerced data type
         """
-        if self._pandas_dtype is dtypes.PandasDtype.String:
+        if self._pandas_dtype is dtypes.PandasDtype.Str:
             # only coerce non-null elements to string
             return series_or_index.where(
                 series_or_index.isna(), series_or_index.astype(str)

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -49,6 +49,7 @@ GenericDtype = TypeVar(  # type: ignore
     Literal[PandasDtype.UINT32],
     Literal[PandasDtype.UINT64],
     Literal[PandasDtype.Object],
+    Literal[PandasDtype.Str],
     Literal[PandasDtype.String],
     Literal[PandasDtype.Timedelta],
     covariant=True,
@@ -181,9 +182,8 @@ UINT64 = Literal[
 ]  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
 Object = Literal[PandasDtype.Object]  #: ``"object"`` numpy dtype
 
-#: The string datatype doesn't map to the first-class pandas datatype and
-#: is represented as a numpy ``"object"`` array. This will change after
-#: pandera only supports pandas 1.0+ and is currently handled
-#: internally by pandera as a special case. To use the pandas ``string``
-#: data type, you must explicitly use ``pd.StringDtype()``.
+Str = Literal[PandasDtype.Str]  #: ``"str"`` numpy dtype
+
+#: ``"string"`` pandas dtypes: pandas 1.0.0+. For <1.0.0, this enum will
+#: fall back on the str-as-object-array representation.
 String = Literal[PandasDtype.String]

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -14,7 +14,7 @@ from pandera import (
     Index,
     Int,
     SeriesSchema,
-    String,
+    Str,
     error_formatters,
     errors,
 )
@@ -53,7 +53,7 @@ def test_check_groupby():
                     ),
                 ],
             ),
-            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
         },
         index=Index(Int, name="data_id"),
     )
@@ -113,7 +113,7 @@ def test_check_groupby_multiple_columns():
                     ),
                 ],
             ),
-            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
             "col3": Column(Bool),
         }
     )
@@ -147,7 +147,7 @@ def test_check_groups():
                     ),
                 ],
             ),
-            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
         }
     )
 
@@ -174,7 +174,7 @@ def test_check_groups():
                     ),
                 ],
             ),
-            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
         }
     )
     with pytest.raises(
@@ -195,7 +195,7 @@ def test_check_groups():
                     ),
                 ],
             ),
-            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
         }
     )
     with pytest.raises(
@@ -215,7 +215,7 @@ def test_check_groups():
                     ),
                 ],
             ),
-            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
         }
     )
     with pytest.raises(errors.SchemaError):
@@ -239,9 +239,7 @@ def test_groupby_init_exceptions():
                         ),
                     ],
                 ),
-                "col2": Column(
-                    String, Check(lambda s: s.isin(["foo", "bar"]))
-                ),
+                "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
             }
         )
 
@@ -285,8 +283,8 @@ def test_dataframe_checks():
         columns={
             "col1": Column(Int),
             "col2": Column(Float),
-            "col3": Column(String),
-            "col4": Column(String),
+            "col3": Column(Str),
+            "col4": Column(Str),
         },
         checks=[
             Check(lambda df: df["col1"] < df["col2"]),
@@ -315,7 +313,7 @@ def test_dataframe_checks():
     groupby_check_schema = DataFrameSchema(
         columns={
             "col1": Column(Int),
-            "col3": Column(String),
+            "col3": Column(Str),
         },
         checks=[
             Check(lambda g: g["foo"]["col1"].iat[0] == 1, groupby="col3"),

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -15,7 +15,7 @@ from pandera import (
     Float,
     Int,
     SchemaModel,
-    String,
+    Str,
     check_input,
     check_io,
     check_output,
@@ -40,7 +40,7 @@ def test_check_function_decorators():
                 ],
             ),
             "b": Column(
-                String,
+                Str,
                 Check(lambda x: x in ["x", "y", "z"], element_wise=True),
             ),
             "c": Column(
@@ -59,9 +59,9 @@ def test_check_function_decorators():
     )
     out_schema = DataFrameSchema(
         {
-            "e": Column(String, Check(lambda s: s == "foo")),
+            "e": Column(Str, Check(lambda s: s == "foo")),
             "f": Column(
-                String, Check(lambda x: x in ["a", "b"], element_wise=True)
+                Str, Check(lambda x: x in ["a", "b"], element_wise=True)
             ),
         }
     )
@@ -189,7 +189,7 @@ def test_check_function_decorator_errors():
 def test_check_input_method_decorators():
     """Test the check_input and check_output decorator behaviours when the
     dataframe is changed within the function being checked"""
-    in_schema = DataFrameSchema({"column1": Column(String)})
+    in_schema = DataFrameSchema({"column1": Column(Str)})
     out_schema = DataFrameSchema({"column2": Column(Int)})
     dataframe = pd.DataFrame({"column1": ["a", "b", "c"]})
 

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -458,3 +458,9 @@ def test_pandas_dtype_equality(pandas_dtype):
     """Test __eq__ implementation."""
     assert pandas_dtype is not None
     assert pandas_dtype == pandas_dtype.value
+
+
+@pytest.mark.parametrize("pdtype", PandasDtype)
+def test_dtype_none_comparison(pdtype):
+    """Test that comparing PandasDtype to None is False."""
+    assert pdtype != None  # noqa E711  # pylint: disable=singleton-comparison

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -403,7 +403,7 @@ def test_python_builtin_types():
     assert isinstance(schema(df), pd.DataFrame)
     assert schema.dtype["int_col"] == PandasDtype.Int.str_alias
     assert schema.dtype["float_col"] == PandasDtype.Float.str_alias
-    assert schema.dtype["str_col"] == PandasDtype.String.str_alias
+    assert schema.dtype["str_col"] == PandasDtype.Str.str_alias
     assert schema.dtype["bool_col"] == PandasDtype.Bool.str_alias
     assert schema.dtype["object_col"] == PandasDtype.Object.str_alias
     assert schema.dtype["complex_col"] == PandasDtype.Complex.str_alias
@@ -419,7 +419,7 @@ def test_python_builtin_types_not_supported(python_type):
 @pytest.mark.parametrize(
     "pandas_api_type,pandas_dtype",
     [
-        ["string", PandasDtype.String],
+        ["string", PandasDtype.Str],
         ["floating", PandasDtype.Float],
         ["integer", PandasDtype.Int],
         ["categorical", PandasDtype.Category],
@@ -456,5 +456,5 @@ def test_pandas_api_type_exception(invalid_pandas_api_type):
 )
 def test_pandas_dtype_equality(pandas_dtype):
     """Test __eq__ implementation."""
-    assert pandas_dtype != None  # pylint:disable=singleton-comparison
+    assert pandas_dtype is not None
     assert pandas_dtype == pandas_dtype.value

--- a/tests/test_hypotheses.py
+++ b/tests/test_hypotheses.py
@@ -9,7 +9,7 @@ from pandera import (
     Float,
     Hypothesis,
     Int,
-    String,
+    Str,
     errors,
 )
 from pandera.hypotheses import HAS_SCIPY
@@ -114,7 +114,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(String),
+            "sex": Column(Str),
         }
     )
 
@@ -132,7 +132,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(String),
+            "sex": Column(Str),
         }
     )
 
@@ -150,7 +150,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(String),
+            "sex": Column(Str),
         }
     )
 
@@ -170,7 +170,7 @@ def test_hypothesis():
                     )
                 ],
             ),
-            "sex": Column(String),
+            "sex": Column(Str),
         }
     )
 
@@ -194,7 +194,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(String),
+            "sex": Column(Str),
         }
     )
 
@@ -212,7 +212,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(String),
+            "sex": Column(Str),
         }
     )
 
@@ -230,7 +230,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(String),
+            "sex": Column(Str),
         }
     )
 
@@ -259,7 +259,7 @@ def test_two_sample_ttest_hypothesis_relationships():
                         ),
                     ],
                 ),
-                "sex": Column(String),
+                "sex": Column(Str),
             }
         )
         assert isinstance(schema, DataFrameSchema)
@@ -280,7 +280,7 @@ def test_two_sample_ttest_hypothesis_relationships():
                             ),
                         ],
                     ),
-                    "sex": Column(String),
+                    "sex": Column(Str),
                 }
             )
 
@@ -302,7 +302,7 @@ def test_one_sample_hypothesis():
 
     subset_schema = DataFrameSchema(
         {
-            "group": Column(String),
+            "group": Column(Str),
             "height_in_feet": Column(
                 Float,
                 [

--- a/tests/test_schema_components.py
+++ b/tests/test_schema_components.py
@@ -16,7 +16,7 @@ from pandera import (
     Int,
     MultiIndex,
     Object,
-    String,
+    Str,
     errors,
 )
 from tests.test_dtypes import TESTABLE_DTYPES
@@ -34,7 +34,7 @@ def test_column():
 
     column_a = Column(Int, name="a")
     column_b = Column(Float, name="b")
-    column_c = Column(String, name="c")
+    column_c = Column(Str, name="c")
 
     assert isinstance(
         data.pipe(column_a).pipe(column_b).pipe(column_c), pd.DataFrame
@@ -105,7 +105,7 @@ def test_multi_index_columns():
         {
             ("zero", "foo"): Column(Float, Check(lambda s: (s > 0) & (s < 1))),
             ("zero", "bar"): Column(
-                String, Check(lambda s: s.isin(["a", "b", "c", "d"]))
+                Str, Check(lambda s: s.isin(["a", "b", "c", "d"]))
             ),
             ("one", "foo"): Column(Int, Check(lambda s: (s > 0) & (s < 10))),
             ("one", "bar"): Column(
@@ -137,7 +137,7 @@ def test_multi_index_index():
             indexes=[
                 Index(Int, Check(lambda s: (s < 5) & (s >= 0)), name="index0"),
                 Index(
-                    String,
+                    Str,
                     Check(lambda s: s.isin(["foo", "bar"])),
                     name="index1",
                 ),
@@ -174,7 +174,7 @@ def test_multi_index_schema_coerce():
     indexes = [
         Index(Float),
         Index(Int),
-        Index(String),
+        Index(Str),
     ]
     schema = DataFrameSchema(index=MultiIndex(indexes=indexes))
     df = pd.DataFrame(
@@ -197,10 +197,10 @@ def test_multi_index_schema_coerce():
 def tests_multi_index_subindex_coerce():
     """MultIndex component should override sub indexes."""
     indexes = [
-        Index(String, coerce=True),
-        Index(String, coerce=False),
-        Index(String, coerce=True),
-        Index(String, coerce=False),
+        Index(Str, coerce=True),
+        Index(Str, coerce=False),
+        Index(Str, coerce=True),
+        Index(Str, coerce=False),
     ]
 
     data = pd.DataFrame(index=pd.MultiIndex.from_arrays([[1, 2, 3, 4]] * 4))
@@ -242,9 +242,7 @@ def test_schema_component_equality_operators():
     multi_index = MultiIndex(
         indexes=[
             Index(Int, Check(lambda s: (s < 5) & (s >= 0)), name="index0"),
-            Index(
-                String, Check(lambda s: s.isin(["foo", "bar"])), name="index1"
-            ),
+            Index(Str, Check(lambda s: s.isin(["foo", "bar"])), name="index1"),
         ]
     )
     not_equal_schema = DataFrameSchema(

--- a/tests/test_schema_statistics.py
+++ b/tests/test_schema_statistics.py
@@ -61,13 +61,13 @@ def test_infer_dataframe_statistics(multi_index, nullable):
         assert stat_columns["boolean"]["pandas_dtype"] is pa.Bool
 
     assert stat_columns["float"]["pandas_dtype"] is DEFAULT_FLOAT
-    assert stat_columns["string"]["pandas_dtype"] is pa.String
+    assert stat_columns["string"]["pandas_dtype"] is pa.Str
     assert stat_columns["datetime"]["pandas_dtype"] is pa.DateTime
 
     if multi_index:
         stat_indices = statistics["index"]
         for stat_index, name, dtype in zip(
-            stat_indices, ["int_index", "str_index"], [DEFAULT_INT, pa.String]
+            stat_indices, ["int_index", "str_index"], [DEFAULT_INT, pa.Str]
         ):
             assert stat_index["name"] == name
             assert stat_index["pandas_dtype"] is dtype
@@ -157,7 +157,7 @@ def test_parse_check_statistics(check_stats, expectation):
         [
             pd.Series(["a", "b", "c", "a"], name="str_series"),
             {
-                "pandas_dtype": pa.String,
+                "pandas_dtype": pa.Str,
                 "nullable": False,
                 "checks": None,
                 "name": "str_series",
@@ -244,7 +244,7 @@ INTEGER_TYPES = [
             0,
             pd.Series(["a", "b", "c", "a"], name="str_series"),
             {
-                "pandas_dtype": pa.String,
+                "pandas_dtype": pa.Str,
                 "nullable": True,
                 "checks": None,
                 "name": "str_series",
@@ -310,7 +310,7 @@ def test_infer_nullable_series_schema_statistics(
             [
                 {
                     "name": "str_index",
-                    "pandas_dtype": PandasDtype.String,
+                    "pandas_dtype": PandasDtype.Str,
                     "nullable": False,
                     "checks": None,
                 },
@@ -377,7 +377,7 @@ def test_get_dataframe_schema_statistics():
                 ],
             ),
             "str": pa.Column(
-                pa.String, checks=[pa.Check.isin(["foo", "bar", "baz"])]
+                pa.Str, checks=[pa.Check.isin(["foo", "bar", "baz"])]
             ),
         },
         index=pa.Index(
@@ -414,7 +414,7 @@ def test_get_dataframe_schema_statistics():
                 "regex": False,
             },
             "str": {
-                "pandas_dtype": pa.String,
+                "pandas_dtype": pa.Str,
                 "checks": {"isin": {"allowed_values": ["foo", "bar", "baz"]}},
                 "nullable": False,
                 "allow_duplicates": True,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -985,7 +985,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
                 # into a Series
                 "data": pd.Series(["a", "b", "d"]),
                 "schema_errors": {
-                    "Index": {"isin(%s)" % {"a", "b", "c"}: ["d"]},
+                    "Index": {"isin(%s)" % set(["a", "b", "c"]): ["d"]},
                 },
             },
         ],

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -22,10 +22,12 @@ from pandera import (
     Object,
     PandasDtype,
     SeriesSchema,
+    Str,
     String,
     Timedelta,
     errors,
 )
+from pandera.dtypes import LEGACY_PANDAS
 from pandera.schemas import SeriesSchemaBase
 from tests.test_dtypes import TESTABLE_DTYPES
 
@@ -41,7 +43,7 @@ def test_dataframe_schema():
             "b": Column(
                 Float, Check(lambda x: 0 <= x <= 10, element_wise=True)
             ),
-            "c": Column(String, Check(lambda x: set(x) == {"x", "y", "z"})),
+            "c": Column(Str, Check(lambda x: set(x) == {"x", "y", "z"})),
             "d": Column(Bool, Check(lambda x: x.mean() > 0.5)),
             "e": Column(
                 Category, Check(lambda x: set(x) == {"c1", "c2", "c3"})
@@ -141,7 +143,7 @@ def test_series_schema():
     )
 
     str_schema = SeriesSchema(
-        String,
+        Str,
         Check(lambda s: s.isin(["foo", "bar", "baz"])),
         nullable=True,
         coerce=True,
@@ -224,7 +226,7 @@ def test_series_schema_with_index(coerce):
         index=MultiIndex(
             [
                 Index(Int, coerce=coerce),
-                Index(String, coerce=coerce),
+                Index(Str, coerce=coerce),
             ]
         ),
     )
@@ -320,7 +322,7 @@ def test_coerce_dtype_in_dataframe():
         {
             "column1": Column(Int, Check(lambda x: x > 0), coerce=True),
             "column2": Column(DateTime, coerce=True),
-            "column3": Column(String, coerce=True, nullable=True),
+            "column3": Column(Str, coerce=True, nullable=True),
         }
     )
     # specify `coerce` at the DataFrameSchema level
@@ -328,7 +330,7 @@ def test_coerce_dtype_in_dataframe():
         {
             "column1": Column(Int, Check(lambda x: x > 0)),
             "column2": Column(DateTime),
-            "column3": Column(String, nullable=True),
+            "column3": Column(Str, nullable=True),
         },
         coerce=True,
     )
@@ -368,12 +370,10 @@ def test_coerce_dtype_nullable_str():
     with pytest.raises(errors.SchemaError):
         for df in [df_nans, df_nones]:
             DataFrameSchema(
-                {"col": Column(String, coerce=True, nullable=False)}
+                {"col": Column(Str, coerce=True, nullable=False)}
             ).validate(df)
 
-    schema = DataFrameSchema(
-        {"col": Column(String, coerce=True, nullable=True)}
-    )
+    schema = DataFrameSchema({"col": Column(Str, coerce=True, nullable=True)})
 
     for df in [df_nans, df_nones]:
         validated_df = schema.validate(df)
@@ -431,7 +431,7 @@ def test_required():
     and then not specified and a second column which is implicitly required
     isn't available."""
     schema = DataFrameSchema(
-        {"col1": Column(Int, required=False), "col2": Column(String)}
+        {"col1": Column(Int, required=False), "col2": Column(Str)}
     )
 
     df_ok_1 = pd.DataFrame({"col2": ["hello", "world"]})
@@ -509,7 +509,7 @@ def test_dataframe_schema_str_repr():
     schema = DataFrameSchema(
         columns={
             "col1": Column(Int),
-            "col2": Column(String),
+            "col2": Column(Str),
             "col3": Column(DateTime),
         },
         index=Index(Int, name="my_index"),
@@ -527,16 +527,18 @@ def test_dataframe_schema_dtype_property():
     schema = DataFrameSchema(
         columns={
             "col1": Column(Int),
-            "col2": Column(String),
-            "col3": Column(DateTime),
-            "col4": Column("uint16"),
+            "col2": Column(Str),
+            "col3": Column(String),
+            "col4": Column(DateTime),
+            "col5": Column("uint16"),
         }
     )
     assert schema.dtype == {
         "col1": "int64",
         "col2": "object",
-        "col3": "datetime64[ns]",
-        "col4": "uint16",
+        "col3": ("object" if LEGACY_PANDAS else "string"),
+        "col4": "datetime64[ns]",
+        "col5": "uint16",
     }
 
 
@@ -552,32 +554,32 @@ def test_schema_equality_operators():
     df_schema = DataFrameSchema(
         {
             "col1": Column(Int, Check(lambda s: s >= 0)),
-            "col2": Column(String, Check(lambda s: s >= 2)),
+            "col2": Column(Str, Check(lambda s: s >= 2)),
         },
         strict=True,
     )
     df_schema_columns_in_different_order = DataFrameSchema(
         {
-            "col2": Column(String, Check(lambda s: s >= 2)),
+            "col2": Column(Str, Check(lambda s: s >= 2)),
             "col1": Column(Int, Check(lambda s: s >= 0)),
         },
         strict=True,
     )
     series_schema = SeriesSchema(
-        String,
+        Str,
         checks=[Check(lambda s: s.str.startswith("foo"))],
         nullable=False,
         allow_duplicates=True,
         name="my_series",
     )
     series_schema_base = SeriesSchemaBase(
-        String,
+        Str,
         checks=[Check(lambda s: s.str.startswith("foo"))],
         nullable=False,
         allow_duplicates=True,
         name="my_series",
     )
-    not_equal_schema = DataFrameSchema({"col1": Column(String)}, strict=False)
+    not_equal_schema = DataFrameSchema({"col1": Column(Str)}, strict=False)
 
     assert df_schema == copy.deepcopy(df_schema)
     assert df_schema != not_equal_schema
@@ -603,7 +605,7 @@ def test_add_and_remove_columns():
     # test that add_columns doesn't modify schema1 after add_columns:
     schema2 = schema1.add_columns(
         {
-            "col2": Column(String, Check(lambda x: x <= 0)),
+            "col2": Column(Str, Check(lambda x: x <= 0)),
             "col3": Column(Object, Check(lambda x: x == 0)),
         }
     )
@@ -616,7 +618,7 @@ def test_add_and_remove_columns():
     expected_schema_2 = DataFrameSchema(
         {
             "col1": Column(Int, Check(lambda s: s >= 0)),
-            "col2": Column(String, Check(lambda x: x <= 0)),
+            "col2": Column(Str, Check(lambda x: x <= 0)),
             "col3": Column(Object, Check(lambda x: x == 0)),
         },
         strict=True,
@@ -704,10 +706,10 @@ def _boolean_update_column_case(bool_kwarg):
         [
             Column(Int),
             "col",
-            {"pandas_dtype": String},
+            {"pandas_dtype": Str},
             lambda old, new: [
                 old.columns["col"].pandas_dtype is Int,
-                new.columns["col"].pandas_dtype is String,
+                new.columns["col"].pandas_dtype is Str,
             ],
         ],
         *[
@@ -812,13 +814,13 @@ def test_lazy_dataframe_validation_error():
             "int_col": Column(Int, Check.greater_than(5)),
             "int_col2": Column(Int),
             "float_col": Column(Float, Check.less_than(0)),
-            "str_col": Column(String, Check.isin(["foo", "bar"])),
+            "str_col": Column(Str, Check.isin(["foo", "bar"])),
             "not_in_dataframe": Column(Int),
         },
         checks=Check(
             lambda df: df != 1, error="dataframe_not_equal_1", ignore_na=False
         ),
-        index=Index(String, name="str_index"),
+        index=Index(Str, name="str_index"),
         strict=True,
     )
 
@@ -884,7 +886,7 @@ def test_lazy_dataframe_validation_nullable():
         columns={
             "int_column": Column(Int, nullable=False),
             "float_column": Column(Float, nullable=False),
-            "str_column": Column(String, nullable=False),
+            "str_column": Column(Str, nullable=False),
         },
         strict=True,
     )
@@ -976,7 +978,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
             },
         ],
         [
-            Index(String, checks=Check.isin(["a", "b", "c"])),
+            Index(Str, checks=Check.isin(["a", "b", "c"])),
             pd.DataFrame({"col": [1, 2, 3]}, index=["a", "b", "d"]),
             {
                 # expect that the data in the SchemaError is the pd.Index cast

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -4,14 +4,11 @@ from typing import Type
 
 import pandas as pd
 import pytest
-from packaging import version
 
 import pandera as pa
-from pandera.dtypes import PandasDtype
+from pandera.dtypes import LEGACY_PANDAS, PandasDtype
 from pandera.model import SchemaModel
 from pandera.typing import Series
-
-LEGACY_PANDAS = version.parse(pd.__version__).major < 1  # type: ignore
 
 
 class SchemaBool(pa.SchemaModel):


### PR DESCRIPTION
fixes #312

this diff adds a `Str` enum to the `PandasDtype` enum class so that
there's a distinction between the str dtype that pandas represents
as an object array and the native string dtype that became available
after pandas v1. For <1 pandas installations, the PandasDtype.String
and "string" alias will fall back on the PandasDtype.Str dtype.