### PR TITLE
327 add documentation for dataframeschema transformations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,6 +19,21 @@ create a development environment that is separate from your existing Python
 environment so that you can make and test changes without compromising your
 own work environment.
 
+### Contributing documentation
+
+Maybe the easiest, fastest, and most useful way to contribute to this project
+(and any other project) is to contribute documentation. If you find an API
+within the project that doesn't have an example or description, or could be
+clearer in its explanation, contribute yours!
+
+This project uses Sphinx for auto-documentation and RST syntax for docstrings.
+Once you have the code downloaded and you find something that is in need of some
+TLD, take a look at the [Sphinx](https://www.sphinx-doc.org/en/1.0/rest.html)
+documentation or well-documented [examples](https://pandera.readthedocs.io/en/stable/_modules/pandera/schemas.html#DataFrameSchema)
+within the codebase for guidance on contributing.
+
+
+
 ### Dataframe Schema Style Guides
 
 We have guidelines regarding dataframe and schema styles that are encouraged

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -688,18 +688,24 @@ the pipeline output.
 .. testoutput:: set_index
     :options: +NORMALIZE_WHITESPACE
 
-    DataFrameSchema(columns={'column2': <Schema Column: 'column2' type=float>},
+    DataFrameSchema(
+        columns={
+            "column2": "<Schema Column: 'column2' type=float>"
+        },
+        checks=[],
         index=MultiIndex(
-            columns={
-                "column3": "<Schema Column: 'column3' type=int>",
-                "column1": "<Schema Column: 'column1' type=int>"
-            },
-            checks=[],
-            index=None,
-            coerce=False,
-            strict=False
-        ),
-        coerce=False)
+        columns={
+            "column3": "<Schema Column: 'column3' type=int>",
+            "column1": "<Schema Column: 'column1' type=int>"
+        },
+        checks=[],
+        index=None,
+        coerce=False,
+        strict=False
+    ),
+        coerce=True,
+        strict=True
+    )
 
 
 The available methods for altering the schema are:

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -683,7 +683,7 @@ the pipeline output.
         strict=True,
         coerce=True,
     )
-    print(schema.set_index(["column1"], append = True)
+    print(schema.set_index(["column1"], append = True))
 
 .. testoutput:: set_index
     :options: +NORMALIZE_WHITESPACE

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -670,7 +670,6 @@ the pipeline output.
 
 .. testcode:: set_index
 
-
     import pandera as pa
 
     from pandera import Column, DataFrameSchema, Check, Index

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -586,14 +586,13 @@ Some examples of where this can be provided to pandas are:
 DataFrameSchema Transformations
 -------------------------------
 
-Pandera supports transforming a schema using
-:func:`~pandera.schemas.DataFrameSchema.add_columns` and
-:func:`~pandera.schemas.DataFrameSchema.remove_columns`.
+Once you've defined a schema, you can then make modifications to it, both on
+the schema level -- such as adding or removing columns and setting or resetting
+the index -- or on the column level -- such as changing the data type or checks.
 
-Once you've defined a schema, you can add columns to the schema and to create
-a new schema object with the additional columns. This is useful for re-using
-schema objects in a data pipeline when additional computation has been done
-on a dataframe, therefore requiring additional checks.
+This is useful for re-using schema objects in a data pipeline when additional
+computation has been done on a dataframe, where the column objects may have
+changed or perhaps where additional checks may be required.
 
 .. testcode:: add_columns
 
@@ -663,3 +662,51 @@ data pipeline:
         coerce=False,
         strict=True
     )
