### PR TITLE
feature/fallback-strategy

### DIFF
--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -302,14 +302,16 @@ class _CheckBase:
             for col in self.groupby:
                 # raise schema definition error if column is not in the
                 # validated dataframe
-                if (
-                    isinstance(df_or_series, pd.DataFrame)
-                    and col not in df_or_series
+                if isinstance(df_or_series, pd.DataFrame) and (
+                    col not in df_or_series
+                    and col not in df_or_series.index.names
                 ):
                     raise errors.SchemaDefinitionError(
                         f"`groupby` column '{col}' not found"
                     )
-            drop_na_columns.extend(self.groupby)
+            drop_na_columns.extend(
+                [col for col in self.groupby if col in df_or_series]
+            )
 
         if drop_na_columns:
             return df_or_series.loc[
@@ -463,6 +465,8 @@ class _CheckBase:
 
 class Check(_CheckBase):
     """Check a pandas Series or DataFrame for certain properties."""
+
+    REGISTERED_CUSTOM_CHECKS: Dict[str, Callable] = {}  # noqa
 
     @classmethod
     @st.register_check_strategy(st.eq_strategy)

--- a/pandera/extensions.py
+++ b/pandera/extensions.py
@@ -1,0 +1,159 @@
+"""Extend the pandera API."""
+
+import warnings
+from enum import Enum
+from functools import partial, wraps
+from typing import Callable, List, Optional, Tuple, Union
+
+import pandas as pd
+
+from . import strategies as st
+from .checks import Check, register_check_statistics
+
+
+class CheckType(Enum):
+    VECTORIZED = 1
+    ELEMENT_WISE = 2
+    GROUPBY = 3
+
+
+def register_check_method(
+    check_fn=None,
+    *,
+    statistics: Optional[List[str]] = None,
+    supported_types: Union[type, Tuple, List] = (pd.DataFrame, pd.Series),
+    check_type: Union[CheckType, str] = "vectorized",
+    strategy=None,
+):
+    """Registers a function as a :class:`~pandera.checks.Check` method.
+
+    :param check_fn: check function to register. The function should take one
+        positional argument for the object to validate and additional
+        keyword-only arguments for the check statistics.
+    :param statistics: list of keyword-only arguments in the ``check_fn``,
+        which serve as the statistics needed to serialize/de-serialize the
+        check and generate data if a ``strategy`` function is provided.
+    :param supported_types: the pandas type(s) supported by the check function.
+        Valid values are ``pd.DataFrame``, ``pd.Series``, or a tuple of
+        ``(pa.DataFrame, pa.Series)`` if both types are supported.
+    :param check_type: the expected input of the check function. Valid values
+        are ``~pandera.extensions.CheckType`` enums or
+        {"vectorized", "element_wise", "groupby"}. The input signature of
+        ``check_fn`` is determined by this argument:
+
+        - if ``vectorized``, the first positional argument of ``check_fn``
+          should be one of the ``supported_types``.
+        - if ``element_wise``, the first positional argument of ``check_fn``
+          should be a single scalar element in the pandas Series or DataFrame.
+        - if ``groupby``, the first positional argument of ``check_fn`` should
+          be a dictionary mapping group names to subsets of the Series or
+          DataFrame.
+
+    :param strategy: data-generation strategy associated with the check
+        function.
+    :return: register check function wrapper.
+    """
+
+    if statistics is None:
+        statistics = []
+
+    if isinstance(check_type, str):
+        check_type = CheckType[check_type.upper()]
+
+    msg = (
+        "{} is not a valid input type for check_fn. You must specify one of "
+        "pandas.DataFrame, pandas.Series, or a tuple of both."
+    )
+    if isinstance(supported_types, list):
+        supported_types = tuple(supported_types)
+    elif not isinstance(supported_types, tuple):
+        try:
+            supported_types = (supported_types,)
+        except TypeError as exc:
+            raise TypeError(msg.format(supported_types)) from exc
+
+    for supported_type in supported_types:  # type: ignore
+        if supported_type not in {pd.DataFrame, pd.Series}:
+            raise TypeError(msg.format(supported_type))
+
+    if check_type is CheckType.ELEMENT_WISE and set(supported_types) != {
+        pd.DataFrame,
+        pd.Series,
+    }:  # type: ignore
+        raise ValueError(
+            "Element-wise checks should support DataFrame and Series "
+            "validation. Use the default setting for the 'supported_types' "
+            "argument."
+        )
+
+    if check_fn is None:
+        return partial(
+            register_check_method,
+            statistics=statistics,
+            supported_types=supported_types,
+            check_type=check_type,
+            strategy=strategy,
+        )
+
+    def register_check_wrapper(check_fn: Callable):
+        """Register a function as a :class:`~pandera.checks.Check` method."""
+
+        if hasattr(Check, check_fn.__name__):
+            raise ValueError(
+                f"method with name '{check_fn.__name__}' already defined. "
+                "Check methods must have a unique method name."
+            )
+
+        @wraps(check_fn)
+        def check_fn_wrapper(validate_obj, **kwargs):
+            """Wrapper for check_fn to validate inputs."""
+            return check_fn(validate_obj, **kwargs)
+
+        def validate_check_kwargs(check_kwargs):
+            msg = (
+                f"'{check_fn.__name__} has check_type={check_type}. "
+                "Providing the following arguments will have no effect: "
+                "{}. Remove these arguments to avoid this warning."
+            )
+
+            no_effect_args = {
+                CheckType.ELEMENT_WISE: ["element_wise", "groupby", "groups"],
+                CheckType.VECTORIZED: ["element_wise", "groupby", "groups"],
+                CheckType.GROUPBY: ["element_wise"],
+            }[check_type]
+
+            if any(arg in check_kwargs for arg in no_effect_args):
+                warnings.warn(msg.format(no_effect_args))
+                for arg in no_effect_args:
+                    check_kwargs.pop(arg, None)
+
+            if check_type is CheckType.ELEMENT_WISE:
+                check_kwargs["element_wise"] = True
+
+            return check_kwargs
+
+        @register_check_statistics(statistics)
+        def check_method(cls, **kwargs):
+            """Wrapper function that serves as the Check method."""
+            stats, check_kwargs = {}, {}
+            for k, v in kwargs.items():
+                if k in statistics:
+                    stats[k] = v
+                else:
+                    check_kwargs[k] = v
+
+            return cls(
+                partial(check_fn_wrapper, **stats),
+                name=check_fn.__name__,
+                **validate_check_kwargs(check_kwargs),
+            )
+
+        if strategy is not None:
+            check_method = st.register_check_strategy(strategy)(check_method)
+
+        setattr(Check, check_fn.__name__, classmethod(check_method))
+        Check.REGISTERED_CUSTOM_CHECKS[check_fn.__name__] = getattr(
+            Check, check_fn.__name__
+        )
+
+    return register_check_wrapper(check_fn)

--- a/pandera/extensions.py
+++ b/pandera/extensions.py
@@ -12,6 +12,8 @@ from .checks import Check, register_check_statistics
 
 
 class CheckType(Enum):
+    """Check types for registered check methods."""
+
     VECTORIZED = 1
     ELEMENT_WISE = 2
     GROUPBY = 3

--- a/pandera/extensions.py
+++ b/pandera/extensions.py
@@ -36,7 +36,7 @@ def register_check_method(
         which serve as the statistics needed to serialize/de-serialize the
         check and generate data if a ``strategy`` function is provided.
     :param supported_types: the pandas type(s) supported by the check function.
-        Valid values are ``pd.DataFrame``, ``pd.Series``, or a tuple of
+        Valid values are ``pd.DataFrame``, ``pd.Series``, or a list/tuple of
         ``(pa.DataFrame, pa.Series)`` if both types are supported.
     :param check_type: the expected input of the check function. Valid values
         are ``~pandera.extensions.CheckType`` enums or
@@ -69,10 +69,7 @@ def register_check_method(
     if isinstance(supported_types, list):
         supported_types = tuple(supported_types)
     elif not isinstance(supported_types, tuple):
-        try:
-            supported_types = (supported_types,)
-        except TypeError as exc:
-            raise TypeError(msg.format(supported_types)) from exc
+        supported_types = (supported_types,)
 
     for supported_type in supported_types:  # type: ignore
         if supported_type not in {pd.DataFrame, pd.Series}:

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -156,9 +156,11 @@ def Field(
 
     :param alias: The public name of the column/index.
 
-    :param check_name: Whether to check the name of the column/index during validation.
-        `None` is the default behavior, which translates to `True` for columns and
-        multi-index, and to `False` for a single index.
+    :param check_name: Whether to check the name of the column/index during
+        validation. `None` is the default behavior, which translates to `True`
+        for columns and multi-index, and to `False` for a single index.
+    :param kwargs: Specify custom checks that have been registered with the
+        :class:`~pandera.extensions.register_check_method` decorator.
     """
     # pylint:disable=C0103,W0613,R0914
     check_kwargs = {

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -145,6 +145,7 @@ def Field(
     n_failure_cases: int = 10,
     alias: str = None,
     check_name: bool = None,
+    **kwargs,
 ) -> Any:
     """Used to provide extra information about a field of a SchemaModel.
 
@@ -203,6 +204,7 @@ _check_dispatch = {
     "str_matches": Check.str_matches,
     "str_length": Check.str_length,
     "str_startswith": Check.str_startswith,
+    **Check.REGISTERED_CUSTOM_CHECKS,
 }
 
 

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -333,9 +333,13 @@ class Index(SeriesSchemaBase):
             check_obj.index = self.coerce_dtype(check_obj.index)
             # handles case where pandas native string type is not supported
             # by index.
-            obj_to_validate = pd.Series(check_obj.index).astype(self.dtype)
+            obj_to_validate = pd.Series(
+                check_obj.index, name=check_obj.index.name
+            ).astype(self.dtype)
         else:
-            obj_to_validate = pd.Series(check_obj.index)
+            obj_to_validate = pd.Series(
+                check_obj.index, name=check_obj.index.name
+            )
 
         assert isinstance(
             super().validate(

--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -665,7 +665,7 @@ def field_element_strategy(
             pandas_dtype_strategy(pandas_dtype)
             if elements is None
             else elements
-        ).filter(lambda x: check._check_fn(x))
+        ).filter(check._check_fn)
 
     for check in checks:
         if hasattr(check, "strategy"):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-member,redefined-outer-name,unused-argument
+# pylint: disable=unused-variable
 """Unit tests for pandera API extensions."""
 
 from typing import Any, Optional
@@ -55,7 +57,7 @@ def test_register_vectorized_custom_check(custom_check_teardown, data):
         ValueError,
         match="method with name 'custom_check' already defined",
     ):
-
+        # pylint: disable=function-redefined
         @extensions.register_check_method(statistics=["val"])
         def custom_check(pandas_obj, val):  # noqa
             return pandas_obj != val
@@ -69,6 +71,8 @@ def test_register_vectorized_custom_check(custom_check_teardown, data):
     ],
 )
 def test_register_element_wise_custom_check(custom_check_teardown, data):
+    """Test registering an element-wise custom check."""
+
     @extensions.register_check_method(
         statistics=["val"],
         supported_types=(pd.Series, pd.DataFrame),
@@ -108,11 +112,11 @@ def test_register_custom_groupby_check(custom_check_teardown):
     """Test registering a custom groupby check."""
 
     @extensions.register_check_method(
-        statistics=["group_A", "group_B"],
+        statistics=["group_a", "group_b"],
         supported_types=(pd.Series, pd.DataFrame),
         check_type="groupby",
     )
-    def custom_check(dict_groups, *, group_A, group_B):
+    def custom_check(dict_groups, *, group_a, group_b):
         """
         Test that the mean values in group A is larger than that of group B.
 
@@ -120,8 +124,8 @@ def test_register_custom_groupby_check(custom_check_teardown):
         series.
         """
         return (
-            dict_groups[group_A].values.mean()
-            > dict_groups[group_B].values.mean()
+            dict_groups[group_a].values.mean()
+            > dict_groups[group_b].values.mean()
         )
 
     # column groupby check
@@ -185,6 +189,7 @@ def test_register_custom_groupby_check(custom_check_teardown):
     ],
 )
 def test_register_check_invalid_supported_types(supported_types):
+    """Test that TypeError is raised on invalid supported_types arg."""
     with pytest.raises(TypeError):
 
         @extensions.register_check_method(supported_types=supported_types)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -203,7 +203,7 @@ def test_register_check_invalid_supported_types(supported_types):
 def test_register_check_with_strategy(custom_check_teardown):
     """Test registering a custom check with a data generation strategy."""
 
-    import hypothesis  # pylint: disable=import-outside-toplevel
+    import hypothesis  # pylint: disable=import-outside-toplevel,import-error
 
     def custom_ge_strategy(
         pandas_dtype: PandasDtype,

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -640,6 +640,7 @@ def test_check_nullable_dataframe_strategy(pdtype, nullable, data):
 )
 @hypothesis.given(st.data())
 def test_series_strategy_undefined_check_strategy(schema, warning, data):
+    """Test case where series check strategy is undefined."""
     with pytest.warns(
         UserWarning, match=f"{warning} check doesn't have a defined strategy"
     ):
@@ -681,6 +682,7 @@ def test_series_strategy_undefined_check_strategy(schema, warning, data):
 )
 @hypothesis.given(st.data())
 def test_dataframe_strategy_undefined_check_strategy(schema, warning, data):
+    """Test case where dataframe check strategy is undefined."""
     with pytest.warns(
         UserWarning, match=f"{warning} check doesn't have a defined strategy"
     ):

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -129,7 +129,10 @@ def value_ranges(pdtype: pa.PandasDtype):
     ],
 )
 @hypothesis.given(st.data())
