### PR TITLE
Parametrized PandasExtensionType types

### DIFF
--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -149,12 +149,15 @@ Supported dtypes
 
 Any dtypes supported by ``pandera`` can be used as type parameters for
 :class:`~pandera.typing.Series` and :class:`~pandera.typing.Index`. There are,
-however, a couple of gotchas:
+however, a couple of gotchas.
 
-1. The enumeration :class:`~pandera.dtypes.PandasDtype` is not directly supported because
-   the type parameter of a :class:`typing.Generic` cannot be an enumeration [#dtypes]_.
-   Instead, you can use the :mod:`pandera.typing` counterparts:
-   :data:`pandera.typing.Category`, :data:`pandera.typing.Float32`, ...
+Dtype aliases
+^^^^^^^^^^^^^
+
+The enumeration :class:`~pandera.dtypes.PandasDtype` is not directly supported because
+the type parameter of a :class:`typing.Generic` cannot be an enumeration [#dtypes]_.
+Instead, you can use the :mod:`pandera.typing` counterparts:
+:data:`pandera.typing.Category`, :data:`pandera.typing.Float32`, ...
 
 :green:`✔` Good:
 
@@ -181,7 +184,10 @@ however, a couple of gotchas:
     ...
     AttributeError: type object 'Generic' has no attribute 'value'
 
-2. You must give a **type**, not an **instance**.
+Type Vs instance
+^^^^^^^^^^^^^^^^
+
+You must give a **type**, not an **instance**.
 
 :green:`✔` Good:
 
@@ -207,6 +213,43 @@ however, a couple of gotchas:
     Traceback (most recent call last):
     ...
     TypeError: Parameters to generic types must be types. Got StringDtype.
+
+Parametrized dtypes
+^^^^^^^^^^^^^^^^^^^
+Parameters for parametrized dtypes, such as :class:`~pandas.CategoricalDtype`
+or :class:`~pandas.DatetimeTZDtype`, can be given via :data:`typing.Annotated`.
+It requires python 3.9 or
+`typing_extensions <https://pypi.org/project/typing-extensions/>`_
+which is already a requirement of Pandera.
+
+:green:`✔` Good:
+
+.. testcode:: dataframe_schema_model
+
+    import sys
+
+    if sys.version_info[:2] < (3, 9):
+        from typing_extensions import Annotated
+    else:
+        from typing import Annotated
+
+    class Schema(pa.SchemaModel):
+        col: Series[Annotated[pd.DatetimeTZDtype, "ns", "est"]]
+
+Furthermore, you must pass all parameters in the order defined in the dtype's constructor.
+
+:red:`✘` Bad:
+
+.. testcode:: dataframe_schema_model
+
+    class Schema(pa.SchemaModel):
+        col: Series[Annotated[pd.DatetimeTZDtype, "utc"]]
+
+.. testoutput:: dataframe_schema_model
+
+    Traceback (most recent call last):
+    ...
+    TypeError: Annotation 'DatetimeTZDtype' requires all positional arguments ['unit', 'tz'].
 
 Required Columns
 ----------------

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -248,12 +248,10 @@ to python 3.6.
 .. testcode:: dataframe_schema_model
     :skipif: PY36
 
-    import sys
-
-    if (3, 6) < sys.version_info[:2] < (3, 9):
+    try:
+        from typing import Annotated  # python 3.9+
+    except ImportError:
         from typing_extensions import Annotated
-    else:
-        from typing import Annotated
 
     class Schema(pa.SchemaModel):
         col: Series[Annotated[pd.DatetimeTZDtype, "ns", "est"]]

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -243,12 +243,15 @@ Furthermore, you must pass all parameters in the order defined in the dtype's co
 :red:`✘` Bad:
 
 .. testcode:: dataframe_schema_model
-    :skipif: SKIP_PANDAS_LT_V1
+    :skipif: PY36
 
     class Schema(pa.SchemaModel):
         col: Series[Annotated[pd.DatetimeTZDtype, "utc"]]
 
+    Schema.to_schema()
+
 .. testoutput:: dataframe_schema_model
+    :skipif: PY36
 
     Traceback (most recent call last):
     ...

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -220,11 +220,13 @@ Parameters for parametrized dtypes, such as :class:`~pandas.CategoricalDtype`
 or :class:`~pandas.DatetimeTZDtype`, can be given via :data:`typing.Annotated`.
 It requires python 3.9 or
 `typing_extensions <https://pypi.org/project/typing-extensions/>`_
-which is already a requirement of Pandera.
+which is already a requirement of Pandera. Unfortunately :data:`typing.Annotated` has
+not been backported to python 3.6.
 
 :green:`✔` Good:
 
 .. testcode:: dataframe_schema_model
+    :skipif: SKIP_PANDAS_LT_V1
 
     import sys
 
@@ -241,6 +243,7 @@ Furthermore, you must pass all parameters in the order defined in the dtype's co
 :red:`✘` Bad:
 
 .. testcode:: dataframe_schema_model
+    :skipif: SKIP_PANDAS_LT_V1
 
     class Schema(pa.SchemaModel):
         col: Series[Annotated[pd.DatetimeTZDtype, "utc"]]

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - wrapt
   - pyyaml
   - typing_inspect
-  - typing_extensions
+  - typing_extensions>=3.7.4.3
 
   # testing and dependencies
   - black >= 20.8b1

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -34,7 +34,7 @@ from .typing import AnnotatedPandasExtensionType, AnnotationInfo, Index, Series
 if sys.version_info[:2] < (3, 9):  # pragma: no cover
     from typing_extensions import get_type_hints
 else:  # pragma: no cover
-    from typing import get_type_hints  # pylint:disable=no-name-in-module
+    from typing import get_type_hints
 
 SchemaIndex = Union[schema_components.Index, schema_components.MultiIndex]
 
@@ -342,7 +342,9 @@ class SchemaModel:
 
 
 def _get_field_annotations(model: Type[SchemaModel]) -> Dict[str, Any]:
-    annotations = get_type_hints(model, include_extras=True)
+    annotations = get_type_hints(  # pylint:disable=unexpected-keyword-arg
+        model, include_extras=True
+    )
 
     def _not_routine(member: Any) -> bool:
         return not inspect.isroutine(member)

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -216,6 +216,12 @@ class SchemaModel:
             check_name = getattr(field, "check_name", None)
 
             if annotation.metadata:
+                if field.dtype_kwargs:
+                    raise TypeError(
+                        "Cannot specify redundant 'dtype_kwargs' "
+                        + f"for {annotation.raw_annotation}."
+                        + "\n Usage Tip: Drop 'typing.Annotated'."
+                    )
                 dtype_kwargs = _get_dtype_kwargs(annotation)
                 dtype = annotation.arg(**dtype_kwargs)
             else:

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -54,6 +54,7 @@ class FieldInfo:
         "check_name",
         "alias",
         "original_name",
+        "dtype_kwargs",
     )
 
     def __init__(
@@ -65,6 +66,7 @@ class FieldInfo:
         regex: bool = False,
         alias: str = None,
         check_name: bool = None,
+        dtype_kwargs: Dict[str, Any] = None,
     ) -> None:
         self.checks = _to_checklist(checks)
         self.nullable = nullable
@@ -74,6 +76,7 @@ class FieldInfo:
         self.alias = alias
         self.check_name = check_name
         self.original_name = cast(str, None)  # always set by SchemaModel
+        self.dtype_kwargs = dtype_kwargs
 
     @property
     def name(self) -> str:
@@ -98,6 +101,8 @@ class FieldInfo:
         checks: _CheckList = None,
         **kwargs: Any,
     ) -> SchemaComponent:
+        if self.dtype_kwargs:
+            pandas_dtype = pandas_dtype(**self.dtype_kwargs)  # type: ignore
         checks = self.checks + _to_checklist(checks)
         return component(pandas_dtype, checks=checks, **kwargs)  # type: ignore
 
@@ -164,6 +169,7 @@ def Field(
     n_failure_cases: int = 10,
     alias: str = None,
     check_name: bool = None,
+    dtype_kwargs: Dict[str, Any] = None,
     **kwargs,
 ) -> Any:
     """Used to provide extra information about a field of a SchemaModel.
@@ -188,6 +194,7 @@ def Field(
     :param check_name: Whether to check the name of the column/index during
         validation. `None` is the default behavior, which translates to `True`
         for columns and multi-index, and to `False` for a single index.
+    :param dtype_kwargs: The parameters to be forwarded to the type of the field.
     :param kwargs: Specify custom checks that have been registered with the
         :class:`~pandera.extensions.register_check_method` decorator.
     """
@@ -227,6 +234,7 @@ def Field(
         regex=regex,
         check_name=check_name,
         alias=alias,
+        dtype_kwargs=dtype_kwargs,
     )
 
 

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -1,17 +1,8 @@
 """Typing definitions and helpers."""
+
 # pylint:disable=abstract-method,disable=too-many-ancestors
 import sys