+
+If during the course of a data pipeline one of your columns is moved into the
+index, you can simply update the initial input schema using the
+:func:`~pandera.schemas.DataFrameSchema.set_index` method to create a schema for
+the pipeline output.
+
+.. testcode:: set_index
+
+
+    import pandera as pa
+
+    from pandera import Column, DataFrameSchema, Check, Index
+
+    schema = DataFrameSchema(
+        {
+            "column1": Column(pa.Int),
+            "column2": Column(pa.Float)
+        },
+        index=Index(pa.Int, name = "column3"),
+        strict=True,
+        coerce=True,
+    )
+    print(schema.set_index(["column1"], append = True)
+
+.. testoutput:: set_index
+    :options: +NORMALIZE_WHITESPACE
+
+    DataFrameSchema(columns={'column2': <Schema Column: 'column2' type=float>},
+        index=MultiIndex(
+            columns={
+                "column3": "<Schema Column: 'column3' type=int>",
+                "column1": "<Schema Column: 'column1' type=int>"
+            },
+            checks=[],
+            index=None,
+            coerce=False,
+            strict=False
+        ),
+        coerce=False)
+
+
+The available methods for altering the schema are:
+:func:`~pandera.schemas.DataFrameSchema.add_columns` ,
+:func:`~pandera.schemas.DataFrameSchema.remove_columns`,
+:func:`~pandera.schemas.DataFrameSchema.update_columns`,
+:func:`~pandera.schemas.DataFrameSchema.rename_columns`,
+:func:`~pandera.schemas.DataFrameSchema.set_index`,
+and :func:`~pandera.schemas.DataFrameSchema.reset_index`.

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -364,7 +364,10 @@ class DataFrameSchema:
 
             for column in check_obj:
                 if column not in expanded_column_names:
-                    msg = f"column '{column}' not in DataFrameSchema {self.columns}"
+                    msg = (
+                        f"column '{column}' not in DataFrameSchema"
+                        f" {self.columns}"
+                    )
                     error_handler.collect_error(
                         "column_not_in_schema",
                         errors.SchemaError(
@@ -561,25 +564,40 @@ class DataFrameSchema:
     def add_columns(
         self, extra_schema_cols: Dict[str, Any]
     ) -> "DataFrameSchema":
-        """Create a copy of the DataFrameSchema with extra columns.
+        """Create a copy of the :class:`DataFrameSchema` with extra columns.
 
         :param extra_schema_cols: Additional columns of the format
         :type extra_schema_cols: DataFrameSchema
-        :returns: a new ``DataFrameSchema`` with the extra_schema_cols added
+        :returns: a new :class:`DataFrameSchema` with the extra_schema_cols
+            added.
         :example:
 
-        To add columns to the schema, pass a dictionary with column name and ``Column`` instance key-value pairs.
+        To add columns to the schema, pass a dictionary with column name and
+        ``Column`` instance key-value pairs.
 
-        >>> import pandera as pa
-        >>>
-        >>> example_schema = pa.DataFrameSchema({
-        ...     "category" : pa.Column(pa.String),
-        ...     "probability": pa.Column(pa.Float)})
-        >>>
-        >>> example_schema.add_columns({"even_number": pa.Column(pa.Bool)})
-        DataFrameSchema(columns={'category': <Schema Column: 'category' type=string>,
-        'probability': <Schema Column: 'probability' type=float>,
-        'even_number': <Schema Column: 'even_number' type=bool>}, index=None, coerce=False)
+        .. testcode:: add_columns_example1
+
+            import pandera as pa
+
+            example_schema = pa.DataFrameSchema(
+                {
+                    "category" : pa.Column(pa.String),
+                    "probability": pa.Column(pa.Float)
+                }
+            )
+
+            example_schema.add_columns({"even_number": pa.Column(pa.Bool)})
+
+        .. testoutput:: add_columns_example1
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(
+                columns = {
+                    'category': <Schema Column: 'category' type = string>,
+                    'probability': <Schema Column: 'probability' type = float>,
+                    'even_number': <Schema Column: 'even_number' type = bool>
+                },
+                index = None, coerce = False)
 
         .. seealso:: :func:`remove_columns`
 
@@ -593,24 +611,40 @@ class DataFrameSchema:
 
     @_inferred_schema_guard
     def remove_columns(self, cols_to_remove: List[str]) -> "DataFrameSchema":
-        """Removes columns from a ``DataFrameSchema`` and returns a new copy.
+        """Removes columns from a :class:`DataFrameSchema` and returns a new
+        copy.
 
-        :param cols_to_remove: Columns to be removed from the ``DataFrameSchema``
+        :param cols_to_remove: Columns to be removed from the
+            ``DataFrameSchema``
         :type cols_to_remove: List
-        :returns: a new ``DataFrameSchema`` without the cols_to_remove
-        :raises: SchemaInitError: if column not in schema.
+        :returns: a new :class:`DataFrameSchema` without the cols_to_remove
+        :raises: :class:`~pandera.errors.SchemaInitError`: if column not in
+            schema.
         :example:
 
-        To remove a column or set of columns from a schema, pass a list of columns to be removed:
+        To remove a column or set of columns from a schema, pass a list of
+        columns to be removed:
 
-        >>> import pandera as pa
-        >>>
-        >>> example_schema = pa.DataFrameSchema({
-        ...     "category" : pa.Column(pa.String),
-        ...     "probability": pa.Column(pa.Float)})
-        >>>
-        >>> example_schema.remove_columns(["category"])
-        DataFrameSchema(columns={'probability': <Schema Column: 'probability' type=float>}, index=None, coerce=False)
+        .. testcode:: remove_columns_example1
+
+            import pandera as pa
+
+            example_schema = pa.DataFrameSchema(
+                {
+                    "category" : pa.Column(pa.String),
+                    "probability": pa.Column(pa.Float)
+                }
+            )
+
+            example_schema.remove_columns(["category"])
+
+        .. testoutput:: remove_columns_example1
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(
+                columns = {
+                    'probability': <Schema Column: 'probability' type=float>},
+                index = None, coerce = False)
 
         .. seealso:: :func:`add_columns`
 
@@ -633,28 +667,45 @@ class DataFrameSchema:
 
     @_inferred_schema_guard
     def update_column(self, column_name: str, **kwargs) -> "DataFrameSchema":
-        """Create copy of a ``DataFrameSchema`` with updated column properties.
+        """Create copy of a :class:`DataFrameSchema` with
+        updated column properties.
 
         :param column_name:
         :param kwargs: key-word arguments supplied to
             :class:`~pandera.schema_components.Column`
-        :returns: a new ``DataFrameSchema`` with updated column
-        :raises: SchemaInitError: if column not in schema or you try to change the name.
+        :returns: a new :class:`DataFrameSchema` with updated column
+        :raises: :class:`~pandera.errors.SchemaInitError`: if column not in
+            schema or you try to change the name.
         :example:
 
-        Calling ``schema.update_column`` returns the ``DataFrameSchema`` with the updated column.
+        Calling ``schema.update_column`` returns the :class:`DataFrameSchema`
+        with the updated column.
 
-        >>> import pandera as pa
-        >>>
-        >>> example_schema = pa.DataFrameSchema({
-        ...     "category" : pa.Column(pa.String),
-        ...     "probability": pa.Column(pa.Float)})
-        >>>
-        >>> example_schema.update_column("category", pandas_dtype = pa.Category)
-        DataFrameSchema(columns={'category': <Schema Column: 'category' type=category>,
-        'probability': <Schema Column: 'probability' type=float>}, index=None, coerce=False)
+        .. testcode:: update_column_example1
+
+            import pandera as pa
+
+            example_schema = pa.DataFrameSchema({
+                    "category" : pa.Column(pa.String),
+                    "probability": pa.Column(pa.Float)
+                }
+            )
+
+            example_schema.update_column('category', pandas_dtype=pa.Category)
+
+        .. testoutput:: update_column_example1
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(
+                columns = {
+                    'category': <Schema Column: 'category' type=category>,
+                    'probability': <Schema Column: 'probability' type=float>},
+                index = None, coerce = False)
 
         .. seealso:: :func:`rename_columns`
+
+        .. warning:: This method will be deprecated; it is
+            recommended to use the :func:`update_columns` method instead.
 
         """
         # check that columns exist in schema
@@ -671,27 +722,128 @@ class DataFrameSchema:
         schema_copy.columns.update({column_name: new_column})
         return schema_copy
 
+    def update_columns(
+        self, update_dict: Dict[str, Dict[str, Any]]
+    ) -> "DataFrameSchema":
+        """
+        Create copy of a :class:`DataFrameSchema` with updated column
+        properties.
+
+        :param update_dict:
+        :return: a new :class:`DataFrameSchema` with updated columns
+        :raises: :class:`~pandera.errors.SchemaInitError`: if column not in
+            schema or you try to change the name.
+        :example:
+
+        Calling ``schema.update_columns`` returns the :class:`DataFrameSchema`
+        with the updated columns.
+
+        .. testcode:: update_columns_example1
+
+            import pandera as pa
+
+            example_schema = pa.DataFrameSchema({
+                    "category" : pa.Column(pa.String),
+                    "probability": pa.Column(pa.Float)
+                }
+            )
+
+            example_schema.update_columns(
+                {
+                    "category": {"pandas_dtype":pa.Category}
+                }
+            )
+
+        .. testoutput:: update_columns_example1
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(
+                columns = {
+                    'category': <Schema Column: 'category' type = category>,
+                    'probability': <Schema Column: 'probability' type = float>
+                    },
+                index = None, coerce = False)
+
+        .. note:: This is the successor to the ``update_column`` method, which
+            will be deprecated.
+
+
+        """
+
+        new_schema = copy.deepcopy(self)
+
+        # ensure all specified keys are present in the columns
+        not_in_cols: List[str] = [
+            x for x in update_dict.keys() if x not in new_schema.columns.keys()
+        ]
+        if not_in_cols:
+            raise errors.SchemaInitError(
+                f"Keys {not_in_cols} not found in schema columns!"
+            )
+
+        new_columns: Dict[str, Dict[str, Any]] = {}
+        for col in new_schema.columns:
+            # check
+            if update_dict.get(col):
+                if update_dict[col].get("name"):
+                    raise errors.SchemaInitError(
+                        "cannot update 'name' \
+                                             property of the column."
+                    )
+            original_properties = new_schema.columns[col].properties
+            if update_dict.get(col):
+                new_properties = copy.deepcopy(original_properties)
+                new_properties.update(update_dict[col])
+                new_columns[col] = new_schema.columns[col].__class__(
+                    **new_properties
+                )
+            else:
+                new_columns[col] = new_schema.columns[col].__class__(
+                    **original_properties
+                )
+
+        new_schema.columns = new_columns
+
+        return new_schema
+
     def rename_columns(self, rename_dict: Dict[str, str]) -> "DataFrameSchema":
         """Rename columns using a dictionary of key-value pairs.
 
         :param rename_dict: dictionary of 'old_name': 'new_name' key-value
             pairs.
-        :returns: ``DataFrameSchema`` (copy of original)
-        :raises: ``SchemaInitError`` if column not in the schema.
+        :returns: :class:`DataFrameSchema` (copy of original)
+        :raises: :class:`~pandera.errors.SchemaInitError` if column not in the
+            schema.
         :example:
 
-        To rename a column or set of columns, pass a dictionary of old column names and new column names,
-        similar to the ``pd.DataFrame`` method.
+        To rename a column or set of columns, pass a dictionary of old column
+        names and new column names, similar to the pandas DataFrame method.
 
-        >>> import pandera as pa
-        >>>
-        >>> example_schema = pa.DataFrameSchema({
-        ...     "category" : pa.Column(pa.String),
-        ...     "probability": pa.Column(pa.Float)})
-        >>>
-        >>> example_schema.rename_columns({"category": "categories", "probability": "probabilities"})
-        DataFrameSchema(columns={'categories': <Schema Column: 'category' type=string>,
-        'probability': <Schema Column: 'probability' type=float>}, index=None, coerce=False)
+        .. testcode:: rename_columns_example1
+
+            import pandera as pa
+
+            example_schema = pa.DataFrameSchema({
+                    "category" : pa.Column(pa.String),
+                    "probability": pa.Column(pa.Float)
+                }
+            )
+
+            example_schema.rename_columns({
+                    "category": "categories",
+                    "probability": "probabilities"
+                }
+            )
+
+        .. testoutput:: rename_columns_example1
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(
+                columns = {
+                    'categories': <Schema Column: 'categories' type = string>,
+                    'probabilities': <Schema Column: 'probabilities' type = float>
+                },
+                index = None, coerce = False)
 
         .. seealso:: :func:`update_column`
 
@@ -707,13 +859,25 @@ class DataFrameSchema:
                 f"Keys {not_in_cols} not found in schema columns!"
             )
 
+        # ensure all new keys are not present in the current column names
+        already_in_columns: List[str] = [
+            x for x in rename_dict.values() if x in new_schema.columns.keys()
+        ]
+        if already_in_columns:
+            raise errors.SchemaInitError(
+                f"Keys {already_in_columns} already found in schema columns!"
+            )
+
         # We iterate over the existing columns dict and replace those keys
         # that exist in the rename_dict
+
         new_columns = {
-            (
-                rename_dict[col_name] if col_name in rename_dict else col_name
-            ): col_attrs
-            for col_name, col_attrs in self.columns.items()
+            (rename_dict[col_name] if col_name in rename_dict else col_name): (
+                col_attrs.set_name(rename_dict[col_name])
+                if col_name in rename_dict
+                else col_attrs
+            )
+            for col_name, col_attrs in new_schema.columns.items()
         }
 
         new_schema.columns = new_columns
@@ -726,22 +890,37 @@ class DataFrameSchema:
         *New in version 0.4.5*
 
         :param columns: list of column names to select.
-        :returns: ``DataFrameSchema`` (copy of original) with only the selected columns.
-        :raises: ``SchemaInitError`` if column not in the schema.
+        :returns:  :class:`DataFrameSchema` (copy of original) with only
+            the selected columns.
+        :raises: :class:`~pandera.errors.SchemaInitError` if column not in the
+            schema.
         :example:
 
         To subset a schema by column, and return a new schema:
 
-        >>> import pandera as pa
-        >>>
-        >>> example_schema = pa.DataFrameSchema({
-        ...     "category" : pa.Column(pa.String),
-        ...     "probability": pa.Column(pa.Float)})
-        >>>
-        >>> example_schema.select_columns(['category'])
-        DataFrameSchema(columns={'category': <Schema Column: 'category' type=string>}, index=None, coerce=False)
+        .. testcode:: select_columns_example1
 
-        .. note:: If an index is present in the schema, it will also be included in the new schema.
+            import pandera as pa
+
+            example_schema = pa.DataFrameSchema({
+                    "category" : pa.Column(pa.String),
+                    "probability": pa.Column(pa.Float)
+                }
+            )
+
+            example_schema.select_columns(['category'])
+
+        .. testoutput:: select_columns_example1
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(
+                columns = {
+                    'category': <Schema Column: 'category' type = string>
+                    },
+                index = None, coerce = False)
+
+        .. note:: If an index is present in the schema, it will also be
+            included in the new schema.
 
         """
 
@@ -805,39 +984,65 @@ class DataFrameSchema:
     ) -> "DataFrameSchema":
         """
         A method for setting the :class:`Index` of a :class:`DataFrameSchema`,
-        via an existing :class:`Column` or list of :class:`Column`s.
+        via an existing :class:`Column` or list of columns.
 
         :param keys: list of labels
         :param drop: bool, default True
         :param append: bool, default False
         :return: a new :class:`DataFrameSchema` with specified column(s) in the
             index.
-        :raises: ``SchemaInitError`` if column not in the schema.
+        :raises: :class:`~pandera.errors.SchemaInitError` if column not in the
+            schema.
         :examples:
 
-        Just as you would set the index in a pandas DataFrame from an existing column, you can set an index within the
-        schema from an existing column in the schema.
+        Just as you would set the index in a ``pandas`` DataFrame from an
+        existing column, you can set an index within the schema from an
+        existing column in the schema.
 
-        >>> import pandera as pa
-        >>>
-        >>> example_schema = pa.DataFrameSchema({
-        ...     "category" : pa.Column(pa.String),
-        ...     "probability": pa.Column(pa.Float)})
-        >>>
-        >>> example_schema.set_index(['category'])
-        DataFrameSchema(columns={'probability': <Schema Column: 'probability' type=float>},
-        index=<Schema Index: 'category'>, coerce=False)
+        .. testcode:: set_index_example1
 
-        If you have an existing index in your schema, and you would like to append a new column as an index to it
-        (yielding a ``Multiindex``), just use set_index as you would in pandas.
+            import pandera as pa
 
-        >>> example_schema = pa.DataFrameSchema({"column1": pa.Column(pa.String),"column2": pa.Column(pa.Int)},
-        ...     index = Index(name = "column3", pandas_dtype = pa.Int))
-        >>> example_schema.set_index(["column2"], append = True)
-        DataFrameSchema(columns={'column1': <Schema Column: 'column1' type=string>},
-        index=MultiIndex(columns={"column3": "<Schema Column: 'column3' type=int>",
-        "column2": "<Schema Column: 'column2' type=int64>"},
-        checks=[],index=None,coerce=False,strict=False), coerce=False)
+            example_schema = pa.DataFrameSchema({
+                "category" : pa.Column(pa.String),
+                "probability": pa.Column(pa.Float)})
+
+            example_schema.set_index(['category'])
+
+        .. testoutput:: set_index_example1
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(
+                columns = {
+                    'probability': <Schema Column:'probability' type = float>},
+                index = <Schema Index: 'category'>,
+                coerce = False)
+
+        If you have an existing index in your schema, and you would like to
+        append a new column as an index to it (yielding a :class:`Multiindex`),
+        just use set_index as you would in pandas.
+
+        .. testcode:: set_index_example2
+
+            example_schema = pa.DataFrameSchema({
+                "column1": pa.Column(pa.String),
+                "column2": pa.Column(pa.Int)},
+                index = Index(name = "column3", pandas_dtype = pa.Int))
+
+            example_schema.set_index(["column2"], append = True)
+
+        .. testoutput:: set_index_example2
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(columns = {
+                    'column1': <Schema Column: 'column1' type = string>
+                },
+                index = MultiIndex(columns = {
+                        "column3": "<Schema Column: 'column3' type = int>",
+                        "column2": "<Schema Column: 'column2' type = int64>"
+                        },
+                    checks = [], index = None, coerce = False, strict = False),
+                coerce = False)
 
         .. seealso:: :func:`reset_index`
 
@@ -896,48 +1101,73 @@ class DataFrameSchema:
         self, level: List[str] = None, drop: bool = False
     ) -> "DataFrameSchema":
         """
-        A method for resetting the :class:`Index` of a :class:`DataFrameSchema`.
+        A method for resetting the :class:`Index` of a :class:`DataFrameSchema`
 
         :param level: list of labels
         :param drop: bool, default True
         :return: a new :class:`DataFrameSchema` with specified column(s) in the
             index.
-        :raises: ``SchemaInitError`` if no index set in schema.
+        :raises: :class:`~pandera.errors.SchemaInitError` if no index set in
+            schema.
         :examples:
 
-        Similar to the pandas reset_index method on a pandas DataFrame,
-        indices of a schema can be fully or partially reset.
+        Similar to the ``pandas`` reset_index method on a pandas DataFrame,
+        this method can be used to to fully or partially reset indices of a
+        schema.
 
-        To remove the entire index from the schema, just call the reset_index method with default parameters.
+        To remove the entire index from the schema, just call the reset_index
+        method with default parameters.
 
-        >>> import pandera as pa
-        >>>
-        >>> example_schema = pa.DataFrameSchema({
-        ...     "probability" : pa.Column(pa.Float)},
-        ...     index = pa.Index(name = "unique_id", \
-        ...     pandas_dtype = pa.Int))
-        >>>
-        >>> example_schema.reset_index()
-        DataFrameSchema(columns={'probability': <Schema Column: 'probability' type=float>,
-        'unique_id': <Schema Column: 'unique_id' type=int64>}, index=None, coerce=False)
+
+        .. testcode:: reset_index_example1
+
+            import pandera as pa
+
+            example_schema = pa.DataFrameSchema({
+                "probability" : pa.Column(pa.Float)},
+                index = pa.Index(name = "unique_id",
+                pandas_dtype = pa.Int))
+
+            example_schema.reset_index()
+
+
+        .. testoutput:: reset_index_example1
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(columns={
+                'probability': <Schema Column: 'probability' type = float>,
+                'unique_id': <Schema Column: 'unique_id' type = int64>},
+                index = None, coerce = False)
 
         This reclassifies an index (or indices) as a column (or columns).
 
-        Similarly, to partially alter the index, pass the name of the column you would like to be removed to
-        the ``level`` parameter.
+        Similarly, to partially alter the index, pass the name of the column
+        you would like to be removed to the ``level`` parameter, and you may
+        also decide whether to drop the levels with the ``drop`` parameter.
 
-        >>> example_schema = pa.DataFrameSchema({
-        ...     "category" : pa.Column(pa.String)},
-        ...     index = pa.MultiIndex([ \
-        ...         pa.Index(name = "unique_id1", pandas_dtype = pa.Int),\
-        ...         pa.Index(name = "unique_id2", pandas_dtype = pa.String)]))
-        >>>
-        >>> example_schema.reset_index(level = ["unique_id1"])
-        DataFrameSchema(columns={'category': <Schema Column: 'category' type=string>,
-        'unique_id1': <Schema Column: 'unique_id1' type=int64>}, index=<Schema Index: 'unique_id2'>, coerce=False)
+
+        .. testcode:: reset_index_example2
+
+            example_schema = pa.DataFrameSchema({
+                "category" : pa.Column(pa.String)},
+                index = pa.MultiIndex([
+                    pa.Index(name = "unique_id1", pandas_dtype = pa.Int),
+                    pa.Index(name = "unique_id2", pandas_dtype = pa.String)
+                    ]
+                )
+            )
+            example_schema.reset_index(level = ["unique_id1"])
+
+        .. testoutput:: reset_index_example2
+            :options: +NORMALIZE_WHITESPACE
+
+            DataFrameSchema(columns = {
+                'category': <Schema Column: 'category' type = string>,
+                'unique_id1': <Schema Column: 'unique_id1' type = int64>
+                },
+                index=<Schema Index: 'unique_id2'>, coerce = False)
 
         .. seealso:: :func:`set_index`
-
 
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
@@ -1159,8 +1389,8 @@ class SeriesSchemaBase:
             if isinstance(dtype_, type):
                 try:
                     # Convert to str here because some pandas dtypes allow
-                    # an empty constructor for compatatibility but fail on str().
-                    # e.g: PeriodDtype
+                    # an empty constructor for compatatibility but fail on
+                    # str(). e.g: PeriodDtype
                     return str(dtype_())
                 except (TypeError, AttributeError) as err:
                     raise TypeError(

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -568,6 +568,8 @@ class DataFrameSchema:
         :returns: a new ``DataFrameSchema`` with the extra_schema_cols added
         :example:
 
+        To add columns to the schema, pass a dictionary with column name and ``Column`` instance key-value pairs.
+
         >>> import pandera as pa
         >>>
         >>> example_schema = pa.DataFrameSchema({
@@ -575,7 +577,12 @@ class DataFrameSchema:
         ...     "probability": pa.Column(pa.Float)})
         >>>
         >>> example_schema.add_columns({"even_number": pa.Column(pa.Bool)})
-        DataFrameSchema(columns={'category': <Schema Column: 'category' type=string>, 'probability': <Schema Column: 'probability' type=float>, 'even_number': <Schema Column: 'even_number' type=bool>}, index=None, coerce=False)
+        DataFrameSchema(columns={'category': <Schema Column: 'category' type=string>,
+        'probability': <Schema Column: 'probability' type=float>,
+        'even_number': <Schema Column: 'even_number' type=bool>}, index=None, coerce=False)
+
+        .. seealso:: :func:`remove_columns`
+
         """
         schema_copy = copy.deepcopy(self)
         schema_copy.columns = {
@@ -591,8 +598,10 @@ class DataFrameSchema:
         :param cols_to_remove: Columns to be removed from the ``DataFrameSchema``
         :type cols_to_remove: List
         :returns: a new ``DataFrameSchema`` without the cols_to_remove
-        :raises SchemaInitError: if column not in schema.
+        :raises: SchemaInitError: if column not in schema.
         :example:
+
+        To remove a column or set of columns from a schema, pass a list of columns to be removed:
 
         >>> import pandera as pa
         >>>
@@ -602,6 +611,9 @@ class DataFrameSchema:
         >>>
         >>> example_schema.remove_columns(["category"])
         DataFrameSchema(columns={'probability': <Schema Column: 'probability' type=float>}, index=None, coerce=False)
+
+        .. seealso:: :func:`add_columns`
+
         """
         schema_copy = copy.deepcopy(self)
 
@@ -627,7 +639,7 @@ class DataFrameSchema:
         :param kwargs: key-word arguments supplied to
             :class:`~pandera.schema_components.Column`
         :returns: a new ``DataFrameSchema`` with updated column
-        :raises SchemaInitError: if column not in schema or you try to change the name.
+        :raises: SchemaInitError: if column not in schema or you try to change the name.
         :example:
 
         Calling ``schema.update_column`` returns the ``DataFrameSchema`` with the updated column.
@@ -639,15 +651,18 @@ class DataFrameSchema:
         ...     "probability": pa.Column(pa.Float)})
         >>>
         >>> example_schema.update_column("category", pandas_dtype = pa.Category)
-        DataFrameSchema(columns={'category': <Schema Column: 'category' type=category>, 'probability': <Schema Column: 'probability' type=float>}, index=None, coerce=False)
+        DataFrameSchema(columns={'category': <Schema Column: 'category' type=category>,
+        'probability': <Schema Column: 'probability' type=float>}, index=None, coerce=False)
+
+        .. seealso:: :func:`rename_columns`
 
         """
         # check that columns exist in schema
 
         if "name" in kwargs:
-            raise errors.SchemaInitError("cannot update 'name' of the column.")
+            raise ValueError("cannot update 'name' of the column.")
         if column_name not in self.columns:
-            raise errors.SchemaInitError(f"column '{column_name}' not in {self}")
+            raise ValueError(f"column '{column_name}' not in {self}")
         schema_copy = copy.deepcopy(self)
         column_copy = copy.deepcopy(self.columns[column_name])
         new_column = column_copy.__class__(
@@ -662,8 +677,11 @@ class DataFrameSchema:
         :param rename_dict: dictionary of 'old_name': 'new_name' key-value
             pairs.
         :returns: ``DataFrameSchema`` (copy of original)
-        :raises ``SchemaInitError`` if column not in the schema.
+        :raises: ``SchemaInitError`` if column not in the schema.
         :example:
+
+        To rename a column or set of columns, pass a dictionary of old column names and new column names,
+        similar to the ``pd.DataFrame`` method.
 
         >>> import pandera as pa
         >>>
@@ -672,7 +690,11 @@ class DataFrameSchema:
         ...     "probability": pa.Column(pa.Float)})
         >>>
         >>> example_schema.rename_columns({"category": "categories", "probability": "probabilities"})
-        DataFrameSchema(columns={'categories': <Schema Column: 'category' type=string>, 'probability': <Schema Column: 'probability' type=float>}, index=None, coerce=False)
+        DataFrameSchema(columns={'categories': <Schema Column: 'category' type=string>,
+        'probability': <Schema Column: 'probability' type=float>}, index=None, coerce=False)
+
+        .. seealso:: :func:`update_column`
+
         """
         new_schema = copy.deepcopy(self)
 
@@ -695,6 +717,7 @@ class DataFrameSchema:
         }
 
         new_schema.columns = new_columns
+
         return new_schema
 
     def select_columns(self, columns: List[str]) -> "DataFrameSchema":
@@ -704,8 +727,10 @@ class DataFrameSchema:
 
         :param columns: list of column names to select.
         :returns: ``DataFrameSchema`` (copy of original) with only the selected columns.
-        :raises ``SchemaInitError`` if column not in the schema.
+        :raises: ``SchemaInitError`` if column not in the schema.
         :example:
+
+        To subset a schema by column, and return a new schema:
 
         >>> import pandera as pa
         >>>
@@ -715,6 +740,9 @@ class DataFrameSchema:
         >>>
         >>> example_schema.select_columns(['category'])
         DataFrameSchema(columns={'category': <Schema Column: 'category' type=string>}, index=None, coerce=False)
+
+        .. note:: If an index is present in the schema, it will also be included in the new schema.
+
         """
 
         new_schema = copy.deepcopy(self)
@@ -774,7 +802,7 @@ class DataFrameSchema:
 
     def set_index(
         self, keys: List[str], drop: bool = True, append: bool = False
-    ):
+    ) -> "DataFrameSchema":
         """
         A method for setting the :class:`Index` of a :class:`DataFrameSchema`,
         via an existing :class:`Column` or list of :class:`Column`s.
@@ -784,8 +812,11 @@ class DataFrameSchema:
         :param append: bool, default False
         :return: a new :class:`DataFrameSchema` with specified column(s) in the
             index.
-        :raises ``SchemaInitError`` if column not in the schema.
-        :example:
+        :raises: ``SchemaInitError`` if column not in the schema.
+        :examples:
+
+        Just as you would set the index in a pandas DataFrame from an existing column, you can set an index within the
+        schema from an existing column in the schema.
 
         >>> import pandera as pa
         >>>
@@ -794,7 +825,22 @@ class DataFrameSchema:
         ...     "probability": pa.Column(pa.Float)})
         >>>
         >>> example_schema.set_index(['category'])
-        DataFrameSchema(columns={'probability': <Schema Column: 'probability' type=float>}, index=<Schema Index: 'category'>, coerce=False)
+        DataFrameSchema(columns={'probability': <Schema Column: 'probability' type=float>},
+        index=<Schema Index: 'category'>, coerce=False)
+
+        If you have an existing index in your schema, and you would like to append a new column as an index to it
+        (yielding a ``Multiindex``), just use set_index as you would in pandas.
+
+        >>> example_schema = pa.DataFrameSchema({"column1": pa.Column(pa.String),"column2": pa.Column(pa.Int)},
+        ...     index = Index(name = "column3", pandas_dtype = pa.Int))
+        >>> example_schema.set_index(["column2"], append = True)
+        DataFrameSchema(columns={'column1': <Schema Column: 'column1' type=string>},
+        index=MultiIndex(columns={"column3": "<Schema Column: 'column3' type=int>",
+        "column2": "<Schema Column: 'column2' type=int64>"},
+        checks=[],index=None,coerce=False,strict=False), coerce=False)
+
+        .. seealso:: :func:`reset_index`
+
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         from pandera.schema_components import Index, MultiIndex
@@ -846,14 +892,52 @@ class DataFrameSchema:
 
         return new_schema
 
-    def reset_index(self, level: List[str] = None, drop: bool = False):
+    def reset_index(
+        self, level: List[str] = None, drop: bool = False
+    ) -> "DataFrameSchema":
         """
