### PR TITLE
Add support for aliases

### DIFF
--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -489,7 +489,7 @@ Checks must reference the aliased names.
     df = pd.DataFrame({2020: [99]}, index=[0])
     df.index.name = "_idx"
 
-    Schema.validate(df)
+    print(Schema.validate(df))
 
 .. testoutput:: dataframe_schema_model
 

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -464,6 +464,40 @@ The custom checks are inherited and therefore can be overwritten by the subclass
     2      2             3
 
 
+Aliases
+-------
+
+:class:`~pandera.model.SchemaModel` supports columns which are not valid python variable names via the argument
+`alias` of :class:`~pandera.model_components.Field`.
+
+Checks must reference the aliased names.
+
+.. testcode:: dataframe_schema_model
+
+    import pandera as pa
+    import pandas as pd
+
+    class Schema(pa.SchemaModel):
+        col_2020: pa.typing.Series[int] = pa.Field(alias=2020)
+        idx: pa.typing.Index[int] = pa.Field(alias="_idx", check_name=True)
+
+        @pa.check(2020)
+        def int_column_lt_100(cls, series):
+            return series < 100
+
+
+    df = pd.DataFrame({2020: [99]}, index=[0])
+    df.index.name = "_idx"
+
+    Schema.validate(df)
+
+.. testoutput:: dataframe_schema_model
+
+          2020
+    _idx
+    0       99
+
+
 Footnotes
 ---------
 

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -20,7 +20,7 @@ import wrapt
 
 from . import errors, schemas
 from .model import SchemaModel
-from .typing import parse_annotation
+from .typing import AnnotationInfo
 
 Schemas = Union[schemas.DataFrameSchema, schemas.SeriesSchema]
 InputGetter = Union[str, int]
