### PR TITLE
Add column order validation

### DIFF
--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -16,6 +16,7 @@ The ``DataFrameSchema`` object consists of |column|_\s and an |index|_.
 .. |index| replace:: ``Index``
 .. |coerced| replace:: ``coerce``
 .. |strict| replace:: ``strict``
+.. |ordered| replace:: ``ordered``
 
 .. testcode:: dataframe_schemas
 
@@ -396,6 +397,37 @@ schema, specify ``strict=True``:
     ...
     SchemaError: column 'column2' not in DataFrameSchema {'column1': <Schema Column: 'None' type=int>}
 
+.. _ordered:
+
+Validating the order of the columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For some applications the order of the columns is important. For example:
+
+* If you want to use
+  `selection by position <(https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html#selection-by-position)>`_
+  instead of the more common
+  `selection by label <https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html#selection-by-label>`_.
+* Machine learning: Many ML libraries will cast a Dataframe to numpy arrays,
+  for which order becomes crucial.
+
+To validate the order of the Dataframe columns, specify ``ordered=True``:
+
+.. testcode:: columns_ordered
+
+    import pandas as pd
+    import pandera as pa
+
+    schema = pa.DataFrameSchema(
+        columns={"a": pa.Column(pa.Int), "b": pa.Column(pa.Int)}, ordered=True
+    )
+    df = pd.DataFrame({"b": [1], "a": [1]})
+    print(schema.validate(df))
+
+.. testoutput:: columns_ordered
+
+    Traceback (most recent call last):
+    ...
+    SchemaError: column 'b' out-of-order
 
 .. _index:
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -48,7 +48,7 @@ class BaseConfig:  # pylint:disable=R0903
     name: Optional[str] = None  #: name of schema
     coerce: bool = False  #: coerce types of all schema components
     strict: bool = False  #: make sure all specified columns are in dataframe
-    check_index_name: bool = False
+    ordered: bool = False  #: validate columns order
     multiindex_name: Optional[str] = None  #: name of multiindex
 
     #: coerce types of all MultiIndex components
@@ -123,6 +123,7 @@ class SchemaModel:
             coerce=cls.__config__.coerce,
             strict=cls.__config__.strict,
             name=cls.__config__.name,
+            ordered=cls.__config__.ordered,
         )
         if cls not in MODEL_CACHE:
             MODEL_CACHE[cls] = cls.__schema__

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -437,7 +437,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         # are specified in the dataframe schema
         if self.strict or self.ordered:
             colum_names = []
-            for colname, col_schema in self.columns.items():
+            for col_name, col_schema in self.columns.items():
                 if col_schema.regex:
                     try:
                         colum_names.extend(
@@ -445,8 +445,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                         )
                     except errors.SchemaError:
                         pass
-                else:
-                    colum_names.append(colname)
+                elif col_name in check_obj.columns:
+                    colum_names.append(col_name)
             # ordered "set" of columns
             sorted_column_names = iter(dict.fromkeys(colum_names))
             expanded_column_names = frozenset(colum_names)

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -88,7 +88,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         :param strict: whether or not to accept columns in the dataframe that
             aren't in the DataFrameSchema.
         :param name: name of the schema.
-        :param ordered:  whether or not to validate the column order.
+        :param ordered: whether or not to validate the columns order.
 
         :raises SchemaInitError: if impossible to build schema from parameters
 
@@ -174,7 +174,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
     @property
     def ordered(self):
-        """Whether to coerce series to specified type."""
+        """Whether or not to validate the columns order."""
         return self._ordered
 
     # the _is_inferred getter and setter methods are not public

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -457,6 +457,7 @@ def test_config():
         class Config:
             name = "Base schema"
             coerce = True
+            ordered = True
             multiindex_coerce = True
             multiindex_strict = True
             multiindex_name: Optional[str] = "mi"
@@ -480,6 +481,7 @@ def test_config():
         name="Child schema",
         coerce=True,
         strict=True,
+        ordered=True,
     )
 
     assert expected == Child.to_schema()

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -205,6 +205,29 @@ def test_dataframe_reset_column_name():
         DataFrameSchema(columns={"new_name": Column(name="old_name")})
 
 
