### PR TITLE
fix py3.6 optional + literal dtypes in SchemaModel

### DIFF
--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -130,13 +130,13 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
                 self.origin, self.arg = typing_inspect.get_args(
                     raw_annotation
                 )[0]
-                return
             # get_args -> (pandera.typing.Index[str], <class 'NoneType'>)
             raw_annotation = typing_inspect.get_args(raw_annotation)[0]
 
-        self.origin = typing_inspect.get_origin(raw_annotation)
-        args = typing_inspect.get_args(raw_annotation)
-        self.arg = args[0] if args else args
+        if not (self.optional and _LEGACY_TYPING):
+            self.origin = typing_inspect.get_origin(raw_annotation)
+            args = typing_inspect.get_args(raw_annotation)
+            self.arg = args[0] if args else args
 
         self.literal = typing_inspect.is_literal_type(self.arg)
         if self.literal:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 import pandera as pa
-from pandera.typing import DataFrame, Index, Series
+from pandera.typing import DataFrame, Index, Series, String
 
 
 def test_to_schema():
@@ -67,6 +67,7 @@ def test_optional_column():
     class Schema(pa.SchemaModel):
         a: Optional[Series[str]]
         b: Optional[Series[str]] = pa.Field(eq="b")
+        c: Optional[Series[String]]  # test pandera.typing alias
 
     schema = Schema.to_schema()
     assert not schema.columns["a"].required
@@ -79,10 +80,14 @@ def test_optional_index():
     class Schema(pa.SchemaModel):
         idx: Optional[Index[str]]
 
-    with pytest.raises(
-        pa.errors.SchemaInitError, match="Index 'idx' cannot be Optional."
-    ):
-        Schema.to_schema()
+    class SchemaWithAliasDtype(pa.SchemaModel):
+        idx: Optional[Index[String]]  # test pandera.typing alias
+
+    for model in (Schema, SchemaWithAliasDtype):
+        with pytest.raises(
+            pa.errors.SchemaInitError, match="Index 'idx' cannot be Optional."
+        ):
+            model.to_schema()
 
 
 def test_schemamodel_with_fields():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -72,6 +72,7 @@ def test_optional_column():
     schema = Schema.to_schema()
     assert not schema.columns["a"].required
     assert not schema.columns["b"].required
+    assert not schema.columns["c"].required
 
 
 def test_optional_index():


### PR DESCRIPTION
With python 3.6, class-based API with an optional column of type pandera.typing.* (i.e. a `Literal`) raises a `TypeError`

Closes #378 