@@ -469,7 +469,7 @@ def check_types(
         arguments = sig.bind(*args, **kwargs).arguments
         for arg_name, arg_value in arguments.items():
             annotation = sig.parameters[arg_name].annotation
-            annotation_info = parse_annotation(annotation)
+            annotation_info = AnnotationInfo(annotation)
 
             if annotation_info.optional and arg_value is None:
                 continue
@@ -490,7 +490,7 @@ def check_types(
 
         out = wrapped(*args, **kwargs)
 
-        annotation_info = parse_annotation(sig.return_annotation)
+        annotation_info = AnnotationInfo(sig.return_annotation)
         if annotation_info.optional and out is None:
             return out
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -229,7 +229,6 @@ class SchemaModel:
         """Centralize publicly named fields and their corresponding annotations."""
         fields = {}
         for field_name, annotation in annotations.items():
-            print(field_name)
             field: Optional[FieldInfo] = getattr(cls, field_name, None)
             if field is not None and not isinstance(field, FieldInfo):
                 raise SchemaInitError(

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -28,7 +28,7 @@ from .model_components import (
     FieldInfo,
 )
 from .schemas import DataFrameSchema
-from .typing import Index, Series, parse_annotation
+from .typing import AnnotationInfo, Index, Series
 
 SchemaIndex = Union[schema_components.Index, schema_components.MultiIndex]
 
@@ -82,7 +82,7 @@ class SchemaModel:
     Config: Type[BaseConfig] = BaseConfig
     __schema__: Optional[DataFrameSchema] = None
     __config__: Optional[Type[BaseConfig]] = None
-    __field_annotations__: Dict[str, Type] = {}
+    __fields__: Dict[str, Tuple[AnnotationInfo, Optional[FieldInfo]]] = {}
     __checks__: Dict[str, List[Check]] = {}
     __dataframe_checks__: List[Check] = []
 
@@ -95,13 +95,14 @@ class SchemaModel:
         if cls in MODEL_CACHE:
             return MODEL_CACHE[cls]
 
-        cls.__field_annotations__ = cls._collect_field_annotations()
-
+        annotations = cls._collect_field_annotations()
+        cls.__fields__ = cls._collect_fields(annotations)
         check_infos = cast(
             List[FieldCheckInfo], cls._collect_check_infos(CHECK_KEY)
         )
-        field_names = list(cls.__field_annotations__.keys())
-        cls.__checks__ = cls._extract_checks(check_infos, field_names)
+        cls.__checks__ = cls._extract_checks(
+            check_infos, field_names=list(cls.__fields__.keys())
+        )
 
         df_check_infos = cls._collect_check_infos(DATAFRAME_CHECK_KEY)
         cls.__dataframe_checks__ = cls._extract_df_checks(df_check_infos)
@@ -113,9 +114,7 @@ class SchemaModel:
             if name.startswith("multiindex_")
         }
         columns, index = cls._build_columns_index(
-            cls.__checks__,
-            cls.__field_annotations__,
-            **mi_kwargs,
+            cls.__fields__, cls.__checks__, **mi_kwargs
         )
         cls.__schema__ = DataFrameSchema(
             columns,
@@ -148,30 +147,22 @@ class SchemaModel:
     @classmethod
     def _build_columns_index(  # pylint:disable=too-many-locals
         cls,
+        fields: Dict[str, Tuple[AnnotationInfo, Optional[FieldInfo]]],
         checks: Dict[str, List[Check]],
-        annotations: Dict[str, Any],
         **multiindex_kwargs: Any,
     ) -> Tuple[
         Dict[str, schema_components.Column],
         Optional[Union[schema_components.Index, schema_components.MultiIndex]],
     ]:
-        annotations = {
-            field_name: (parse_annotation(raw_annotation), raw_annotation)
-            for field_name, raw_annotation in annotations.items()
-        }
         index_count = sum(
-            annotation.origin is Index
-            for annotation, _ in annotations.values()
+            annotation.origin is Index for annotation, _ in fields.values()
         )
 
         columns: Dict[str, schema_components.Column] = {}
         indices: List[schema_components.Index] = []
-        for field_name, (annotation, raw_annotation) in annotations.items():
-
-            field: FieldInfo = getattr(cls, field_name, None)
-            _check_fieldinfo(field, field_name)
-
+        for field_name, (annotation, field) in fields.items():
             field_checks = checks.get(field_name, [])
+            field_name = getattr(field, "alias", None) or field_name
             check_name = getattr(field, "check_name", None)
 
             if annotation.origin is Series:
@@ -212,21 +203,42 @@ class SchemaModel:
                 indices.append(index)
             else:
                 raise SchemaInitError(
-                    f"Invalid annotation '{field_name}: {raw_annotation}'"
+                    f"Invalid annotation '{field_name}: {annotation.raw_annotation}'"
                 )
 
         return columns, _build_schema_index(indices, **multiindex_kwargs)
 
     @classmethod
-    def _collect_field_annotations(cls) -> Dict[str, Any]:
+    def _collect_field_annotations(cls) -> Dict[str, AnnotationInfo]:
         """Collect inherited field annotations from bases."""
         bases = inspect.getmro(cls)[:-2]  # bases -> SchemaModel -> object
         bases = cast(Tuple[Type[SchemaModel]], bases)
-        annotations = {}
+        raw_annotations = {}
         for base in reversed(bases):
             base_annotations = _get_field_annotations(base)
-            annotations.update(base_annotations)
-        return annotations
+            raw_annotations.update(base_annotations)
+        return {
+            name: AnnotationInfo(annotation)
+            for name, annotation in raw_annotations.items()
+        }
+
+    @classmethod
+    def _collect_fields(
+        cls, annotations: Dict[str, AnnotationInfo]
+    ) -> Dict[str, Tuple[AnnotationInfo, Optional[FieldInfo]]]:
+        """Collect inherited field annotations from bases."""
+        fields = {}
+        for field_name, annotation in annotations.items():
+            print(field_name)
+            field: Optional[FieldInfo] = getattr(cls, field_name, None)
+            if field is not None and not isinstance(field, FieldInfo):
+                raise SchemaInitError(
+                    f"'{field_name}' can only be assigned a 'Field', "
+                    + f"not a '{type(field)}.'"
+                )
+            field_name = getattr(field, "alias", None) or field_name
+            fields[field_name] = (annotation, field)
+        return fields
 
     @classmethod
     def _collect_config(cls) -> Type[BaseConfig]:
@@ -266,20 +278,20 @@ class SchemaModel:
 
     @classmethod
     def _extract_checks(
-        cls, check_infos: List[FieldCheckInfo], fields: List[str]
+        cls, check_infos: List[FieldCheckInfo], field_names: List[str]
     ) -> Dict[str, List[Check]]:
         """Collect field annotations from bases in mro reverse order."""
         checks: Dict[str, List[Check]] = {}
         for check_info in check_infos:
             if check_info.regex:
-                matched = _regex_filter(fields, check_info.fields)
+                matched = _regex_filter(field_names, check_info.fields)
             else:
                 matched = check_info.fields
 
             check_ = check_info.to_check(cls)
 
             for field in matched:
-                if field not in fields:
+                if field not in field_names:
                     raise SchemaInitError(
                         f"Check {check_.name} is assigned to a non-existing field '{field}'."
                     )
@@ -332,11 +344,3 @@ def _regex_filter(seq: Iterable, regexps: Iterable[str]) -> Set[str]:
         pattern = re.compile(regex)
         matched.update(filter(pattern.match, seq))
     return matched
-
-
-def _check_fieldinfo(field: FieldInfo, field_name: str) -> None:
-    if field is not None and not isinstance(field, FieldInfo):
-        raise SchemaInitError(
-            f"'{field_name}' can only be assigned a 'Field', "
-            + f"not a '{field.__class__}.'"
-        )

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -226,7 +226,7 @@ class SchemaModel:
     def _collect_fields(
         cls, annotations: Dict[str, AnnotationInfo]
     ) -> Dict[str, Tuple[AnnotationInfo, Optional[FieldInfo]]]:
-        """Collect inherited field annotations from bases."""
+        """Centralize publicly named fields and their corresponding annotations."""
         fields = {}
         for field_name, annotation in annotations.items():
             print(field_name)

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -51,6 +51,7 @@ class FieldInfo:
         "coerce",
         "regex",
         "check_name",
+        "alias",
     )
 
     def __init__(
@@ -60,6 +61,7 @@ class FieldInfo:
         allow_duplicates: bool = True,
         coerce: bool = False,
         regex: bool = False,
+        alias: str = None,
         check_name: bool = None,
     ) -> None:
         self.checks = _to_checklist(checks)
@@ -67,6 +69,7 @@ class FieldInfo:
         self.allow_duplicates = allow_duplicates
         self.coerce = coerce
         self.regex = regex
+        self.alias = alias
         self.check_name = check_name
 
     def _to_schema_component(
@@ -140,6 +143,7 @@ def Field(
     ignore_na: bool = True,
     raise_warning: bool = False,
     n_failure_cases: int = 10,
+    alias: str = None,
     check_name: bool = None,
 ) -> Any:
     """Used to provide extra information about a field of a SchemaModel.
@@ -148,6 +152,8 @@ def Field(
 
     Some arguments apply only to number dtypes and some apply only to ``str``.
     See the :ref:`User Guide <schema_models>` for more.
+
+    :param alias: The public name of the column/index.
 
     :param check_name: Whether to check the name of the column/index during validation.
         `None` is the default behavior, which translates to `True` for columns and
@@ -178,6 +184,7 @@ def Field(
         coerce=coerce,
         regex=regex,
         check_name=check_name,
+        alias=alias,
     )
 
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -985,7 +985,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
                 # into a Series
                 "data": pd.Series(["a", "b", "d"]),
                 "schema_errors": {
-                    "Index": {"isin(%s)" % set(["a", "b", "c"]): ["d"]},
+                    "Index": {f"isin({set(['a', 'b', 'c'])})": ["d"]},
                 },
             },
         ],


### PR DESCRIPTION
This PR adds support for aliases in `SchemaModel` and closes #324.

Example:
 
```python
    import pandera as pa
    import pandas as pd

    class Schema(pa.SchemaModel):
        col_2020: pa.typing.Series[int] = pa.Field(alias=2020)
        idx: pa.typing.Index[int] = pa.Field(alias="_idx", check_name=True)

        @pa.check(2020)
        def int_column_lt_100(cls, series):
            return series < 100


    df = pd.DataFrame({2020: [99]}, index=[0])
    df.index.name = "_idx"

    Schema.validate(df)
```
I also restructured the schema construction. I replaced the internal attribute `__fields_annotations__` by `__fields__` which is a dict indexed by public column/index name (i.e. optionally aliased) and values are tuples of (`AnnotationInfo`, `FieldInfo`). That gives us more flexibility.