### PR TITLE
feature/str-dtype: introduce PandasDtype.STRING for pandas-native str type

### DIFF
--- a/docs/source/checks.rst
+++ b/docs/source/checks.rst
@@ -31,7 +31,7 @@ Multiple checks can be applied to a column:
 .. testcode:: checks
 
   schema = pa.DataFrameSchema({
-      "column2": pa.Column(pa.Str, [
+      "column2": pa.Column(pa.String, [
           pa.Check(lambda s: s.str.startswith("value")),
           pa.Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
       ]),
@@ -50,7 +50,7 @@ For common validation tasks, built-in checks are available in ``pandera``.
   schema = DataFrameSchema({
       "small_values": Column(pa.Float, Check.less_than(100)),
       "one_to_three": Column(pa.Int, Check.isin([1, 2, 3])),
-      "phone_number": Column(pa.Str, Check.str_matches(r'^[a-z0-9-]+$')),
+      "phone_number": Column(pa.String, Check.str_matches(r'^[a-z0-9-]+$')),
   })
 
 See the :class:`~pandera.checks.Check` API reference for a complete list of built-in checks.
@@ -159,7 +159,7 @@ fly.
             ]),
         "age": pa.Column(pa.Int, pa.Check(lambda s: s > 0)),
         "age_less_than_20": pa.Column(pa.Bool),
-        "sex": pa.Column(pa.Str, pa.Check(lambda s: s.isin(["M", "F"])))
+        "sex": pa.Column(pa.String, pa.Check(lambda s: s.isin(["M", "F"])))
     })
 
     df = (
@@ -203,7 +203,7 @@ columns in a ``DataFrame``. For example, if you want to make assertions about
             pa.Float,
             pa.Check(lambda g: g["A"].mean() < g["B"].mean(), groupby="group")
         ),
-        "group": pa.Column(pa.Str)
+        "group": pa.Column(pa.String)
     })
 
     schema.validate(df)

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -28,7 +28,7 @@ The ``DataFrameSchema`` object consists of |column|_\s and an |index|_.
             "column1": Column(pa.Int),
             "column2": Column(pa.Float, Check(lambda s: s < -1.2)),
             # you can provide a list of validators
-            "column3": Column(pa.Str, [
+            "column3": Column(pa.String, [
                Check(lambda s: s.str.startswith("value")),
                Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
             ]),
@@ -131,7 +131,7 @@ checks.
     from pandera import Column, DataFrameSchema
 
     df = pd.DataFrame({"column1": [1, 2, 3]})
-    schema = DataFrameSchema({"column1": Column(pa.Str, coerce=True)})
+    schema = DataFrameSchema({"column1": Column(pa.String, coerce=True)})
 
     validated_df = schema.validate(df)
     assert isinstance(validated_df.column1.iloc[0], str)
@@ -203,7 +203,7 @@ in the column constructor:
    df = pd.DataFrame({"column2": ["hello", "pandera"]})
    schema = DataFrameSchema({
        "column1": Column(pa.Int, required=False),
-       "column2": Column(pa.Str)
+       "column2": Column(pa.String)
    })
 
    validated_df = schema.validate(df)
@@ -222,7 +222,7 @@ Since ``required=True`` by default, missing columns would raise an error:
 
     schema = DataFrameSchema({
         "column1": Column(pa.Int),
-        "column2": Column(pa.Str),
+        "column2": Column(pa.String),
     })
 
     schema.validate(df)
@@ -256,7 +256,7 @@ objects can also be used to validate columns in a dataframe on its own:
     })
 
     column1_schema = pa.Column(pa.Int, name="column1")
-    column2_schema = pa.Column(pa.Str, name="column2")
+    column2_schema = pa.Column(pa.String, name="column2")
 
     # pass the dataframe as an argument to the Column object callable
     df = column1_schema(df)
