### PR TITLE
fix error in way schema errors are raised in check_types

### DIFF
--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -502,7 +502,7 @@ def check_types(
                     out, head, tail, sample, random_state, lazy, inplace
                 )
             except errors.SchemaError as e:
-                _handle_schema_error("check_types", wrapped, out, "return", e)
+                _handle_schema_error("check_types", wrapped, schema, out, e)
 
         return out
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -507,6 +507,12 @@ def test_check_types_error_input():
     ):
         transform(df)
 
+    try:
+        transform(df)
+    except errors.SchemaError as exc:
+        assert exc.schema == InSchema.to_schema()
+        assert exc.data.equals(df)
+
 
 @pytest.mark.parametrize("out_schema_cls", [DerivedOutSchema, OutSchema])
 def test_check_types_error_output(out_schema_cls):
@@ -522,6 +528,12 @@ def test_check_types_error_output(out_schema_cls):
         errors.SchemaError, match="column 'b' not in dataframe"
     ):
         transform(df)
+
+    try:
+        transform(df)
+    except errors.SchemaError as exc:
+        assert exc.schema == out_schema_cls.to_schema()
+        assert exc.data.equals(df)
 
 
 @pytest.mark.parametrize("out_schema_cls", [DerivedOutSchema, OutSchema])


### PR DESCRIPTION
this PR fixes an bug in the way SchemError was being raised in the `check_types` decorator.