### PR TITLE
bugfix: non-required columns that are not in dataframe are not coerced

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -330,7 +330,11 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                         obj[matched_colname] = _try_coercion(
                             col_schema.coerce_dtype, obj[matched_colname]
                         )
-            elif (col_schema.coerce or self.coerce) and self.pdtype is None:
+            elif (
+                (col_schema.coerce or self.coerce)
+                and self.pdtype is None
+                and colname in obj
+            ):
                 obj.loc[:, colname] = _try_coercion(
                     col_schema.coerce_dtype, obj[colname]
                 )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -609,9 +609,11 @@ def test_coerce_without_dtype():
 
 
 def test_required():
-    """Tests how a Required Column is handled when it's not included, included
+    """
+    Tests how a required Column is handled when it's not included, included
     and then not specified and a second column which is implicitly required
-    isn't available."""
+    isn't available.
+    """
     schema = DataFrameSchema(
         {"col1": Column(Int, required=False), "col2": Column(String)}
     )
@@ -634,6 +636,27 @@ def test_required():
 
     with pytest.raises(Exception):
         schema.validate(df_not_ok)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pd.DataFrame({"col": [1, 2, 3]}),
+        pd.DataFrame({"col": ["1", "2", "3"]}),
+        pd.DataFrame(),
+    ],
+)
+@pytest.mark.parametrize("required", [True, False])
+def test_coerce_not_required(data, required):
+    """Test that not required columns are not coerced."""
+    schema = DataFrameSchema(
+        {"col": Column(int, required=required)}, coerce=True
+    )
+    if required and data.empty:
+        with pytest.raises(errors.SchemaError):
+            schema(data)
+        return
+    schema(data)
 
 
 def test_head_dataframe_schema():


### PR DESCRIPTION
this diff fixes a bug where non-required column schemas that
are not present in the validated dataframe were attempted to
be coerced. Now if non-required column is not present, no
type coercion happens