@@ -414,7 +414,7 @@ You can also specify an :class:`~pandera.schema_components.Index` in the :class:
     schema = DataFrameSchema(
        columns={"a": Column(pa.Int)},
        index=Index(
-           pa.Str,
+           pa.String,
            Check(lambda x: x.str.startswith("index_"))))
 
     df = pd.DataFrame(
@@ -475,7 +475,7 @@ tuples for each level in the index hierarchy:
 
     schema = DataFrameSchema({
         ("foo", "bar"): Column(pa.Int),
-        ("foo", "baz"): Column(pa.Str)
+        ("foo", "baz"): Column(pa.String)
     })
 
     df = pd.DataFrame({
@@ -512,7 +512,7 @@ indexes by composing a list of ``pandera.Index`` objects.
   schema = DataFrameSchema(
       columns={"column1": Column(pa.Int)},
       index=MultiIndex([
-          Index(pa.Str,
+          Index(pa.String,
                 Check(lambda s: s.isin(["foo", "bar"])),
                 name="index0"),
           Index(pa.Int, name="index1"),
@@ -607,7 +607,7 @@ on a dataframe, therefore requiring additional checks.
         strict=True)
 
     transformed_schema = schema.add_columns({
-        "col2": pa.Column(pa.Str, pa.Check(lambda s: s == "value")),
+        "col2": pa.Column(pa.String, pa.Check(lambda s: s == "value")),
         "col3": pa.Column(pa.Float, pa.Check(lambda x: x == 0.0)),
     })
 
@@ -642,7 +642,7 @@ data pipeline:
     schema = pa.DataFrameSchema(
         columns={
             "col1": pa.Column(pa.Int, pa.Check(lambda s: s >= 0)),
-            "col2": pa.Column(pa.Str, pa.Check(lambda x: x <= 0)),
+            "col2": pa.Column(pa.String, pa.Check(lambda x: x <= 0)),
             "col3": pa.Column(pa.Object, pa.Check(lambda x: x == 0)),
         },
         strict=True,

--- a/docs/source/hypothesis.rst
+++ b/docs/source/hypothesis.rst
@@ -48,7 +48,7 @@ which can be called as in this example of a two-sample t-test:
                     alpha=0.05,
                     equal_var=True),
         ]),
-        "sex": Column(pa.Str)
+        "sex": Column(pa.String)
     })
 
     schema.validate(df)
@@ -99,7 +99,7 @@ Here's an implementation of the two-sample t-test that uses the
                     relationship_kwargs={"alpha": 0.05}
                 )
         ]),
-        "sex": Column(pa.Str, checks=Check.isin(["M", "F"]))
+        "sex": Column(pa.String, checks=Check.isin(["M", "F"]))
     })
 
     schema.validate(df)
@@ -139,7 +139,7 @@ the tidy dataset and schema might look like this:
                 alpha=0.05
             )
         ),
-        "group": Column(pa.Str, Check(lambda s: s.isin(["A", "B"])))
+        "group": Column(pa.String, Check(lambda s: s.isin(["A", "B"])))
     })
 
     schema.validate(df)

