### PR TITLE
add pandera accessor to pandas objects

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,6 +1,6 @@
 """A flexible and expressive pandas validation library."""
 
-from . import constants, errors
+from . import constants, errors, pandas_accessor
 from .checks import Check
 from .decorators import check_input, check_io, check_output, check_types
 from .dtypes import LEGACY_PANDAS, PandasDtype

--- a/pandera/pandas_accessor.py
+++ b/pandera/pandas_accessor.py
@@ -1,0 +1,58 @@
+"""Register pandas accessor for pandera schema metadata."""
+
+from typing import Optional, Union
+
+import pandas as pd
+
+from . import schemas
+
+Schemas = Union[schemas.DataFrameSchema, schemas.SeriesSchema]
+
+
+class PanderaAccessor:
+    """Pandera accessor for pandas object."""
+
+    def __init__(self, pandas_obj):
+        """Initialize the pandera accessor."""
+        self._pandas_obj = pandas_obj
+        self._schema: Optional[Schemas] = None
+
+    @staticmethod
+    def check_schema_type(schema: Schemas):
+        """Abstract method for checking the schema type."""
+        raise NotImplementedError
+
+    def add_schema(self, schema):
+        """Add a schema to the pandas object."""
+        self.check_schema_type(schema)
+        self._schema = schema
+        return self._pandas_obj
+
+    @property
+    def schema(self) -> Optional[Schemas]:
+        """Access schema metadata."""
+        return self._schema
+
+
+@pd.api.extensions.register_dataframe_accessor("pandera")
+class PanderaDataFrameAccessor(PanderaAccessor):
+    """Pandera accessor for pandas DataFrame."""
+
+    @staticmethod
+    def check_schema_type(schema):
+        if not isinstance(schema, schemas.DataFrameSchema):
+            raise TypeError(
+                f"schema arg must be a DataFrameSchema, found {type(schema)}"
+            )
+
+
+@pd.api.extensions.register_series_accessor("pandera")
+class PanderaSeriesAccessor(PanderaAccessor):
+    """Pandera accessor for pandas Series."""
+
+    @staticmethod
+    def check_schema_type(schema):
+        if not isinstance(schema, schemas.SeriesSchema):
+            raise TypeError(
+                f"schema arg must be a SeriesSchema, found {type(schema)}"
+            )

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -410,6 +410,8 @@ class DataFrameSchema:
         if not inplace:
             check_obj = check_obj.copy()
 
+        check_obj = check_obj.pandera.add_schema(self)
+
         # dataframe strictness check makes sure all columns in the dataframe
         # are specified in the dataframe schema
         if self.strict:
@@ -929,7 +931,8 @@ class SeriesSchemaBase:
         if self._pandas_dtype is dtypes.PandasDtype.Str:
             # only coerce non-null elements to string
             return series_or_index.where(
-                series_or_index.isna(), series_or_index.astype(str)
+                series_or_index.isna(),
+                series_or_index.astype(str),
             )
 
         try:
@@ -991,9 +994,8 @@ class SeriesSchemaBase:
 
         error_handler = SchemaErrorHandler(lazy)
 
-        check_obj = _pandas_obj_to_validate(
-            check_obj, head, tail, sample, random_state
-        )
+        if not inplace:
+            check_obj = check_obj.copy()
 
         series = (
             check_obj
@@ -1001,8 +1003,9 @@ class SeriesSchemaBase:
             else check_obj[self.name]
         )
 
-        if not inplace:
-            series = series.copy()
+        series = _pandas_obj_to_validate(
+            series, head, tail, sample, random_state
+        )
 
         if series.name != self._name:
             msg = "Expected %s to have name '%s', found '%s'" % (
@@ -1290,8 +1293,13 @@ class SeriesSchema(SeriesSchemaBase):
                 "expected %s, got %s" % (pd.Series, type(check_obj))
             )
 
+        if not inplace:
+            check_obj = check_obj.copy()
+
+        check_obj = check_obj.pandera.add_schema(self)
+
         if self.coerce:
-            check_obj = self.coerce_dtype(check_obj)
+            check_obj = self.coerce_dtype(check_obj).pandera.add_schema(self)
 
         if self.index is not None and (self.index.coerce or self.coerce):
             check_obj.index = self.index.coerce_dtype(check_obj.index)
@@ -1300,9 +1308,15 @@ class SeriesSchema(SeriesSchemaBase):
         if self.index:
             self.index(check_obj)
 
-        return super().validate(
-            check_obj, head, tail, sample, random_state, lazy
+        super().validate(
+            check_obj.copy(),
+            head,
+            tail,
+            sample,
+            random_state,
+            lazy,
         )
+        return check_obj
 
     def __call__(
         self,
@@ -1315,7 +1329,9 @@ class SeriesSchema(SeriesSchemaBase):
         inplace: bool = False,
     ) -> pd.Series:
         """Alias for :func:`SeriesSchema.validate` method."""
-        return self.validate(check_obj, head, tail, sample, random_state, lazy)
+        return self.validate(
+            check_obj, head, tail, sample, random_state, lazy, inplace
+        )
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -1,0 +1,41 @@
+"""Unit tests for pandas_accessor module."""
+
+import pandas as pd
+import pytest
+
+import pandera as pa
+
+
+@pytest.mark.parametrize(
+    "schema1, schema2, data",
+    [
+        [
+            pa.DataFrameSchema({"col": pa.Column(int)}, coerce=True),
+            pa.DataFrameSchema({"col": pa.Column(float)}, coerce=True),
+            pd.DataFrame({"col": [1, 2, 3]}),
+        ],
+        [
+            pa.SeriesSchema(int, coerce=True),
+            pa.SeriesSchema(float, coerce=True),
+            pd.Series([1, 2, 3]),
+        ],
+    ],
+)
+@pytest.mark.parametrize("inplace", [False, True])
+def test_dataframe_series_add_schema(schema1, schema2, data, inplace):
+    """
+    Test that pandas object contains schema metadata after pandera validation.
+    """
+    validated_data_1 = schema1(data, inplace=inplace)
+    if inplace:
+        assert data.pandera.schema == schema1
+    else:
+        assert data.pandera.schema is None
+    assert validated_data_1.pandera.schema == schema1
+
+    validated_data_2 = schema2(validated_data_1, inplace=inplace)
+    if inplace:
+        assert validated_data_1.pandera.schema == schema2
+    else:
+        assert validated_data_1.pandera.schema == schema1
+    assert validated_data_2.pandera.schema == schema2


### PR DESCRIPTION
this PR adds a `pandas_obj.pandera` accessor to DataFrames and Series objects
to make it easier to inspect pandas objects that have been validated with a pandera
schema