+def test_dataframe_ordered():
+    """Test that columns are ordered."""
+    schema = DataFrameSchema(
+        {"a": Column(Int), "b": Column(Int)}, ordered=True, strict=True
+    )
+
+    df = pd.DataFrame([[1, 2, 3]], columns=["a", "a", "b"])
+    assert isinstance(schema.validate(df), pd.DataFrame)
+
+    df = pd.DataFrame([[1, 2]], columns=["b", "a"])
+    err_msg = "A total of 2 schema errors"
+    with pytest.raises(errors.SchemaErrors, match=err_msg):
+        schema.validate(df, lazy=True)
+
+    schema = DataFrameSchema(
+        {"a": Column(Int), "b": Column(Int), "c": Column(Int)}, ordered=True
+    )
+    df = pd.DataFrame([[1, 2, 3, 4, 5]], columns=["a", "b", "d", "a", "c"])
+    err_msg = "A total of 1 schema errors"
+    with pytest.raises(errors.SchemaErrors, match=err_msg):
+        schema.validate(df, lazy=True)
+
+
 def test_series_schema():
     """Tests that a SeriesSchema Check behaves as expected for integers and
     strings. Tests error cases for types, duplicates, name errors, and issues

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -209,7 +209,13 @@ def test_dataframe_reset_column_name():
 @pytest.mark.parametrize(
     "columns,index",
     [
-        ({"a": Column(Int), "b": Column(Int)}, None),
+        (
+            {
+                "a": Column(Int, required=False),
+                "b": Column(Int, required=False),
+            },
+            None,
+        ),
         (
             None,
             MultiIndex(
@@ -222,6 +228,7 @@ def test_dataframe_reset_column_name():
 def test_ordered(columns: Dict[str, Column], index: MultiIndex):
     """Test that columns are ordered."""
     schema = DataFrameSchema(columns=columns, index=index, ordered=True)
+
     df = pd.DataFrame(
         data=[[1, 2, 3]],
         columns=["a", "a", "b"],
@@ -231,7 +238,14 @@ def test_ordered(columns: Dict[str, Column], index: MultiIndex):
     )
     assert isinstance(schema.validate(df), pd.DataFrame)
 
-    schema = DataFrameSchema(columns=columns, index=index, ordered=True)
+    # test optional column
+    df = pd.DataFrame(
+        data=[[1]],
+        columns=["b"],
+        index=pd.MultiIndex.from_arrays([[1], [2]], names=["a", "b"]),
+    )
+    assert isinstance(schema.validate(df), pd.DataFrame)
+
     df = pd.DataFrame(
         data=[[1, 2]],
         columns=["b", "a"],

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -256,6 +256,12 @@ def test_ordered(columns: Dict[str, Column], index: MultiIndex):
         schema.validate(df, lazy=True)
 
 
+def test_ordered_notnamed_multiindex():
+    """Test that a multiindex must be named to validate its order."""
+    with pytest.raises(errors.SchemaInitError):
+        MultiIndex(indexes=[Index(Int, name="a"), Index(Int)], ordered=True)
+
+
 def test_series_schema():
     """Tests that a SeriesSchema Check behaves as expected for integers and
     strings. Tests error cases for types, duplicates, name errors, and issues


### PR DESCRIPTION
This PR adds an `ordered` argument to `DataFrameSchema` and to `model.BaseConfig` for the model api. It closes #342.

A side effect is that 2 schema errors will be raised if there is a permutation:
```python
import pandas as pd
import pandera as pa

schema = pa.DataFrameSchema({"a": pa.Column(int), "b": pa.Column(int)}, ordered=True)
df = pd.DataFrame([[1, 2]], columns=["b", "a"])
schema.validate(df, lazy=True)
#> Traceback (most recent call last):
#> <ipython-input-1-f6ae10d7ea6a> in <module>
#> ----> 1 schema.validate(df, lazy=True)
#> ~/Projects/development/pandera/pandera/schemas.py in validate(self, check_obj, head, tail, sample, random_state, lazy, inplace)
#>     582         if lazy and error_handler.collected_errors:
#>     583             raise errors.SchemaErrors(
#> --> 584                 error_handler.collected_errors, check_obj
#>     585             )
#>     586 
#> SchemaErrors: A total of 2 schema errors were found.
#> Error Counts
#> - column_not_ordered: 2
#> Schema Error Summary
#>                                       failure_cases  n_failure_cases
#> schema_context  column check                                        
#> DataFrameSchema <NA>   column_ordered        [a, b]                2
#> Usage Tip
#> Directly inspect all errors by catching the exception:
#> ```
#> try:
#>     schema.validate(dataframe, lazy=True)
#> except SchemaErrors as err:
#>     err.failure_cases  # dataframe of schema errors
#>     err.data  # invalid dataframe
#> ```
```
<sup>Created on 2020-12-11 by the [reprexpy package](https://github.com/crew102/reprexpy)</sup>

Note: The PR targets the dev branch.