--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -59,7 +59,7 @@ of all schemas and schema components gives you the option of doing just this:
         columns={
             "int_column": Column(pa.Int),
             "float_column": Column(pa.Float, Check.greater_than(0)),
-            "str_column": Column(pa.Str, Check.equal_to("a")),
+            "str_column": Column(pa.String, Check.equal_to("a")),
             "date_column": Column(pa.DateTime),
         },
         strict=True

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -119,7 +119,7 @@ You can also write your schema to a python script with :func:`~pandera.io.to_scr
                 regex=False,
             ),
             "column2": Column(
-                pandas_dtype=PandasDtype.Str,
+                pandas_dtype=PandasDtype.String,
                 checks=None,
                 nullable=False,
                 allow_duplicates=True,

--- a/docs/source/series_schemas.rst
+++ b/docs/source/series_schemas.rst
@@ -20,7 +20,7 @@ The :class:`~pandera.schemas.SeriesSchema` class allows for the validation of pa
 
     # specify multiple validators
     schema = pa.SeriesSchema(
-        pa.Str,
+        pa.String,
         checks=[
             pa.Check(lambda s: s.str.startswith("foo")),
             pa.Check(lambda s: s.str.endswith("bar")),

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -38,6 +38,6 @@ UINT16 = PandasDtype.UINT16
 UINT32 = PandasDtype.UINT32
 UINT64 = PandasDtype.UINT64
 Object = PandasDtype.Object
-Str = PandasDtype.Str
 String = PandasDtype.String
+STRING = PandasDtype.STRING
 Timedelta = PandasDtype.Timedelta

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -152,7 +152,7 @@ class _CheckBase:
         ...     columns={
         ...         "measure_1": pa.Column(pa.Int, checks=measure_checks),
         ...         "measure_2": pa.Column(pa.Int, checks=measure_checks),
-        ...         "group": pa.Column(pa.Str),
+        ...         "group": pa.Column(pa.String),
         ...     },
         ...     checks=check_dataframe
         ... )

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -324,7 +324,7 @@ class PandasDtype(Enum):
         if isinstance(other, str):
             other = self.from_str_alias(other)
         if self.value == "string" and LEGACY_PANDAS:
-            return PandasDtype.Str.value == other.value
+            return PandasDtype.String.value == other.value
         elif self.value == "string":
             return self.value == other.value
         return self.str_alias == other.str_alias

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -82,7 +82,7 @@ class PandasDtype(Enum):
     1    2.3
     2    3.4
     dtype: float64
-    >>> pa.SeriesSchema(pa.Str).validate(pd.Series(["a", "b", "c"]))
+    >>> pa.SeriesSchema(pa.String).validate(pd.Series(["a", "b", "c"]))
         0    a
     1    b
     2    c
@@ -149,11 +149,11 @@ class PandasDtype(Enum):
     Complex64 = "complex64"  #: ``"complex"`` numpy dtype
     Complex128 = "complex128"  #: ``"complex"`` numpy dtype
     Complex256 = "complex256"  #: ``"complex"`` numpy dtype
-    Str = "str"  #: ``"str"`` numpy dtype
+    String = "str"  #: ``"str"`` numpy dtype
 
     #: ``"string"`` pandas dtypes: pandas 1.0.0+. For <1.0.0, this enum will
     #: fall back on the str-as-object-array representation.
-    String = "string"
+    STRING = "string"
 
     @property
     def str_alias(self):
@@ -205,8 +205,8 @@ class PandasDtype(Enum):
             "complex64": cls.Complex64,
             "complex128": cls.Complex128,
             "complex256": cls.Complex256,
-            "str": cls.Str,
-            "string": cls.Str if LEGACY_PANDAS else cls.String,
+            "str": cls.String,
+            "string": cls.String if LEGACY_PANDAS else cls.STRING,
         }.get(str_alias)
 
         if pandas_dtype is None:
@@ -228,7 +228,7 @@ class PandasDtype(Enum):
             return cls.Object
 
         pandas_dtype = {
-            "string": cls.Str,
+            "string": cls.String,
             "floating": cls.Float,
             "integer": cls.Int,
             "categorical": cls.Category,
@@ -255,7 +255,7 @@ class PandasDtype(Enum):
         """
         pandas_dtype = {
             bool: cls.Bool,
-            str: cls.Str,
+            str: cls.String,
             int: cls.Int,
             float: cls.Float,
             object: cls.Object,
@@ -402,7 +402,7 @@ class PandasDtype(Enum):
     @property
     def is_string(self) -> bool:
         """Return True if PandasDtype is a string."""
-        return self in [PandasDtype.Str, PandasDtype.String]
+        return self in [PandasDtype.String, PandasDtype.STRING]
 
     @property
     def is_category(self) -> bool:

--- a/pandera/hypotheses.py
+++ b/pandera/hypotheses.py
@@ -126,7 +126,7 @@ class Hypothesis(_CheckBase):
         ...             relationship_kwargs={"alpha": 0.05}
         ...         )
         ...     ]),
-        ...     "group": pa.Column(pa.Str),
+        ...     "group": pa.Column(pa.String),
         ... })
         >>> df = (
         ...     pd.DataFrame({
@@ -307,7 +307,7 @@ class Hypothesis(_CheckBase):
         ...                 alpha=0.05,
         ...                 equal_var=True),
         ...     ]),
-        ...     "group": pa.Column(pa.Str)
+        ...     "group": pa.Column(pa.String)
         ... })
         >>> df = (
         ...     pd.DataFrame({

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -64,7 +64,7 @@ class Column(SeriesSchemaBase):
         >>>
         >>>
         >>> schema = pa.DataFrameSchema({
-        ...     "column": pa.Column(pa.Str)
+        ...     "column": pa.Column(pa.String)
         ... })
         >>>
         >>> schema.validate(pd.DataFrame({"column": ["foo", "bar"]}))
@@ -429,7 +429,7 @@ class MultiIndex(DataFrameSchema):
         >>> schema = pa.DataFrameSchema(
         ...     columns={"column": pa.Column(pa.Int)},
         ...     index=pa.MultiIndex([
-        ...         pa.Index(pa.Str,
+        ...         pa.Index(pa.String,
         ...               pa.Check(lambda s: s.isin(["foo", "bar"])),
         ...               name="index0"),
         ...         pa.Index(pa.Int, name="index1"),

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -94,7 +94,7 @@ class DataFrameSchema:
         >>> import pandera as pa
         >>>
         >>> schema = pa.DataFrameSchema({
-        ...     "str_column": pa.Column(pa.Str),
+        ...     "str_column": pa.Column(pa.String),
         ...     "float_column": pa.Column(pa.Float),
         ...     "int_column": pa.Column(pa.Int),
         ...     "date_column": pa.Column(pa.DateTime),
@@ -113,7 +113,7 @@ class DataFrameSchema:
         ...     # check that the "category" column contains a few discrete
         ...     # values, and the majority of the entries are dogs.
         ...     "category": pa.Column(
-        ...         pa.Str, [
+        ...         pa.String, [
         ...             pa.Check(lambda s: s.isin(["dog", "cat", "duck"])),
         ...             pa.Check(lambda s: (s == "dog").mean() > 0.5),
         ...         ]),
@@ -275,7 +275,7 @@ class DataFrameSchema:
         )
 
     def _coerce_dtype(self, obj: pd.DataFrame) -> pd.DataFrame:
-        if self.pandas_dtype is dtypes.PandasDtype.Str:
+        if self.pandas_dtype is dtypes.PandasDtype.String:
             # only coerce non-null elements to string
             return obj.where(obj.isna(), obj.astype(str))
 
@@ -397,7 +397,7 @@ class DataFrameSchema:
         ...     # check that the "category" column contains a few discrete
         ...     # values, and the majority of the entries are dogs.
         ...     "category": pa.Column(
-        ...         pa.Str, [
+        ...         pa.String, [
         ...             pa.Check(lambda s: s.isin(["dog", "cat", "duck"])),
         ...             pa.Check(lambda s: (s == "dog").mean() > 0.5),
         ...         ]),
@@ -952,7 +952,7 @@ class SeriesSchemaBase:
             (including time series).
         :returns: ``Series`` with coerced data type
         """
-        if self._pandas_dtype is dtypes.PandasDtype.Str:
+        if self._pandas_dtype is dtypes.PandasDtype.String:
             # only coerce non-null elements to string
             return series_or_index.where(
                 series_or_index.isna(),

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -49,8 +49,8 @@ GenericDtype = TypeVar(  # type: ignore
     Literal[PandasDtype.UINT32],
     Literal[PandasDtype.UINT64],
     Literal[PandasDtype.Object],
-    Literal[PandasDtype.Str],
     Literal[PandasDtype.String],
+    Literal[PandasDtype.STRING],
     Literal[PandasDtype.Timedelta],
     covariant=True,
 )
@@ -182,8 +182,8 @@ UINT64 = Literal[
 ]  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
 Object = Literal[PandasDtype.Object]  #: ``"object"`` numpy dtype
 
-Str = Literal[PandasDtype.Str]  #: ``"str"`` numpy dtype
+String = Literal[PandasDtype.String]  #: ``"str"`` numpy dtype
 
 #: ``"string"`` pandas dtypes: pandas 1.0.0+. For <1.0.0, this enum will
 #: fall back on the str-as-object-array representation.
-String = Literal[PandasDtype.String]
+STRING = Literal[PandasDtype.STRING]  #: ``"str"`` numpy dtype

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -14,7 +14,7 @@ from pandera import (
     Index,
     Int,
     SeriesSchema,
-    Str,
+    String,
     error_formatters,
     errors,
 )
@@ -53,7 +53,7 @@ def test_check_groupby():
                     ),
                 ],
             ),
-            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
         },
         index=Index(Int, name="data_id"),
     )
@@ -113,7 +113,7 @@ def test_check_groupby_multiple_columns():
                     ),
                 ],
             ),
-            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
             "col3": Column(Bool),
         }
     )
@@ -147,7 +147,7 @@ def test_check_groups():
                     ),
                 ],
             ),
-            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
         }
     )
 
@@ -174,7 +174,7 @@ def test_check_groups():
                     ),
                 ],
             ),
-            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
         }
     )
     with pytest.raises(
@@ -195,7 +195,7 @@ def test_check_groups():
                     ),
                 ],
             ),
-            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
         }
     )
     with pytest.raises(
@@ -215,7 +215,7 @@ def test_check_groups():
                     ),
                 ],
             ),
-            "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
+            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
         }
     )
     with pytest.raises(errors.SchemaError):
@@ -239,7 +239,9 @@ def test_groupby_init_exceptions():
                         ),
                     ],
                 ),
-                "col2": Column(Str, Check(lambda s: s.isin(["foo", "bar"]))),
+                "col2": Column(
+                    String, Check(lambda s: s.isin(["foo", "bar"]))
+                ),
             }
         )
 
@@ -283,8 +285,8 @@ def test_dataframe_checks():
         columns={
             "col1": Column(Int),
             "col2": Column(Float),
-            "col3": Column(Str),
-            "col4": Column(Str),
+            "col3": Column(String),
+            "col4": Column(String),
         },
         checks=[
             Check(lambda df: df["col1"] < df["col2"]),
@@ -313,7 +315,7 @@ def test_dataframe_checks():
     groupby_check_schema = DataFrameSchema(
         columns={
             "col1": Column(Int),
-            "col3": Column(Str),
+            "col3": Column(String),
         },
         checks=[
             Check(lambda g: g["foo"]["col1"].iat[0] == 1, groupby="col3"),

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -15,7 +15,7 @@ from pandera import (
     Float,
     Int,
     SchemaModel,
-    Str,
+    String,
     check_input,
     check_io,
     check_output,
@@ -40,7 +40,7 @@ def test_check_function_decorators():
                 ],
             ),
             "b": Column(
-                Str,
+                String,
                 Check(lambda x: x in ["x", "y", "z"], element_wise=True),
             ),
             "c": Column(
@@ -59,9 +59,9 @@ def test_check_function_decorators():
     )
     out_schema = DataFrameSchema(
         {
-            "e": Column(Str, Check(lambda s: s == "foo")),
+            "e": Column(String, Check(lambda s: s == "foo")),
             "f": Column(
-                Str, Check(lambda x: x in ["a", "b"], element_wise=True)
+                String, Check(lambda x: x in ["a", "b"], element_wise=True)
             ),
         }
     )
@@ -189,7 +189,7 @@ def test_check_function_decorator_errors():
 def test_check_input_method_decorators():
     """Test the check_input and check_output decorator behaviours when the
     dataframe is changed within the function being checked"""
-    in_schema = DataFrameSchema({"column1": Column(Str)})
+    in_schema = DataFrameSchema({"column1": Column(String)})
     out_schema = DataFrameSchema({"column2": Column(Int)})
     dataframe = pd.DataFrame({"column1": ["a", "b", "c"]})
 

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -403,7 +403,7 @@ def test_python_builtin_types():
     assert isinstance(schema(df), pd.DataFrame)
     assert schema.dtype["int_col"] == PandasDtype.Int.str_alias
     assert schema.dtype["float_col"] == PandasDtype.Float.str_alias
-    assert schema.dtype["str_col"] == PandasDtype.Str.str_alias
+    assert schema.dtype["str_col"] == PandasDtype.String.str_alias
     assert schema.dtype["bool_col"] == PandasDtype.Bool.str_alias
     assert schema.dtype["object_col"] == PandasDtype.Object.str_alias
     assert schema.dtype["complex_col"] == PandasDtype.Complex.str_alias
@@ -419,7 +419,7 @@ def test_python_builtin_types_not_supported(python_type):
 @pytest.mark.parametrize(
     "pandas_api_type,pandas_dtype",
     [
-        ["string", PandasDtype.Str],
+        ["string", PandasDtype.String],
         ["floating", PandasDtype.Float],
         ["integer", PandasDtype.Int],
         ["categorical", PandasDtype.Category],
@@ -552,7 +552,7 @@ def test_dtype_none_comparison(pdtype):
             ],
         ],
         [lambda x: x.is_bool, [PandasDtype.Bool]],
-        [lambda x: x.is_string, [PandasDtype.Str, PandasDtype.String]],
+        [lambda x: x.is_string, [PandasDtype.String, PandasDtype.String]],
         [lambda x: x.is_category, [PandasDtype.Category]],
         [lambda x: x.is_datetime, [PandasDtype.DateTime]],
         [lambda x: x.is_timedelta, [PandasDtype.Timedelta]],

--- a/tests/test_hypotheses.py
+++ b/tests/test_hypotheses.py
@@ -9,7 +9,7 @@ from pandera import (
     Float,
     Hypothesis,
     Int,
-    Str,
+    String,
     errors,
 )
 from pandera.hypotheses import HAS_SCIPY
@@ -114,7 +114,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(Str),
+            "sex": Column(String),
         }
     )
 
@@ -132,7 +132,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(Str),
+            "sex": Column(String),
         }
     )
 
@@ -150,7 +150,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(Str),
+            "sex": Column(String),
         }
     )
 
@@ -170,7 +170,7 @@ def test_hypothesis():
                     )
                 ],
             ),
-            "sex": Column(Str),
+            "sex": Column(String),
         }
     )
 
@@ -194,7 +194,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(Str),
+            "sex": Column(String),
         }
     )
 
@@ -212,7 +212,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(Str),
+            "sex": Column(String),
         }
     )
 
@@ -230,7 +230,7 @@ def test_hypothesis():
                     ),
                 ],
             ),
-            "sex": Column(Str),
+            "sex": Column(String),
         }
     )
 
@@ -259,7 +259,7 @@ def test_two_sample_ttest_hypothesis_relationships():
                         ),
                     ],
                 ),
-                "sex": Column(Str),
+                "sex": Column(String),
             }
         )
         assert isinstance(schema, DataFrameSchema)
@@ -280,7 +280,7 @@ def test_two_sample_ttest_hypothesis_relationships():
                             ),
                         ],
                     ),
-                    "sex": Column(Str),
+                    "sex": Column(String),
                 }
             )
 
@@ -302,7 +302,7 @@ def test_one_sample_hypothesis():
 
     subset_schema = DataFrameSchema(
         {
-            "group": Column(Str),
+            "group": Column(String),
             "height_in_feet": Column(
                 Float,
                 [

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -137,7 +137,7 @@ columns:
     required: true
     regex: false
   str_column:
-    pandas_dtype: string
+    pandas_dtype: str
     nullable: false
     checks:
       isin:
@@ -173,7 +173,7 @@ columns:
     required: true
     regex: false
   optional_props_column:
-    pandas_dtype: string
+    pandas_dtype: str
     nullable: true
     checks:
       str_length:
@@ -234,7 +234,7 @@ columns:
         min_value: -10
         max_value: 20
   str_column:
-    pandas_dtype: string
+    pandas_dtype: str
     nullable: false
     checks:
       isin:

--- a/tests/test_schema_components.py
+++ b/tests/test_schema_components.py
@@ -16,7 +16,6 @@ from pandera import (
     Int,
     MultiIndex,
     Object,
-    Str,
     String,
     errors,
 )
@@ -35,7 +34,7 @@ def test_column():
 
     column_a = Column(Int, name="a")
     column_b = Column(Float, name="b")
-    column_c = Column(Str, name="c")
+    column_c = Column(String, name="c")
 
     assert isinstance(
         data.pipe(column_a).pipe(column_b).pipe(column_c), pd.DataFrame
@@ -92,7 +91,7 @@ def test_index_schema():
         schema.validate(pd.DataFrame(index=range(1, 20)))
 
 
-@pytest.mark.parametrize("pdtype", [Float, Int, Str, String])
+@pytest.mark.parametrize("pdtype", [Float, Int, String, String])
 def test_index_schema_coerce(pdtype):
     """Test that index can be type-coerced."""
     schema = DataFrameSchema(index=Index(pdtype, coerce=True))
@@ -112,7 +111,7 @@ def test_multi_index_columns():
         {
             ("zero", "foo"): Column(Float, Check(lambda s: (s > 0) & (s < 1))),
             ("zero", "bar"): Column(
-                Str, Check(lambda s: s.isin(["a", "b", "c", "d"]))
+                String, Check(lambda s: s.isin(["a", "b", "c", "d"]))
             ),
             ("one", "foo"): Column(Int, Check(lambda s: (s > 0) & (s < 10))),
             ("one", "bar"): Column(
@@ -144,7 +143,7 @@ def test_multi_index_index():
             indexes=[
                 Index(Int, Check(lambda s: (s < 5) & (s >= 0)), name="index0"),
                 Index(
-                    Str,
+                    String,
                     Check(lambda s: s.isin(["foo", "bar"])),
                     name="index1",
                 ),
@@ -181,7 +180,7 @@ def test_multi_index_schema_coerce():
     indexes = [
         Index(Float),
         Index(Int),
-        Index(Str),
+        Index(String),
     ]
     schema = DataFrameSchema(index=MultiIndex(indexes=indexes))
     df = pd.DataFrame(
@@ -204,10 +203,10 @@ def test_multi_index_schema_coerce():
 def tests_multi_index_subindex_coerce():
     """MultIndex component should override sub indexes."""
     indexes = [
-        Index(Str, coerce=True),
-        Index(Str, coerce=False),
-        Index(Str, coerce=True),
-        Index(Str, coerce=False),
+        Index(String, coerce=True),
+        Index(String, coerce=False),
+        Index(String, coerce=True),
+        Index(String, coerce=False),
     ]
 
     data = pd.DataFrame(index=pd.MultiIndex.from_arrays([[1, 2, 3, 4]] * 4))
@@ -246,7 +245,9 @@ def test_schema_component_equality_operators():
     multi_index = MultiIndex(
         indexes=[
             Index(Int, Check(lambda s: (s < 5) & (s >= 0)), name="index0"),
-            Index(Str, Check(lambda s: s.isin(["foo", "bar"])), name="index1"),
+            Index(
+                String, Check(lambda s: s.isin(["foo", "bar"])), name="index1"
+            ),
         ]
     )
     not_equal_schema = DataFrameSchema(

--- a/tests/test_schema_statistics.py
+++ b/tests/test_schema_statistics.py
@@ -61,13 +61,13 @@ def test_infer_dataframe_statistics(multi_index, nullable):
         assert stat_columns["boolean"]["pandas_dtype"] is pa.Bool
 
     assert stat_columns["float"]["pandas_dtype"] is DEFAULT_FLOAT
-    assert stat_columns["string"]["pandas_dtype"] is pa.Str
+    assert stat_columns["string"]["pandas_dtype"] is pa.String
     assert stat_columns["datetime"]["pandas_dtype"] is pa.DateTime
 
     if multi_index:
         stat_indices = statistics["index"]
         for stat_index, name, dtype in zip(
-            stat_indices, ["int_index", "str_index"], [DEFAULT_INT, pa.Str]
+            stat_indices, ["int_index", "str_index"], [DEFAULT_INT, pa.String]
         ):
             assert stat_index["name"] == name
             assert stat_index["pandas_dtype"] is dtype
@@ -157,7 +157,7 @@ def test_parse_check_statistics(check_stats, expectation):
         [
             pd.Series(["a", "b", "c", "a"], name="str_series"),
             {
-                "pandas_dtype": pa.Str,
+                "pandas_dtype": pa.String,
                 "nullable": False,
                 "checks": None,
                 "name": "str_series",
@@ -244,7 +244,7 @@ INTEGER_TYPES = [
             0,
             pd.Series(["a", "b", "c", "a"], name="str_series"),
             {
-                "pandas_dtype": pa.Str,
+                "pandas_dtype": pa.String,
                 "nullable": True,
                 "checks": None,
                 "name": "str_series",
@@ -310,7 +310,7 @@ def test_infer_nullable_series_schema_statistics(
             [
                 {
                     "name": "str_index",
-                    "pandas_dtype": PandasDtype.Str,
+                    "pandas_dtype": PandasDtype.String,
                     "nullable": False,
                     "checks": None,
                 },
@@ -377,7 +377,7 @@ def test_get_dataframe_schema_statistics():
                 ],
             ),
             "str": pa.Column(
-                pa.Str, checks=[pa.Check.isin(["foo", "bar", "baz"])]
+                pa.String, checks=[pa.Check.isin(["foo", "bar", "baz"])]
             ),
         },
         index=pa.Index(
@@ -414,7 +414,7 @@ def test_get_dataframe_schema_statistics():
                 "regex": False,
             },
             "str": {
-                "pandas_dtype": pa.Str,
+                "pandas_dtype": pa.String,
                 "checks": {"isin": {"allowed_values": ["foo", "bar", "baz"]}},
                 "nullable": False,
                 "allow_duplicates": True,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1205,7 +1205,7 @@ def test_series_schema_pdtype(pdtype):
         pdtype.value,
     ]:
         series_schema = SeriesSchema(pandas_dtype_input)
-        if pdtype is PandasDtype.String and LEGACY_PANDAS:
+        if pdtype is PandasDtype.STRING and LEGACY_PANDAS:
             assert series_schema.pdtype == PandasDtype.String
         else:
             assert series_schema.pdtype == pdtype

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from pandera import (
+    STRING,
     Bool,
     Category,
     Check,
@@ -22,7 +23,6 @@ from pandera import (
     Object,
     PandasDtype,
     SeriesSchema,
-    Str,
     String,
     Timedelta,
     errors,
@@ -43,7 +43,7 @@ def test_dataframe_schema():
             "b": Column(
                 Float, Check(lambda x: 0 <= x <= 10, element_wise=True)
             ),
-            "c": Column(Str, Check(lambda x: set(x) == {"x", "y", "z"})),
+            "c": Column(String, Check(lambda x: set(x) == {"x", "y", "z"})),
             "d": Column(Bool, Check(lambda x: x.mean() > 0.5)),
             "e": Column(
                 Category, Check(lambda x: set(x) == {"c1", "c2", "c3"})
@@ -163,7 +163,7 @@ def test_dataframe_pandas_dtype_coerce():
     schema.pandas_dtype = str
     assert (schema(df).dtypes == "object").all()
 
-    schema.pandas_dtype = PandasDtype.Str
+    schema.pandas_dtype = PandasDtype.String
     assert (schema(df).dtypes == "object").all()
 
     # raises ValueError if _coerce_dtype is called when pandas_dtype is None
@@ -220,7 +220,7 @@ def test_series_schema():
     )
 
     str_schema = SeriesSchema(
-        Str,
+        String,
         Check(lambda s: s.isin(["foo", "bar", "baz"])),
         nullable=True,
         coerce=True,
@@ -330,7 +330,7 @@ def test_series_schema_with_index(coerce):
         index=MultiIndex(
             [
                 Index(Int, coerce=coerce),
-                Index(Str, coerce=coerce),
+                Index(String, coerce=coerce),
             ]
         ),
     )
@@ -426,7 +426,7 @@ def test_coerce_dtype_in_dataframe():
         {
             "column1": Column(Int, Check(lambda x: x > 0), coerce=True),
             "column2": Column(DateTime, coerce=True),
-            "column3": Column(Str, coerce=True, nullable=True),
+            "column3": Column(String, coerce=True, nullable=True),
         }
     )
     # specify `coerce` at the DataFrameSchema level
@@ -434,7 +434,7 @@ def test_coerce_dtype_in_dataframe():
         {
             "column1": Column(Int, Check(lambda x: x > 0)),
             "column2": Column(DateTime),
-            "column3": Column(Str, nullable=True),
+            "column3": Column(String, nullable=True),
         },
         coerce=True,
     )
@@ -474,10 +474,12 @@ def test_coerce_dtype_nullable_str():
     with pytest.raises(errors.SchemaError):
         for df in [df_nans, df_nones]:
             DataFrameSchema(
-                {"col": Column(Str, coerce=True, nullable=False)}
+                {"col": Column(String, coerce=True, nullable=False)}
             ).validate(df)
 
-    schema = DataFrameSchema({"col": Column(Str, coerce=True, nullable=True)})
+    schema = DataFrameSchema(
+        {"col": Column(String, coerce=True, nullable=True)}
+    )
 
     for df in [df_nans, df_nones]:
         validated_df = schema.validate(df)
@@ -535,7 +537,7 @@ def test_required():
     and then not specified and a second column which is implicitly required
     isn't available."""
     schema = DataFrameSchema(
-        {"col1": Column(Int, required=False), "col2": Column(Str)}
+        {"col1": Column(Int, required=False), "col2": Column(String)}
     )
 
     df_ok_1 = pd.DataFrame({"col2": ["hello", "world"]})
@@ -613,7 +615,7 @@ def test_dataframe_schema_str_repr():
     schema = DataFrameSchema(
         columns={
             "col1": Column(Int),
-            "col2": Column(Str),
+            "col2": Column(String),
             "col3": Column(DateTime),
         },
         index=Index(Int, name="my_index"),
@@ -631,8 +633,8 @@ def test_dataframe_schema_dtype_property():
     schema = DataFrameSchema(
         columns={
             "col1": Column(Int),
-            "col2": Column(Str),
-            "col3": Column(String),
+            "col2": Column(String),
+            "col3": Column(STRING),
             "col4": Column(DateTime),
             "col5": Column("uint16"),
         }
@@ -658,32 +660,32 @@ def test_schema_equality_operators():
     df_schema = DataFrameSchema(
         {
             "col1": Column(Int, Check(lambda s: s >= 0)),
-            "col2": Column(Str, Check(lambda s: s >= 2)),
+            "col2": Column(String, Check(lambda s: s >= 2)),
         },
         strict=True,
     )
     df_schema_columns_in_different_order = DataFrameSchema(
         {
-            "col2": Column(Str, Check(lambda s: s >= 2)),
+            "col2": Column(String, Check(lambda s: s >= 2)),
             "col1": Column(Int, Check(lambda s: s >= 0)),
         },
         strict=True,
     )
     series_schema = SeriesSchema(
-        Str,
+        String,
         checks=[Check(lambda s: s.str.startswith("foo"))],
         nullable=False,
         allow_duplicates=True,
         name="my_series",
     )
     series_schema_base = SeriesSchemaBase(
-        Str,
+        String,
         checks=[Check(lambda s: s.str.startswith("foo"))],
         nullable=False,
         allow_duplicates=True,
         name="my_series",
     )
-    not_equal_schema = DataFrameSchema({"col1": Column(Str)}, strict=False)
+    not_equal_schema = DataFrameSchema({"col1": Column(String)}, strict=False)
 
     assert df_schema == copy.deepcopy(df_schema)
     assert df_schema != not_equal_schema
@@ -709,7 +711,7 @@ def test_add_and_remove_columns():
     # test that add_columns doesn't modify schema1 after add_columns:
     schema2 = schema1.add_columns(
         {
-            "col2": Column(Str, Check(lambda x: x <= 0)),
+            "col2": Column(String, Check(lambda x: x <= 0)),
             "col3": Column(Object, Check(lambda x: x == 0)),
         }
     )
@@ -722,7 +724,7 @@ def test_add_and_remove_columns():
     expected_schema_2 = DataFrameSchema(
         {
             "col1": Column(Int, Check(lambda s: s >= 0)),
-            "col2": Column(Str, Check(lambda x: x <= 0)),
+            "col2": Column(String, Check(lambda x: x <= 0)),
             "col3": Column(Object, Check(lambda x: x == 0)),
         },
         strict=True,
@@ -810,10 +812,10 @@ def _boolean_update_column_case(bool_kwarg):
         [
             Column(Int),
             "col",
-            {"pandas_dtype": Str},
+            {"pandas_dtype": String},
             lambda old, new: [
                 old.columns["col"].pandas_dtype is Int,
-                new.columns["col"].pandas_dtype is Str,
+                new.columns["col"].pandas_dtype is String,
             ],
         ],
         *[
@@ -918,13 +920,13 @@ def test_lazy_dataframe_validation_error():
             "int_col": Column(Int, Check.greater_than(5)),
             "int_col2": Column(Int),
             "float_col": Column(Float, Check.less_than(0)),
-            "str_col": Column(Str, Check.isin(["foo", "bar"])),
+            "str_col": Column(String, Check.isin(["foo", "bar"])),
             "not_in_dataframe": Column(Int),
         },
         checks=Check(
             lambda df: df != 1, error="dataframe_not_equal_1", ignore_na=False
         ),
-        index=Index(Str, name="str_index"),
+        index=Index(String, name="str_index"),
         strict=True,
     )
 
@@ -990,7 +992,7 @@ def test_lazy_dataframe_validation_nullable():
         columns={
             "int_column": Column(Int, nullable=False),
             "float_column": Column(Float, nullable=False),
-            "str_column": Column(Str, nullable=False),
+            "str_column": Column(String, nullable=False),
         },
         strict=True,
     )
@@ -1082,7 +1084,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
             },
         ],
         [
-            Index(Str, checks=Check.isin(["a", "b", "c"])),
+            Index(String, checks=Check.isin(["a", "b", "c"])),
             pd.DataFrame({"col": [1, 2, 3]}, index=["a", "b", "d"]),
             {
                 # expect that the data in the SchemaError is the pd.Index cast
@@ -1204,6 +1206,6 @@ def test_series_schema_pdtype(pdtype):
     ]:
         series_schema = SeriesSchema(pandas_dtype_input)
         if pdtype is PandasDtype.String and LEGACY_PANDAS:
-            assert series_schema.pdtype == PandasDtype.Str
+            assert series_schema.pdtype == PandasDtype.String
         else:
             assert series_schema.pdtype == pdtype

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -467,7 +467,7 @@ def test_dataframe_checks(pdtype, data):
     dataframe_schema(example)
 
 
-@pytest.mark.parametrize("pdtype", [pa.Int, pa.Float, pa.Str, pa.DateTime])
+@pytest.mark.parametrize("pdtype", [pa.Int, pa.Float, pa.String, pa.DateTime])
 @hypothesis.given(st.data())
 def test_dataframe_strategy_with_indexes(pdtype, data):
     """Test dataframe strategy with index and multiindex components."""


### PR DESCRIPTION
Changing the PandasDtype.String to map onto the
pandas-native 'string' type would have caused backwards
compatibility issues

Revert changes from 2e2c5d7: remove PandasDtype.Str, and
add a PandasDtype.STRING type for the pandas-native string
type.