### PR TITLE
Fix minimally required packaging version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     data_files=[("", ["LICENSE.txt"])],
     packages=["pandera"],
     install_requires=[
-        "packaging",
+        "packaging >= 20.0",
         "numpy >= 1.9.0",
         "pandas >= 0.23.0",
         "typing_extensions ; python_version<'3.8'",


### PR DESCRIPTION
The `major` alias which is used in [dtypes.py](https://github.com/pandera-dev/pandera/blob/bfe404d20f2317d85d71ab098d76e6d7c7a78982/pandera/dtypes.py#L12) was added in version 20.0