### PR TITLE
Add support for optional name validation of single-index

### DIFF
--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -44,7 +44,14 @@ class FieldInfo:
     *new in 0.5.0*
     """
 
-    __slots__ = ("checks", "nullable", "allow_duplicates", "coerce", "regex")
+    __slots__ = (
+        "checks",
+        "nullable",
+        "allow_duplicates",
+        "coerce",
+        "regex",
+        "check_name",
+    )
 
     def __init__(
         self,
@@ -53,12 +60,14 @@ class FieldInfo:
         allow_duplicates: bool = True,
         coerce: bool = False,
         regex: bool = False,
+        check_name: bool = None,
     ) -> None:
         self.checks = _to_checklist(checks)
         self.nullable = nullable
         self.allow_duplicates = allow_duplicates
         self.coerce = coerce
         self.regex = regex
+        self.check_name = check_name
 
     def _to_schema_component(
         self,
@@ -131,6 +140,7 @@ def Field(
     ignore_na: bool = True,
     raise_warning: bool = False,
     n_failure_cases: int = 10,
+    check_name: bool = None,
 ) -> Any:
     """Used to provide extra information about a field of a SchemaModel.
 
@@ -138,6 +148,10 @@ def Field(
 
     Some arguments apply only to number dtypes and some apply only to ``str``.
     See the :ref:`User Guide <schema_models>` for more.
+
+    :param check_name: Whether to check the name of the column/index during validation.
+        `None` is the default behavior, which translates to `True` for columns and
+        multi-index, and to `False` for a single index.
     """
     # pylint:disable=C0103,W0613,R0914
     check_kwargs = {
@@ -163,6 +177,7 @@ def Field(
         allow_duplicates=allow_duplicates,
         coerce=coerce,
         regex=regex,
+        check_name=check_name,
     )
 
 

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -943,7 +943,7 @@ class SeriesSchemaBase:
         if not inplace:
             series = series.copy()
 
-        if series.name != self._name:
+        if self.name is not None and series.name != self._name:
             msg = "Expected %s to have name '%s', found '%s'" % (
                 type(self),
                 self._name,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -135,6 +135,16 @@ def test_multiindex():
     assert expected == Schema.to_schema()
 
 
+def test_column_check_name():
+    """Test that column name is mandatory."""
+
+    class Schema(pa.SchemaModel):
+        a: Series[int] = pa.Field(check_name=False)
+
+    with pytest.raises(pa.errors.SchemaInitError):
+        Schema.to_schema()
+
+
 def test_single_index_check_name():
     """Test single index name."""
     df = pd.DataFrame(index=pd.Index(["cat", "dog"], name="animal"))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -135,6 +135,64 @@ def test_multiindex():
     assert expected == Schema.to_schema()
 
 
+def test_single_index_check_name():
+    """Test single index name."""
+    df = pd.DataFrame(index=pd.Index(["cat", "dog"], name="animal"))
+
+    class DefaultSchema(pa.SchemaModel):
+        a: Index[str]
+
+    assert isinstance(DefaultSchema.validate(df), pd.DataFrame)
+
+    class DefaultFieldSchema(pa.SchemaModel):
+        a: Index[str] = pa.Field(check_name=None)
+
+    assert isinstance(DefaultFieldSchema.validate(df), pd.DataFrame)
+
+    class NotCheckNameSchema(pa.SchemaModel):
+        a: Index[str] = pa.Field(check_name=False)
+
+    assert isinstance(NotCheckNameSchema.validate(df), pd.DataFrame)
+
+    class SchemaNamedIndex(pa.SchemaModel):
+        a: Index[str] = pa.Field(check_name=True)
+
+    err_msg = "name 'a', found 'animal'"
+    with pytest.raises(pa.errors.SchemaError, match=err_msg):
+        SchemaNamedIndex.validate(df)
+
+
+def test_multiindex_check_name():
+    """Test a MultiIndex name."""
+
+    df = pd.DataFrame(
+        index=pd.MultiIndex.from_arrays(
+            [["foo", "bar"], [0, 1]], names=["a", "b"]
+        )
+    )
+
+    class DefaultSchema(pa.SchemaModel):
+        a: Index[str]
+        b: Index[int]
+
+    assert isinstance(DefaultSchema.validate(df), pd.DataFrame)
+
+    class CheckNameSchema(pa.SchemaModel):
+        a: Index[str] = pa.Field(check_name=True)
+        b: Index[int] = pa.Field(check_name=True)
+
+    assert isinstance(CheckNameSchema.validate(df), pd.DataFrame)
+
+    class NotCheckNameSchema(pa.SchemaModel):
+        a: Index[str] = pa.Field(check_name=False)
+        b: Index[int] = pa.Field(check_name=False)
+
+    df = pd.DataFrame(
+        index=pd.MultiIndex.from_arrays([["foo", "bar"], [0, 1]])
+    )
+    assert isinstance(NotCheckNameSchema.validate(df), pd.DataFrame)
+
+
 def test_check_validate_method():
     """Test validate method on valid data."""
 


### PR DESCRIPTION
This PR adds optional name validation for single-index.

1. Previously, validation would fail on a named index if the index name was not set in the `DataFrameSchema`:
```python
import pandas as pd
import pandera as pa

from pandera import Column, DataFrameSchema, Index, Check

schema = DataFrameSchema(index=Index(pa.Object))
df = pd.DataFrame(index=pd.Index(["index_1", "index_2", "index_3"], name="idx"))
schema.validate(df)
#> Traceback (most recent call last):
#> ...
#> SchemaError: Expected <class 'pandera.schema_components.Index'> to have name 'None', found 'idx'
```

<sup>Created on 2020-11-19 by the [reprexpy package](https://github.com/crew102/reprexpy)</sup>

The new behavior is to disable name validation when the name is set to `None`. We discussed adding a new argument `check_name` to `Index` in #323 but I think this solution is more elegant. @cosmicBboy Let me know if you see any drawbacks to this approach.

Moreover, the PR does add a `check_name` parameters to `Field`.  That closes #323 

2.  `check_name` (bool): Whether to check the name of the column/index during validation.
 `None` is the default behavior, which translates to `True` for columns and multi-index, and to `False` for a single index.

```python
import pandera as pa
import pandas as pd

df = pd.DataFrame(index=pd.Index(["cat", "dog"], name="animal"))


class SchemaNamedIndex(pa.SchemaModel):
    a: pa.typing.Index[str]
    # Same as the following:
    # a: pa.typing.Index[str] = Field(check_name=False)
    # a: pa.typing.Index[str] = Field(check_name=None)


SchemaNamedIndex.validate(df)  # ok
#> Empty DataFrame
#> Columns: []
#> Index: [cat, dog]


class SchemaNamedIndex(pa.SchemaModel):
    a: pa.typing.Index[str] = pa.Field(check_name=True)


SchemaNamedIndex.validate(df)  # fails
#> Traceback (most recent call last):
#> ...
#> SchemaError: Expected <class 'pandera.schema_components.Index'> to have name 'a', found 'animal'
```

<sup>Created on 2020-11-19 by the [reprexpy package](https://github.com/crew102/reprexpy)</sup>

3. As discussed [here](https://github.com/pandera-dev/pandera/issues/323#issuecomment-729225310), columns must always be named.

4. Multi-index suffers from the same "bug" as described in 1. but it's much harder to fix because `pa.MultiIndex` is implemented as a subclass of `pa.DataFrameSchema`. I think it should be the topic of another issue.

```python
import pandas as pd
import pandera as pa

from pandera import Column, DataFrameSchema, Index, MultiIndex, Check

schema = DataFrameSchema(index=MultiIndex([Index(pa.String), Index(pa.Int)]))
df = pd.DataFrame(
    index=pd.MultiIndex.from_arrays(
        [["foo", "bar", "foo"], [0, 1, 2]], names=["index0", "index1"]
    )
)
schema.validate(df)
#> Traceback (most recent call last):
#> ...
#> SchemaError: column '0' not in dataframe
#>               index0  index1
#> index0 index1               
#> foo    0         foo       0
#> bar    1         bar       1
#> foo    2         foo       2
```

<sup>Created on 2020-11-19 by the [reprexpy package](https://github.com/crew102/reprexpy)</sup>

