### PR TITLE
bugfix/lazy-error-dtype-coercion

### DIFF
--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -105,7 +105,7 @@ of all schemas and schema components gives you the option of doing just this:
     try:
         schema.validate(dataframe, lazy=True)
     except SchemaErrors as err:
-        err.schema_errors  # dataframe of schema errors
+        err.failure_cases  # dataframe of schema errors
         err.data  # invalid dataframe
     ```
 
@@ -122,7 +122,7 @@ catch these errors and inspect the failure cases in a more granular form:
         schema.validate(df, lazy=True)
     except pa.errors.SchemaErrors as err:
         print("Schema errors and failure cases:")
-        print(err.schema_errors.head())
+        print(err.failure_cases.head())
         print("\nDataFrame object that failed validation:")
         print(err.data.head())
 

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -152,7 +152,7 @@ class _CheckBase:
         ...     columns={
         ...         "measure_1": pa.Column(pa.Int, checks=measure_checks),
         ...         "measure_2": pa.Column(pa.Int, checks=measure_checks),
-        ...         "group": pa.Column(pa.String),
+        ...         "group": pa.Column(pa.Str),
         ...     },
         ...     checks=check_dataframe
         ... )

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -82,7 +82,7 @@ class PandasDtype(Enum):
     1    2.3
     2    3.4
     dtype: float64
-    >>> pa.SeriesSchema(pa.String).validate(pd.Series(["a", "b", "c"]))
+    >>> pa.SeriesSchema(pa.Str).validate(pd.Series(["a", "b", "c"]))
         0    a
     1    b
     2    c

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -60,7 +60,7 @@ Directly inspect all errors by catching the exception:
 try:
     schema.validate(dataframe, lazy=True)
 except SchemaErrors as err:
-    err.schema_errors  # dataframe of schema errors
+    err.failure_cases  # dataframe of schema errors
     err.data  # invalid dataframe
 ```
 """
@@ -78,6 +78,11 @@ class SchemaErrors(Exception):
         self.error_counts = error_counts
         self.schema_errors = schema_errors
         self.data = data
+
+    @property
+    def failure_cases(self):
+        """Get all failure cases."""
+        return self.schema_errors
 
     @staticmethod
     def _message(error_counts, schema_errors):

--- a/pandera/hypotheses.py
+++ b/pandera/hypotheses.py
@@ -126,7 +126,7 @@ class Hypothesis(_CheckBase):
         ...             relationship_kwargs={"alpha": 0.05}
         ...         )
         ...     ]),
-        ...     "group": pa.Column(pa.String),
+        ...     "group": pa.Column(pa.Str),
         ... })
         >>> df = (
         ...     pd.DataFrame({
@@ -307,7 +307,7 @@ class Hypothesis(_CheckBase):
         ...                 alpha=0.05,
         ...                 equal_var=True),
         ...     ]),
-        ...     "group": pa.Column(pa.String)
+        ...     "group": pa.Column(pa.Str)
         ... })
         >>> df = (
         ...     pd.DataFrame({

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -46,8 +46,7 @@ def _inferred_schema_guard(method):
             # the original schema instance and the copy should be set to
             # not inferred.
             new_schema._is_inferred = False
-            return new_schema
-        schema._is_inferred = False
+        return new_schema
 
     return _wrapper
 
@@ -878,10 +877,6 @@ class SeriesSchemaBase:
     @property
     def checks(self):
         """Return list of checks or hypotheses."""
-        if self._checks is None:
-            return []
-        if isinstance(self._checks, (Check, Hypothesis)):
-            return [self._checks]
         return self._checks
 
     @checks.setter
@@ -983,7 +978,7 @@ class SeriesSchemaBase:
     @property
     def _allow_groupby(self):
         """Whether the schema or schema component allows groupby operations."""
-        raise NotImplementedError(
+        raise NotImplementedError(  # pragma: no cover
             "The _allow_groupby property must be implemented by subclasses "
             "of SeriesSchemaBase"
         )

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1331,9 +1331,9 @@ class SeriesSchema(SeriesSchemaBase):
 
         if self.coerce:
             try:
-                check_obj = self.coerce_dtype(
-                    check_obj
-                ).pandera.add_schema(self)
+                check_obj = self.coerce_dtype(check_obj).pandera.add_schema(
+                    self
+                )
             except errors.SchemaError as exc:
                 error_handler.collect_error("dtype_coercion_error", exc)
 
@@ -1345,8 +1345,15 @@ class SeriesSchema(SeriesSchemaBase):
 
         # validate index
         if self.index:
-            self.index(check_obj)
+            try:
+                self.index(check_obj, head, tail, sample, random_state, lazy)
+            except errors.SchemaErrors as err:
+                for schema_error_dict in err._schema_error_dicts:
+                    error_handler.collect_error(
+                        "index_check", schema_error_dict["error"]
+                    )
 
+        # validate series
         try:
             super().validate(check_obj, head, tail, sample, random_state, lazy)
         except errors.SchemaErrors as err:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -138,6 +138,7 @@ def test_dataframe_pandas_dtype_coerce():
         pandas_dtype=int,
         coerce=True,
     )
+
     df = pd.DataFrame({f"column_{i}": range(10) for i in range(5)}).astype(
         float
     )
@@ -150,6 +151,10 @@ def test_dataframe_pandas_dtype_coerce():
     # raises SchemeError if dataframe can't be coerced
     with pytest.raises(errors.SchemaErrors):
         schema.coerce_dtype(pd.DataFrame({"foo": list("abcdef")}))
+
+    # raises SchemaErrors on lazy validation
+    with pytest.raises(errors.SchemaErrors):
+        schema(pd.DataFrame({"foo": list("abcdef")}), lazy=True)
 
     # test that original dataframe dtypes are preserved
     assert (df.dtypes == Float.str_alias).all()
@@ -165,6 +170,39 @@ def test_dataframe_pandas_dtype_coerce():
     schema.pandas_dtype = None
     with pytest.raises(ValueError):
         schema._coerce_dtype(df)
+
+
+def test_dataframe_coerce_regex():
+    """Test dataframe pandas dtype coercion for regex columns"""
+    schema = DataFrameSchema(
+        columns={"column_": Column(float, regex=True, required=False)},
+        pandas_dtype=int,
+        coerce=True,
+    )
+
+    no_match_df = pd.DataFrame({"foo": [1, 2, 3]})
+    match_valid_df = pd.DataFrame(
+        {
+            "column_1": [1, 2, 3],
+            "column_2": ["1", "2", "3"],
+        }
+    )
+
+    schema(no_match_df)
+    schema(match_valid_df)
+
+    # if the regex column is required, no matches should raise an error
+    schema_required = schema.update_column("column_", required=True)
+    with pytest.raises(
+        errors.SchemaError, match="Column regex name='column_' did not match"
+    ):
+        schema_required(no_match_df)
+
+
+def test_dataframe_reset_column_name():
+    """Test resetting column name at DataFrameSchema init on named column."""
+    with pytest.warns(UserWarning):
+        DataFrameSchema(columns={"new_name": Column(name="old_name")})
 
 
 def test_series_schema():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -148,7 +148,7 @@ def test_dataframe_pandas_dtype_coerce():
         assert col.pandas_dtype is float
 
     # raises SchemeError if dataframe can't be coerced
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         schema.coerce_dtype(pd.DataFrame({"foo": list("abcdef")}))
 
     # test that original dataframe dtypes are preserved


### PR DESCRIPTION
This PR fixes a bug discussed in #338 where lazy validation wasn't correctly capturing data type coercion errors. Now these errors should be captured during lazy validation, where a `SchemaErrors` exception should be raised instead of `SchemaError`.

- update docs to use `pa.Str`
- add a `failure_cases` attribute to `SchemaErrors` for a more consistent API