### PR TITLE
bugfix: schema model index validation

### DIFF
--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -113,7 +113,6 @@ class SchemaErrors(Exception):
         with pd.option_context("display.max_colwidth", 100):
             msg += agg_schema_errors.to_string()
         msg += SCHEMA_ERRORS_SUFFIX
-
         return msg
 
     @staticmethod

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -58,6 +58,9 @@ class BaseConfig:  # pylint:disable=R0903
     #: make sure all specified columns are in MultiIndex
     multiindex_strict: bool = False
 
+    #: validate MultiIndex in order
+    multiindex_ordered: bool = True
+
 
 _config_options = [
     attr for attr in vars(BaseConfig) if not attr.startswith("_")

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -338,12 +338,14 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         if self.pdtype is not None:
             obj = _try_coercion(self._coerce_dtype, obj)
         if self.index is not None and (self.index.coerce or self.coerce):
-            index = copy.deepcopy(self.index)
+            index_schema = copy.deepcopy(self.index)
             if self.coerce:
                 # coercing at the dataframe-level should apply index coercion
                 # for both single- and multi-indexes.
-                index._coerce = True
-            obj.index = _try_coercion(index.coerce_dtype, obj.index)
+                index_schema._coerce = True
+            coerced_index = _try_coercion(index_schema.coerce_dtype, obj.index)
+            if coerced_index is not None:
+                obj.index = coerced_index
 
         if error_handler.collected_errors:
             raise errors.SchemaErrors(error_handler.collected_errors, obj)

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -438,20 +438,20 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         # dataframe strictness check makes sure all columns in the dataframe
         # are specified in the dataframe schema
         if self.strict or self.ordered:
-            colum_names = []
+            column_names = []
             for col_name, col_schema in self.columns.items():
                 if col_schema.regex:
                     try:
-                        colum_names.extend(
+                        column_names.extend(
                             col_schema.get_regex_columns(check_obj.columns)
                         )
                     except errors.SchemaError:
                         pass
                 elif col_name in check_obj.columns:
-                    colum_names.append(col_name)
+                    column_names.append(col_name)
             # ordered "set" of columns
-            sorted_column_names = iter(dict.fromkeys(colum_names))
-            expanded_column_names = frozenset(colum_names)
+            sorted_column_names = iter(dict.fromkeys(column_names))
+            expanded_column_names = frozenset(column_names)
 
             # drop adjacent duplicated column names
             if check_obj.columns.has_duplicates:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -220,7 +220,6 @@ def test_dataframe_reset_column_name():
             None,
             MultiIndex(
                 indexes=[Index(Int, name="a"), Index(Int, name="b")],
-                ordered=True,
             ),
         ),
     ],
@@ -268,12 +267,6 @@ def test_ordered(columns: Dict[str, Column], index: MultiIndex):
         errors.SchemaErrors, match="A total of 1 schema errors"
     ):
         schema.validate(df, lazy=True)
-
-
-def test_ordered_notnamed_multiindex():
-    """Test that a multiindex must be named to validate its order."""
-    with pytest.raises(errors.SchemaInitError):
-        MultiIndex(indexes=[Index(Int, name="a"), Index(Int)], ordered=True)
 
 
 def test_series_schema():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -224,7 +224,7 @@ def test_dataframe_reset_column_name():
         ),
     ],
 )
-def test_ordered(columns: Dict[str, Column], index: MultiIndex):
+def test_ordered_dataframe(columns: Dict[str, Column], index: MultiIndex):
     """Test that columns are ordered."""
     schema = DataFrameSchema(columns=columns, index=index, ordered=True)
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -581,6 +581,10 @@ def test_field_element_strategy(pdtype, data):
 )
 @pytest.mark.parametrize("nullable", [True, False])
 @hypothesis.given(st.data())
+@hypothesis.settings(
+    deadline=2000,
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
 def test_check_nullable_field_strategy(pdtype, field_strategy, nullable, data):
     """Test strategies for generating nullable column/index data."""
 
@@ -606,6 +610,10 @@ def test_check_nullable_field_strategy(pdtype, field_strategy, nullable, data):
 @pytest.mark.parametrize("pdtype", NULLABLE_DTYPES)
 @pytest.mark.parametrize("nullable", [True, False])
 @hypothesis.given(st.data())
+@hypothesis.settings(
+    deadline=2000,
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
 def test_check_nullable_dataframe_strategy(pdtype, nullable, data):
     """Test strategies for generating nullable DataFrame data."""
     size = 5


### PR DESCRIPTION
this PR makes sure that `ordered=True` by default in the MultiIndex schema component. It also handles `None`-named indexes by replacing the name with the index integer position. If `ordered=False`, then all index names must be provided so that the multiindex validation can do `index.get_level_values` by key name instead of index position.