-@hypothesis.settings(deadline=2000)
+@hypothesis.settings(
+    deadline=2000,
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
 def test_check_strategy_chained_continuous(
     pdtype, strat_fn, arg_name, base_st_type, compare_op, data
 ):
@@ -384,7 +387,10 @@ def test_register_check_strategy_exception():
 
 
 @hypothesis.given(st.data())
-@hypothesis.settings(deadline=2000)
+@hypothesis.settings(
+    deadline=2000,
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
 def test_series_strategy(data):
     """Test SeriesSchema strategy."""
     series_schema = pa.SeriesSchema(pa.Int, pa.Check.gt(0))
@@ -419,7 +425,10 @@ def test_column_example():
     [pdtype for pdtype in SUPPORTED_DTYPES if not pdtype.is_category],
 )
 @hypothesis.given(st.data())
-@hypothesis.settings(deadline=2000)
+@hypothesis.settings(
+    deadline=2000,
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
 def test_dataframe_strategy(pdtype, data):
     """Test DataFrameSchema strategy."""
     dataframe_schema = pa.DataFrameSchema(
@@ -446,7 +455,10 @@ def test_dataframe_example():
 
 
 @pytest.mark.parametrize("pdtype", NUMERIC_DTYPES)
-@hypothesis.settings(deadline=2000)
+@hypothesis.settings(
+    deadline=2000,
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
 @hypothesis.given(st.data())
 def test_dataframe_checks(pdtype, data):
     """Test dataframe strategy with checks defined at the dataframe level."""
@@ -467,7 +479,10 @@ def test_dataframe_checks(pdtype, data):
 
 @pytest.mark.parametrize("pdtype", [pa.Int, pa.Float, pa.String, pa.DateTime])
 @hypothesis.given(st.data())
-@hypothesis.settings(deadline=2000)
+@hypothesis.settings(
+    deadline=2000,
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
 def test_dataframe_strategy_with_indexes(pdtype, data):
     """Test dataframe strategy with index and multiindex components."""
     dataframe_schema_index = pa.DataFrameSchema(index=pa.Index(pdtype))

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -129,6 +129,7 @@ def value_ranges(pdtype: pa.PandasDtype):
     ],
 )
 @hypothesis.given(st.data())
+@hypothesis.settings(deadline=2000)
 def test_check_strategy_chained_continuous(
     pdtype, strat_fn, arg_name, base_st_type, compare_op, data
 ):
@@ -383,6 +384,7 @@ def test_register_check_strategy_exception():
 
 
 @hypothesis.given(st.data())
+@hypothesis.settings(deadline=2000)
 def test_series_strategy(data):
     """Test SeriesSchema strategy."""
     series_schema = pa.SeriesSchema(pa.Int, pa.Check.gt(0))
@@ -417,6 +419,7 @@ def test_column_example():
     [pdtype for pdtype in SUPPORTED_DTYPES if not pdtype.is_category],
 )
 @hypothesis.given(st.data())
+@hypothesis.settings(deadline=2000)
 def test_dataframe_strategy(pdtype, data):
     """Test DataFrameSchema strategy."""
     dataframe_schema = pa.DataFrameSchema(
@@ -443,7 +446,7 @@ def test_dataframe_example():
 
 
 @pytest.mark.parametrize("pdtype", NUMERIC_DTYPES)
-@hypothesis.settings(deadline=None)
+@hypothesis.settings(deadline=2000)
 @hypothesis.given(st.data())
 def test_dataframe_checks(pdtype, data):
     """Test dataframe strategy with checks defined at the dataframe level."""
@@ -464,6 +467,7 @@ def test_dataframe_checks(pdtype, data):
 
 @pytest.mark.parametrize("pdtype", [pa.Int, pa.Float, pa.String, pa.DateTime])
 @hypothesis.given(st.data())
+@hypothesis.settings(deadline=2000)
 def test_dataframe_strategy_with_indexes(pdtype, data):
     """Test dataframe strategy with index and multiindex components."""
     dataframe_schema_index = pa.DataFrameSchema(index=pa.Index(pdtype))


### PR DESCRIPTION
thie PR does two things:

1. adds a fallback strategy for checks that have undefined strategies. This
   strategy simply applies the check on th generated data and filters out
   values that don't pass the check. This is undesirable for the obvious reason
   that many checks would filter out a lot of data... this leads to...
2. adding a `pandera.extensions` module that enables users to register custom checks
   and, optionally, strategies for those checks. See [here](https://github.com/pandera-dev/pandera/compare/dev...feature/fallback-strategy?expand=1#diff-2155b115d700e8f39a57e254d9e5ab9825b17ca3d8ba5b6acf9b2654bba7f83eR33-R39) for an example.
   Once registered, these checks will be available in the `pa.Check` namespace, as
   well as a `Field(..., my_check=...)` key-word argument.