-        A method for reseting the :class:`Index` of a :class:`DataFrameSchema`.
+        A method for resetting the :class:`Index` of a :class:`DataFrameSchema`.
 
         :param level: list of labels
         :param drop: bool, default True
         :return: a new :class:`DataFrameSchema` with specified column(s) in the
             index.
+        :raises: ``SchemaInitError`` if no index set in schema.
+        :examples:
+
+        Similar to the pandas reset_index method on a pandas DataFrame,
+        indices of a schema can be fully or partially reset.
+
+        To remove the entire index from the schema, just call the reset_index method with default parameters.
+
+        >>> import pandera as pa
+        >>>
+        >>> example_schema = pa.DataFrameSchema({
+        ...     "probability" : pa.Column(pa.Float)},
+        ...     index = pa.Index(name = "unique_id", \
+        ...     pandas_dtype = pa.Int))
+        >>>
+        >>> example_schema.reset_index()
+        DataFrameSchema(columns={'probability': <Schema Column: 'probability' type=float>,
+        'unique_id': <Schema Column: 'unique_id' type=int64>}, index=None, coerce=False)
+
+        This reclassifies an index (or indices) as a column (or columns).
+
+        Similarly, to partially alter the index, pass the name of the column you would like to be removed to
+        the ``level`` parameter.
+
+        >>> example_schema = pa.DataFrameSchema({
+        ...     "category" : pa.Column(pa.String)},
+        ...     index = pa.MultiIndex([ \
+        ...         pa.Index(name = "unique_id1", pandas_dtype = pa.Int),\
+        ...         pa.Index(name = "unique_id2", pandas_dtype = pa.String)]))
+        >>>
+        >>> example_schema.reset_index(level = ["unique_id1"])
+        DataFrameSchema(columns={'category': <Schema Column: 'category' type=string>,
+        'unique_id1': <Schema Column: 'unique_id1' type=int64>}, index=<Schema Index: 'unique_id2'>, coerce=False)
+
+        .. seealso:: :func:`set_index`
+
 
         """
         # pylint: disable=import-outside-toplevel,cyclic-import

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -751,7 +751,7 @@ def test_dataframe_schema_update_column(
 
 
 def test_rename_columns():
-    """Check that DataFrameSchema.rename_columns() method does it's job"""
+    """Check that DataFrameSchema.rename_columns() method does its job"""
 
     rename_dict = {"col1": "col1_new_name", "col2": "col2_new_name"}
     schema_original = DataFrameSchema(
@@ -771,6 +771,9 @@ def test_rename_columns():
     assert all(
         [col_name in schema_original.columns for col_name in rename_dict]
     )
+
+    with pytest.raises(errors.SchemaInitError):
+        schema_original.rename_columns({"foo": "bar"})
 
 
 @pytest.mark.parametrize(
@@ -805,6 +808,9 @@ def test_select_columns(select_columns, schema):
     schema_selected = schema.select_columns(select_columns)
     assert all(x in select_columns for x in schema_selected.columns)
     assert all(x in original_columns for x in schema.columns)
+
+    with pytest.raises(errors.SchemaInitError):
+        schema.select_columns(["foo", "bar"])
 
 
 def test_lazy_dataframe_validation_error():
@@ -985,7 +991,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
                 # into a Series
                 "data": pd.Series(["a", "b", "d"]),
                 "schema_errors": {
-                    "Index": {"isin(%s)" % set(["a", "b", "c"]): ["d"]},
+                    "Index": {f"isin({set(['a', 'b', 'c'])})": ["d"]},
                 },
             },
         ],

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1192,3 +1192,35 @@ def test_invalid_keys(schema_simple):
     schema_simple.index = None
     with pytest.raises(errors.SchemaInitError):
         schema_simple.reset_index()
