### PR TITLE
bugfix: SchemaModel can use registered custom checks

### DIFF
--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -246,7 +246,7 @@ you can also use custom checks with the :ref:`class-based API<schema_models>`:
 
    class Schema(pa.SchemaModel):
        col1: Series[str] = pa.Field(custom_equals="value")
-       col2: Series[int] = pa.Field(in_between={"min_value": 0, "max_value": 10})
+       col2: Series[int] = pa.Field(is_between={"min_value": 0, "max_value": 10})
 
    data = pd.DataFrame({
        "col1": ["value"] * 5,

--- a/pandera/extensions.py
+++ b/pandera/extensions.py
@@ -139,9 +139,13 @@ def register_check_method(
             return check_kwargs
 
         @register_check_statistics(statistics)
-        def check_method(cls, **kwargs):
+        def check_method(cls, *args, **kwargs):
             """Wrapper function that serves as the Check method."""
             stats, check_kwargs = {}, {}
+
+            if args:
+                stats = dict(zip(statistics, args))
+
             for k, v in kwargs.items():
                 if k in statistics:
                     stats[k] = v


### PR DESCRIPTION
fixes #372

This PR fixes a bug where SchemaModels weren't able to use registered custom checks.

- Also improve `Field` docstring.