-from inspect import signature
-from typing import (
-    TYPE_CHECKING,
-    Generic,
-    List,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Generic, Type, TypeVar
 
 import pandas as pd
 import typing_inspect
@@ -24,7 +15,7 @@ else:  # pragma: no cover
     from typing import Literal  # pylint:disable=no-name-in-module
 
 if sys.version_info[:2] < (3, 9):  # pragma: no cover
-    from typing_extensions import Annotated
+    from typing_extensions import Annotated  # pylint:disable=unused-import
 else:  # pragma: no cover
     from typing import Annotated  # pylint:disable=no-name-in-module
 
@@ -66,11 +57,6 @@ GenericDtype = TypeVar(  # type: ignore
     Literal[PandasDtype.String],
     Literal[PandasDtype.STRING],
     Literal[PandasDtype.Timedelta],
-    "CategoricalDtype",
-    "DatetimeTZDtype",
-    "IntervalDtype",
-    "PeriodDtype",
-    "SparseDtype",
     covariant=True,
 )
 Schema = TypeVar("Schema", bound="SchemaModel")  # type: ignore
@@ -158,49 +144,12 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
             self.arg = args[0] if args else args
 
         self.metadata = getattr(self.arg, "__metadata__", None)
+        if self.metadata:
+            self.arg = typing_inspect.get_args(self.arg)[0]
+
         self.literal = typing_inspect.is_literal_type(self.arg)
         if self.literal:
             self.arg = typing_inspect.get_args(self.arg)[0]
-
-
-class AnnotatedPandasExtensionType(type):
-    """Parametrized PandasExtensionType typing."""
-
-    default_dtype: Type[PandasExtensionType]
-    _arg_names: List[str]
-
-    @property
-    def arg_names(cls) -> List[str]:
-        """Return the name of the PandasExtensionType's constructor arguments."""
-        if getattr(cls, "_arg_names", None):
-            return cls._arg_names
-        cls._arg_names = [
-            name
-            for name, _ in signature(
-                cls.default_dtype.__class__
-            ).parameters.items()
-        ]
-        return cls._arg_names
-
-    def __getitem__(
-        cls, metadata: Union[Tuple[str], str]
-    ) -> Type[PandasExtensionType]:
-        """Let brackets [] pass type metadata, first metadata is the name of
-        PandasExtensionType's constructor arguments.
-        """
-        base_annotation = (cls.default_dtype.__class__, cls.arg_names)
-        if not isinstance(metadata, tuple):
-            metadata = (metadata,)
-
-        if len(metadata) != len(cls.arg_names):
-            raise TypeError(
-                f"Annotation '{cls.default_dtype.__class__.__name__}' requires "
-                + f"all positional arguments {cls.arg_names}."
-            )
-        return Annotated[base_annotation + cast(tuple, metadata)]
-
-    def __repr__(cls) -> str:
-        return cls.default_dtype.__class__.__name__
 
 
 Bool = Literal[PandasDtype.Bool]  #: ``"bool"`` numpy dtype
@@ -245,33 +194,3 @@ String = Literal[PandasDtype.String]  #: ``"str"`` numpy dtype
 #: ``"string"`` pandas dtypes: pandas 1.0.0+. For <1.0.0, this enum will
 #: fall back on the str-as-object-array representation.
 STRING = Literal[PandasDtype.STRING]  #: ``"str"`` numpy dtype
-
-
-class CategoricalDtype(metaclass=AnnotatedPandasExtensionType):
-    """Parametrized CategoricalDtype type hint."""
-
-    default_dtype = pd.CategoricalDtype()
-
-
-class DatetimeTZDtype(metaclass=AnnotatedPandasExtensionType):
-    """Parametrized DatetimeTZDtype type hint."""
-
-    default_dtype = pd.DatetimeTZDtype(unit="ns", tz="UTC")
-
-
-class IntervalDtype(metaclass=AnnotatedPandasExtensionType):
-    """Parametrized IntervalDtype type hint."""
-
-    default_dtype = pd.IntervalDtype()
-
-
-class PeriodDtype(pd.PeriodDtype, metaclass=AnnotatedPandasExtensionType):
-    """Parametrized PeriodDtype type hint."""
-
-    default_dtype = pd.PeriodDtype()
-
-
-class SparseDtype(metaclass=AnnotatedPandasExtensionType):
-    """Parametrized SparseDtype type hint."""
-
-    default_dtype = pd.SparseDtype()

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -248,20 +248,30 @@ STRING = Literal[PandasDtype.STRING]  #: ``"str"`` numpy dtype
 
 
 class CategoricalDtype(metaclass=AnnotatedPandasExtensionType):
+    """Parametrized CategoricalDtype type hint."""
+
     default_dtype = pd.CategoricalDtype()
 
 
 class DatetimeTZDtype(metaclass=AnnotatedPandasExtensionType):
+    """Parametrized DatetimeTZDtype type hint."""
+
     default_dtype = pd.DatetimeTZDtype(unit="ns", tz="UTC")
 
 
 class IntervalDtype(metaclass=AnnotatedPandasExtensionType):
+    """Parametrized IntervalDtype type hint."""
+
     default_dtype = pd.IntervalDtype()
 
 
 class PeriodDtype(pd.PeriodDtype, metaclass=AnnotatedPandasExtensionType):
+    """Parametrized PeriodDtype type hint."""
+
     default_dtype = pd.PeriodDtype()
 
 
 class SparseDtype(metaclass=AnnotatedPandasExtensionType):
+    """Parametrized SparseDtype type hint."""
+
     default_dtype = pd.SparseDtype()

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -9,17 +9,13 @@ import typing_inspect
 
 from .dtypes import PandasDtype, PandasExtensionType
 
-if sys.version_info[:2] < (3, 8):  # pragma: no cover
+if sys.version_info[:2] < (3, 8):
     from typing_extensions import Literal
-else:  # pragma: no cover
+else:
     from typing import Literal  # pylint:disable=no-name-in-module
 
-if sys.version_info[:2] < (3, 9):  # pragma: no cover
-    from typing_extensions import Annotated  # pylint:disable=unused-import
-else:  # pragma: no cover
-    from typing import Annotated  # pylint:disable=no-name-in-module
 
-_LEGACY_TYPING = sys.version_info[:3] < (3, 7, 0)
+LEGACY_TYPING = sys.version_info[:2] < (3, 7)
 
 GenericDtype = TypeVar(  # type: ignore
     "GenericDtype",
@@ -130,7 +126,7 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         self.optional = typing_inspect.is_optional_type(raw_annotation)
         if self.optional:
             # e.g: Typing.Union[pandera.typing.Index[str], NoneType]
-            if _LEGACY_TYPING:  # pragma: no cover
+            if LEGACY_TYPING:  # pragma: no cover
                 # get_args -> ((pandera.typing.Index, <class 'str'>), <class 'NoneType'>)
                 self.origin, self.arg = typing_inspect.get_args(
                     raw_annotation
@@ -138,7 +134,7 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
             # get_args -> (pandera.typing.Index[str], <class 'NoneType'>)
             raw_annotation = typing_inspect.get_args(raw_annotation)[0]
 
-        if not (self.optional and _LEGACY_TYPING):
+        if not (self.optional and LEGACY_TYPING):
             self.origin = typing_inspect.get_origin(raw_annotation)
             args = typing_inspect.get_args(raw_annotation)
             self.arg = args[0] if args else args

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -1,5 +1,4 @@
 """Typing definitions and helpers."""
-
 # pylint:disable=abstract-method,disable=too-many-ancestors
 import sys
 from typing import TYPE_CHECKING, Generic, Type, TypeVar
@@ -9,10 +8,10 @@ import typing_inspect
 
 from .dtypes import PandasDtype, PandasExtensionType
 
-if sys.version_info[:2] < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal  # pylint:disable=no-name-in-module
+try:  # python 3.8+
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
 
 
 LEGACY_TYPING = sys.version_info[:2] < (3, 7)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ scipy
 wrapt
 pyyaml
 typing_inspect
-typing_extensions
+typing_extensions>=3.7.4.3
 black >= 20.8b1
 isort >= 5.6.4
 codecov

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,7 +1,6 @@
 """Test typing annotations for the model api."""
 # pylint:disable=missing-class-docstring,too-few-public-methods
 import re
-import sys
 from typing import Any, Dict, Type
 
 import numpy as np
@@ -12,10 +11,11 @@ import pandera as pa
 from pandera.dtypes import LEGACY_PANDAS, PandasDtype
 from pandera.typing import LEGACY_TYPING, Series
 
-if sys.version_info[:2] >= (3, 9):
-    from typing import Annotated  # pylint:disable=no-name-in-module
-elif not LEGACY_TYPING:
-    from typing_extensions import Annotated
+if not LEGACY_TYPING:
+    try:  # python 3.9+
+        from typing import Annotated  # type: ignore
+    except ImportError:
+        from typing_extensions import Annotated  # type: ignore
 
 
 class SchemaBool(pa.SchemaModel):


### PR DESCRIPTION
This PR attempts to implement parametrized PandasExtensionType types as discussed in #376.

I have a working implemention but mypy chokes on dynamically defined [Annotated](https://docs.python.org/3.9/library/typing.html#typing.Annotated) types. 

```python
import pandas as pd
from typing_extensions import Annotated, Literal

import pandera as pa
from pandera.typing import Series


class Schema(pa.SchemaModel):

    A: Series[Annotated[pd.DatetimeTZDtype, "ns", "EST"]]  # ok

    B: Series[Annotated[pd.CategoricalDtype, ["b", "a"], True]]  # ok

    ## fail cases

    C: Series[pa.typing.DatetimeTZDtype[Literal["ns"], Literal["EST"]]]

    D: Series[pa.typing.DatetimeTZDtype["ns", "EST"]]

    E: Series[pa.typing.CategoricalDtype[["b", "a"], True]]


#### C
# test_annotated.py:16: error: "DatetimeTZDtype" expects no type arguments, but 2 given
#### D
# test_annotated.py:18: error: "DatetimeTZDtype" expects no type arguments, but 2 given
# test_annotated.py:18: error: Name 'ns' is not defined
# test_annotated.py:18: error: Name 'EST' is not defined
#### E
# test_annotated.py:20: error: Bracketed expression "[...]" is not valid as a type
# test_annotated.py:20: note: Did you mean "List[...]"?
# test_annotated.py:20: error: Invalid type: try using Literal[True] instead?
# test_annotated.py:20: error: "CategoricalDtype" expects no type arguments, but 2 given
```

According to [a mypy issue](https://github.com/python/mypy/issues/6939):

> "\<something\>[\<something else\>] is a reserved syntax in mypy if \<something\> is a type. "

I tried to fool mypy with:

```python
from typing import TYPE_CHECKING, TypeVar, Generic


T = TypeVar("T")
U = TypeVar("U")

if TYPE_CHECKING:

    class CategoricalDtype(Generic[T, U]):
        pass

    class DatetimeTZDtype(Generic[T]):
        pass


else:

    class CategoricalDtype(metaclass=AnnotatedPandasExtensionType):
        default_dtype = pd.CategoricalDtype()

    class DatetimeTZDtype(metaclass=AnnotatedPandasExtensionType):
        default_dtype = pd.DatetimeTZDtype(unit="ns", tz="UTC")
``` 
It eliminates the `expects no type arguments, but X given` errors, which means **C** is accepted (must use `Literal`).

TL;DR: our options are:
1. `Series[Annotated[pd.DatetimeTZDtype, "ns", "EST"]]`: annoying to force most users to `from typing_extensions import Annotated`.  Annotated is formally introduced in py3.9
2. `Series[pa.typing.DatetimeTZDtype[Literal["ns"], Literal["EST"]]]`: verbose :clown_face:
3. A savior finds a hack for mypy :tada: (not a mypy-plugin...)
4. Switch to another approach. Perhaps `datetime_tz: Series[pd.DatetimeTZDtype] = pa.Field(type_kwargs={"tz": "utc"})`

Honestly it's a tough choice, curious to hear your thoughts ! @cosmicBboy @amitripshtos 
