### PR TITLE
bugfix: multiindex coercion handles all None index names

### DIFF
--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -540,14 +540,15 @@ class MultiIndex(DataFrameSchema):
         """
         error_handler = SchemaErrorHandler(lazy=True)
 
+        # construct MultiIndex with coerced data types
         coerced_multi_index = {}
         for i, index in enumerate(self.indexes):
-            if self.ordered:
+            if all(x is None for x in self.names):
                 index_levels = [i]
             else:
                 index_levels = [
                     i for i, name in enumerate(obj.names) if name == index.name
-                ]  # type: ignore
+                ]
             for index_level in index_levels:
                 index_array = obj.get_level_values(index_level)
                 if index.coerce or self._coerce:

--- a/tests/test_schema_components.py
+++ b/tests/test_schema_components.py
@@ -594,6 +594,11 @@ def test_multiindex_duplicate_index_names(multiindex, error, schema):
             False,
         ],
         [
+            pd.MultiIndex.from_arrays([[1], [1], [1]], names=["a", "a", None]),
+            MultiIndex([Index(int, name="a"), Index(int)], coerce=True),
+            False,
+        ],
+        [
             pd.MultiIndex.from_arrays([[1], [1], [1]], names=["a", None, "a"]),
             MultiIndex([Index(int, name="a"), Index(int)]),
             "column 'a' out-of-order",
@@ -603,6 +608,13 @@ def test_multiindex_duplicate_index_names(multiindex, error, schema):
                 [[1], [1], [1], [1]], names=["a", "a", None, None]
             ),
             MultiIndex([Index(int, name="a"), Index(int)]),
+            False,
+        ],
+        [
+            pd.MultiIndex.from_arrays(
+                [[1], [1], [1], [1]], names=["a", "a", None, None]
+            ),
+            MultiIndex([Index(int, name="a"), Index(int)], coerce=True),
             False,
         ],
     ],
@@ -647,7 +659,25 @@ def test_multiindex_ordered(multiindex, schema, error):
             ),
             False,
         ],
-        # unordered schema component with duplicated names in multiindex
+        [
+            pd.MultiIndex.from_arrays([[1], [1]], names=["b", "a"]),
+            MultiIndex(
+                [Index(int, name="a"), Index(int, name="b")],
+                ordered=False,
+                coerce=True,
+            ),
+            False,
+        ],
+        # unordered schema component with duplicated names in multiindex and
+        # dtype coercion
+        [
+            pd.MultiIndex.from_arrays([[1], [1], [1]], names=["b", "a", "a"]),
+            MultiIndex(
+                [Index(int, name="a"), Index(int, name="b")],
+                ordered=False,
+            ),
+            False,
+        ],
         [
             pd.MultiIndex.from_arrays([[1], [1], [1]], names=["b", "a", "a"]),
             MultiIndex(


### PR DESCRIPTION
This PR makes sure that dtype coercion on multiindex schema components can handle the case where all index names are `None`. Adds test cases to make sure this is covered.