### PR TITLE
improve memory efficiency of validation process

### DIFF
--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -243,8 +243,8 @@ class _CheckBase:
 
     def _prepare_series_input(
         self,
-        series: pd.Series,
-        dataframe_context: Optional[pd.DataFrame] = None,
+        df_or_series: Union[pd.Series, pd.DataFrame],
+        column: Optional[str] = None,
     ) -> SeriesCheckObj:
         """Prepare input for Column check.
 
@@ -256,18 +256,20 @@ class _CheckBase:
             to be used by `_check_fn` and `_vectorized_check`
 
         """
-        if dataframe_context is None or self.groupby is None:
-            return series
-        if isinstance(self.groupby, list):
-            groupby_obj = pd.concat(
-                [series, dataframe_context[self.groupby]], axis=1
-            ).groupby(self.groupby)[series.name]
-            return self._format_groupby_input(groupby_obj, self.groups)
-        if callable(self.groupby):
-            groupby_obj = self.groupby(
-                pd.concat([series, dataframe_context], axis=1)
-            )[series.name]
-            return self._format_groupby_input(groupby_obj, self.groups)
+        if isinstance(df_or_series, pd.Series):
+            return df_or_series
+        elif self.groupby is None:
+            return df_or_series[column]
+        elif isinstance(self.groupby, list):
+            return self._format_groupby_input(
+                df_or_series.groupby(self.groupby)[column],
+                self.groups,
+            )
+        elif callable(self.groupby):
+            return self._format_groupby_input(
+                self.groupby(df_or_series)[column],
+                self.groups,
+            )
         raise TypeError("Type %s not recognized for `groupby` argument.")
 
     def _prepare_dataframe_input(
@@ -283,41 +285,6 @@ class _CheckBase:
             return dataframe
         groupby_obj = dataframe.groupby(self.groupby)
         return self._format_groupby_input(groupby_obj, self.groups)
-
-    def _handle_na(
-        self,
-        df_or_series: Union[pd.DataFrame, pd.Series],
-        column: Optional[str] = None,
-    ):
-        """Handle nan values before passing object to check function."""
-        if not self.ignore_na:
-            return df_or_series
-
-        drop_na_columns = []
-        if column is not None:
-            drop_na_columns.append(column)
-        if self.groupby is not None and isinstance(self.groupby, list):
-            # if groupby is specified as a list of columns, include them in
-            # the columns to consider when dropping records
-            for col in self.groupby:
-                # raise schema definition error if column is not in the
-                # validated dataframe
-                if isinstance(df_or_series, pd.DataFrame) and (
-                    col not in df_or_series
-                    and col not in df_or_series.index.names
-                ):
-                    raise errors.SchemaDefinitionError(
-                        f"`groupby` column '{col}' not found"
-                    )
-            drop_na_columns.extend(
-                [col for col in self.groupby if col in df_or_series]
-            )
-
-        if drop_na_columns:
-            return df_or_series.loc[
-                df_or_series[drop_na_columns].dropna().index
-            ]
-        return df_or_series.dropna()
 
     def __call__(
         self,
@@ -346,20 +313,11 @@ class _CheckBase:
 
             ``failure_cases``: subset of the check_object that failed.
         """
-        df_or_series = self._handle_na(df_or_series, column)
-
-        column_dataframe_context = None
-        if column is not None and isinstance(df_or_series, pd.DataFrame):
-            column_dataframe_context = df_or_series.drop(
-                column, axis="columns"
-            )
-            df_or_series = df_or_series[column].copy()
-
         # prepare check object
-        if isinstance(df_or_series, pd.Series):
-            check_obj = self._prepare_series_input(
-                df_or_series, column_dataframe_context
-            )
+        if isinstance(df_or_series, pd.Series) or (
+            column is not None and isinstance(df_or_series, pd.DataFrame)
+        ):
+            check_obj = self._prepare_series_input(df_or_series, column)
         elif isinstance(df_or_series, pd.DataFrame):
             check_obj = self._prepare_dataframe_input(df_or_series)
         else:
@@ -394,12 +352,22 @@ class _CheckBase:
         ):
             failure_cases = None
         elif isinstance(check_output, pd.Series):
+            if self.ignore_na:
+                isna = (
+                    check_obj.isna().any(axis="columns")
+                    if isinstance(check_obj, pd.DataFrame)
+                    else check_obj.isna()
+                )
+                check_output = check_output | isna
             failure_cases = check_obj[~check_output]
         elif isinstance(check_output, pd.DataFrame):
             # check results consisting of a boolean dataframe should be
             # reported at the most granular level.
+            check_output = check_output.unstack()
+            if self.ignore_na:
+                check_output = check_output | df_or_series.unstack().isna()
             failure_cases = (
-                check_obj.unstack()[~check_output.unstack()]
+                check_obj.unstack()[~check_output]
                 .rename("failure_case")
                 .rename_axis(["column", "index"])
                 .reset_index()

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -104,9 +104,9 @@ class _CheckBase:
 
             where the input is a dictionary mapping
             keys to subsets of the column/dataframe.
-        :param ignore_na: If True, drops null values on the checked series or
-            dataframe before passing into the ``check_fn``. For dataframes,
-            drops rows with any null value. *New in version 0.4.0*
+        :param ignore_na: If True, null values will be ignored when determining
+            if a check passed or failed. For dataframes, ignores rows with any
+            null value. *New in version 0.4.0*
         :param element_wise: Whether or not to apply validator in an
             element-wise fashion. If bool, assumes that all checks should be
             applied to the column element-wise. If list, should be the same
@@ -376,6 +376,9 @@ class _CheckBase:
             raise TypeError(
                 f"output type of check_fn not recognized: {type(check_output)}"
             )
+
+        if failure_cases is not None and self.n_failure_cases is not None:
+            failure_cases = failure_cases.iloc[: self.n_failure_cases]
 
         check_passed = (
             check_output.all()

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -118,8 +118,8 @@ class _CheckBase:
             exception instead of raising a SchemaError for a specific check.
             This option should be used carefully in cases where a failing
             check is informational and shouldn't stop execution of the program.
-        :param n_failure_cases: report the top n failure cases. If None, then
-            report all failure cases.
+        :param n_failure_cases: report the first n unique failure cases. If
+            None, report all failure cases.
         :param check_kwargs: key-word arguments to pass into ``check_fn``
 
         :example:
@@ -378,7 +378,9 @@ class _CheckBase:
             )
 
         if failure_cases is not None and self.n_failure_cases is not None:
-            failure_cases = failure_cases.iloc[: self.n_failure_cases]
+            failure_cases = failure_cases.drop_duplicates().iloc[
+                : self.n_failure_cases
+            ]
 
         check_passed = (
             check_output.all()

--- a/pandera/error_handlers.py
+++ b/pandera/error_handlers.py
@@ -1,6 +1,6 @@
 """Handle schema errors."""
 
-from typing import List
+from typing import Dict, List, Union
 
 from .errors import SchemaError
 
@@ -45,6 +45,6 @@ class SchemaErrorHandler:
         )
 
     @property
-    def collected_errors(self) -> List[SchemaError]:
+    def collected_errors(self) -> List[Dict[str, Union[SchemaError, str]]]:
         """Retrieve SchemaError objects collected during lazy validation."""
         return self._collected_errors

--- a/pandera/hypotheses.py
+++ b/pandera/hypotheses.py
@@ -170,11 +170,13 @@ class Hypothesis(_CheckBase):
         return len(self.samples) <= 1
 
     def _prepare_series_input(
-        self, series: pd.Series, dataframe_context: pd.DataFrame = None
+        self,
+        df_or_series: Union[pd.Series, pd.DataFrame],
+        column: Optional[str] = None,
     ) -> SeriesCheckObj:
         """Prepare Series input for Hypothesis check."""
         self.groups = self.samples
-        return super()._prepare_series_input(series, dataframe_context)
+        return super()._prepare_series_input(df_or_series, column)
 
     def _prepare_dataframe_input(
         self, dataframe: pd.DataFrame

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -185,9 +185,15 @@ class Column(SeriesSchemaBase):
                 "method.",
             )
 
-        def validate_column(check_obj):
+        def validate_column(check_obj, column_name):
             super(Column, copy(self).set_name(column_name)).validate(
-                check_obj, head, tail, sample, random_state, lazy
+                check_obj,
+                head,
+                tail,
+                sample,
+                random_state,
+                lazy,
+                inplace=inplace,
             )
 
         column_keys_to_check = (
@@ -203,9 +209,11 @@ class Column(SeriesSchemaBase):
                 )
             if isinstance(check_obj[column_name], pd.DataFrame):
                 for i in range(check_obj[column_name].shape[1]):
-                    validate_column(check_obj[column_name].iloc[:, [i]])
+                    validate_column(
+                        check_obj[column_name].iloc[:, [i]], column_name
+                    )
             else:
-                validate_column(check_obj)
+                validate_column(check_obj, column_name)
 
         return check_obj
 

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -616,7 +616,7 @@ class MultiIndex(DataFrameSchema):
             except errors.SchemaErrors as err:
                 if lazy:
                     raise
-                raise err._schema_error_dicts[0]["error"] from err
+                raise err.schema_errors[0]["error"] from err
 
         # Prevent data type coercion when the validate method is called because
         # it leads to some weird behavior when calling coerce_dtype within the
@@ -679,7 +679,7 @@ class MultiIndex(DataFrameSchema):
             # the schema context to MultiIndex. This should be fixed by with
             # a more principled schema class hierarchy.
             schema_error_dicts = []
-            for schema_error_dict in err._schema_error_dicts:
+            for schema_error_dict in err.schema_errors:
                 error = schema_error_dict["error"]
                 error = errors.SchemaError(
                     self,

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -525,7 +525,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             try:
                 check_obj = self.coerce_dtype(check_obj)
             except errors.SchemaErrors as err:
-                for schema_error_dict in err._schema_error_dicts:
+                for schema_error_dict in err.schema_errors:
                     if not lazy:
                         # raise the first error immediately if not doing lazy
                         # validation
@@ -567,7 +567,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             except errors.SchemaError as err:
                 error_handler.collect_error("schema_component_check", err)
             except errors.SchemaErrors as err:
-                for schema_error_dict in err._schema_error_dicts:
+                for schema_error_dict in err.schema_errors:
                     error_handler.collect_error(
                         "schema_component_check", schema_error_dict["error"]
                     )
@@ -1947,7 +1947,7 @@ class SeriesSchema(SeriesSchemaBase):
             try:
                 self.index(check_obj, head, tail, sample, random_state, lazy)
             except errors.SchemaErrors as err:
-                for schema_error_dict in err._schema_error_dicts:
+                for schema_error_dict in err.schema_errors:
                     error_handler.collect_error(
                         "index_check", schema_error_dict["error"]
                     )
@@ -1956,7 +1956,7 @@ class SeriesSchema(SeriesSchemaBase):
         try:
             super().validate(check_obj, head, tail, sample, random_state, lazy)
         except errors.SchemaErrors as err:
-            for schema_error_dict in err._schema_error_dicts:
+            for schema_error_dict in err.schema_errors:
                 error_handler.collect_error(
                     "series_check", schema_error_dict["error"]
                 )
@@ -2052,5 +2052,6 @@ def _handle_check_results(
             failure_cases=failure_cases,
             check=check,
             check_index=check_index,
+            check_output=check_result.check_output,
         )
     return check_result.check_passed

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -560,6 +560,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                 result = schema_component(
                     df_to_validate,
                     lazy=lazy if schema_component.has_subcomponents else None,
+                    # don't make a copy of the data
+                    inplace=True,
                 )
                 check_results.append(isinstance(result, pd.DataFrame))
             except errors.SchemaError as err:
@@ -1625,6 +1627,10 @@ class SeriesSchemaBase:
             series, head, tail, sample, random_state
         )
 
+        check_obj = _pandas_obj_to_validate(
+            check_obj, head, tail, sample, random_state
+        )
+
         if self.name is not None and series.name != self._name:
             msg = "Expected %s to have name '%s', found '%s'" % (
                 type(self),
@@ -1732,7 +1738,6 @@ class SeriesSchemaBase:
         if isinstance(check_obj, pd.Series):
             check_obj, check_args = series, [None]
         else:
-            check_obj = check_obj.loc[series.index.unique()].copy()
             check_args = [self.name]  # type: ignore
 
         for check_index, check in enumerate(self.checks):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1041,8 +1041,8 @@ def test_lazy_dataframe_validation_error():
 
         # make sure all expected check errors are in schema errors
         for schema_context, check_failure_cases in expectation.items():
-            err_df = err.schema_errors.loc[
-                err.schema_errors.schema_context == schema_context
+            err_df = err.failure_cases.loc[
+                err.failure_cases.schema_context == schema_context
             ]
             for check, failure_cases in check_failure_cases.items():
                 assert check in err_df.check.values
@@ -1078,7 +1078,7 @@ def test_lazy_dataframe_validation_nullable():
     try:
         schema.validate(df, lazy=True)
     except errors.SchemaErrors as err:
-        assert err.schema_errors.failure_case.isna().all()
+        assert err.failure_cases.failure_case.isna().all()
         for col, index in [
             ("int_column", 1),
             ("float_column", 2),
@@ -1086,7 +1086,7 @@ def test_lazy_dataframe_validation_nullable():
         ]:
             # pylint: disable=cell-var-from-loop
             assert (
-                err.schema_errors.loc[
+                err.failure_cases.loc[
                     lambda df: df.column == col, "index"
                 ].iloc[0]
                 == index
@@ -1212,9 +1212,9 @@ def test_lazy_series_validation_error(schema, data, expectation):
         for schema_context, check_failure_cases in expectation[
             "schema_errors"
         ].items():
-            assert schema_context in err.schema_errors.schema_context.values
-            err_df = err.schema_errors.loc[
-                err.schema_errors.schema_context == schema_context
+            assert schema_context in err.failure_cases.schema_context.values
+            err_df = err.failure_cases.loc[
+                err.failure_cases.schema_context == schema_context
             ]
             for check, failure_cases in check_failure_cases.items():
                 assert check in err_df.check.values


### PR DESCRIPTION
Fixes #317, #356 

This PR improves overall memory efficiency of `pandera` by minimizing
the number of views/copies being created during the validation routine.
This lowers  pandera's memory overhead so that it can handle larger
dataframes.

Another way it does this is by handling nulls in the `Check` class not
by dropping rows/elements that are `na` (thus creating copies), but by
ignoring null entries in the resulting `check_output`.

We also limit the number of failure cases captured and reported by
`pandera` to the `check.n_failure_cases` value.