### PR TITLE
bugfix: coerce nullable str column handles all na

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1543,9 +1543,14 @@ class SeriesSchemaBase:
             (including time series).
         :returns: ``Series`` with coerced data type
         """
-        if self._pandas_dtype is dtypes.PandasDtype.String:
-            # only coerce non-null elements to string
-            return obj.where(
+        if (
+            self._pandas_dtype is dtypes.PandasDtype.String
+            or self._pandas_dtype is str
+            or self._pandas_dtype == "str"
+        ):
+            # only coerce non-null elements to string, make sure series is of
+            # object dtype
+            return obj.astype(object).where(
                 obj.isna(),
                 obj.astype(str),
             )


### PR DESCRIPTION
this diff fixes an issue reported in #365 that fails to coerce
nullable string column in the case that all values are null.
The issue surfaces when reading a csv file when a column has
all null values, since these columns will be of float dtype. We
can reproduce this behavior by creating a null column in a
dataframe of float type.

Add tests to make sure this case is handled, along with the
nullable string and integer types in pandas>1.0.0.