+
+
+def test_update_columns(schema_simple):
+    """ Catch-all test for update columns functionality """
+
+    # Basic function
+    test_schema = schema_simple.update_columns({"col2": {"pandas_dtype": Int}})
+    assert (
+        schema_simple.columns["col1"].properties
+        == test_schema.columns["col1"].properties
+    )
+    assert test_schema.columns["col2"].pandas_dtype == Int
+
+    # Multiple columns, multiple properties
+    test_schema = schema_simple.update_columns(
+        {
+            "col1": {"pandas_dtype": Category, "coerce": True},
+            "col2": {"pandas_dtype": Int, "allow_duplicates": False},
+        }
+    )
+    assert test_schema.columns["col1"].pandas_dtype == Category
+    assert test_schema.columns["col1"].coerce is True
+    assert test_schema.columns["col2"].pandas_dtype == Int
+    assert test_schema.columns["col2"].allow_duplicates is False
+
+    # Errors
+    with pytest.raises(errors.SchemaInitError):
+        schema_simple.update_columns({"col3": {"pandas_dtype": Int}})
+    with pytest.raises(errors.SchemaInitError):
+        schema_simple.update_columns({"col1": {"name": "foo"}})
+    with pytest.raises(errors.SchemaInitError):
+        schema_simple.update_columns({"ind0": {"pandas_dtype": Int}})


### PR DESCRIPTION
Here is some basic documentation for the verb functions.

I also added some error handling on a few of the other functions, since for some, if you passed a non-existing column it would just return the original dataframeschema, without throwing an error.