### PR TITLE
bugfix: df data synthesis with size=None, fix CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -98,14 +98,36 @@ for each pull request:
 This project uses [pre-commit](https://pre-commit.com/) to ensure that code
 standard checks pass locally before pushing to the remote project repo. Follow
 the [installation instructions](https://pre-commit.com/#installation), then
-set up hooks with `pre-commit install`. After, `black`, `pylint` and `mypy` checks should
-be run with every commit.
+set up hooks with `pre-commit install`. After, `black`, `pylint` and `mypy`
+checks should be run with every commit.
 
-### Run the test suite
+### Run the test suite locally
 
 Before submitting your changes for review, make sure to check that your changes
-do not break any tests by running: `nox` or `nox -db conda` depending on your environment.
+do not break any tests by running:
 
+```
+# if you're working with virtualenv
+$ make nox
+
+# if you're working with conda
+$ make nox-conda
+```
+
+: `nox` or `nox -db conda` depending on your
+environment.
+
+#### Using `mamba` (optional)
+
+You can also use [mamba](https://github.com/mamba-org/mamba), which is a faster
+implementation of [miniconda](https://docs.conda.io/en/latest/miniconda.html),
+to run the `nox` test suite. Simply install it via conda-forge, and
+`make nox-conda` should use it under the hood.
+
+```
+$ conda install -c conda-forge mamba
+$ make nox-conda
+```
 
 ### Raising Pull Requests
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -114,9 +114,6 @@ $ make nox
 $ make nox-conda
 ```
 
-: `nox` or `nox -db conda` depending on your
-environment.
-
 #### Using `mamba` (optional)
 
 You can also use [mamba](https://github.com/mamba-org/mamba), which is a faster

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   DEFAULT_PYTHON: 3.8
+  CI: "true"
   # Increase this value to reset cache if environment.yml has not changed
   CACHE_VERSION: 0
 
@@ -36,7 +37,9 @@ jobs:
         with:
           activate-environment: pandera-dev
           auto-update-conda: false
+          channels: conda-forge
           python-version: ${{ env.DEFAULT_PYTHON }}
+          mamba-version: "*"
           environment-file: environment.yml
           use-only-tar-bz2: true
           auto-activate-base: false
@@ -164,28 +167,28 @@ jobs:
       - name: Unit Tests - Core
         run: >
           nox
-          -db conda -r
+          -db conda -r -v
           --non-interactive
           --session "tests-${{ matrix.python-version }}(extra='core', pandas='${{ matrix.pandas-version }}')"
 
       - name: Unit Tests - Hypotheses
         run: >
           nox
-          -db conda -r
+          -db conda -r -v
           --non-interactive
           --session "tests-${{ matrix.python-version }}(extra='hypotheses', pandas='${{ matrix.pandas-version }}')"
 
       - name: Unit Tests - IO
         run: >
           nox
-          -db conda -r
+          -db conda -r -v
           --non-interactive
           --session "tests-${{ matrix.python-version }}(extra='io', pandas='${{ matrix.pandas-version }}')"
 
       - name: Unit Tests - Strategies
         run: >
           nox
-          -db conda -r
+          -db conda -r -v
           --non-interactive
           --session "tests-${{ matrix.python-version }}(extra='strategies', pandas='${{ matrix.pandas-version }}')"
 
@@ -195,6 +198,6 @@ jobs:
       - name: Check Docs
         run: >
           nox
-          -db conda -r
+          -db conda -r -v
           --non-interactive
           --session "docs-${{ matrix.python-version }}(pandas='${{ matrix.pandas-version }}')"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,11 +35,12 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: pandera-dev
-          auto-update-conda: false
-          channels: conda-forge
           python-version: ${{ env.DEFAULT_PYTHON }}
           mamba-version: "*"
+          channels: conda-forge
+          channel-priority: true
+          activate-environment: pandera-dev
+          auto-update-conda: false
           environment-file: environment.yml
           use-only-tar-bz2: true
           auto-activate-base: false
@@ -83,9 +84,12 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          mamba-version: "*"
+          channels: conda-forge
+          channel-priority: true
           activate-environment: pandera-dev
           auto-update-conda: false
-          python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
           use-only-tar-bz2: true
           auto-activate-base: false
@@ -152,9 +156,12 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          mamba-version: "*"
+          channels: conda-forge
+          channel-priority: true
           activate-environment: pandera-dev
-          auto-update-conda: ${{ runner.os == 'Windows' }}
-          python-version: ${{ matrix.python-version }}
+          auto-update-conda: false
           environment-file: environment.yml
           use-only-tar-bz2: true
           auto-activate-base: false

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ venv.bak/
 
 # Docs
 docs/source/generated
+
+# Nox
+.nox
+.nox-*

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 .PHONY: tests clean clean-pyc upload-pypi-test upload-pypi requirements docs \
 	code-cov
 
-tests:
-	pytest
-
 clean:
 	python setup.py clean
 
@@ -23,10 +20,11 @@ upload-pypi:
 requirements:
 	pip install -r requirements-dev.txt
 
-docs:
-	rm -rf docs/source/generated && \
-		python -m sphinx -E "docs/source" "docs/_build" -W && \
-		make -C docs doctest
-
 code-cov:
 	pytest --cov-report=html --cov=pandera tests/
+
+nox:
+	nox -r
+
+nox-conda:
+	nox -r -db conda --envdir .nox-conda

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ code-cov:
 	pytest --cov-report=html --cov=pandera tests/
 
 nox:
-	nox -r
+	nox -r --envdir .nox-virtualenv
 
 nox-conda:
 	nox -r -db conda --envdir .nox-conda

--- a/noxfile.py
+++ b/noxfile.py
@@ -144,7 +144,7 @@ def conda_install(session: Session, *args):
 def install(session: Session, *args: str):
     """Install dependencies in the appropriate virtual environment
     (conda or virtualenv) and return the type of the environmment."""
-    if session.virtualenv is nox.virtualenv.CondaEnv:
+    if isinstance(session.virtualenv, nox.virtualenv.CondaEnv):
         print("using conda installer")
         conda_install(session, *args)
     else:
@@ -173,7 +173,7 @@ def install_extras(
         spec if spec != "pandas" else f"pandas{pandas_version}"
         for spec in REQUIRES[extra].values()
     ]
-    if session.virtualenv is nox.virtualenv.CondaEnv:
+    if isinstance(session.virtualenv, nox.virtualenv.CondaEnv):
         print("using conda installer")
         conda_install(session, *specs)
     else:

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,6 +34,10 @@ SOURCE_PATHS = PACKAGE, "tests", "noxfile.py"
 REQUIREMENT_PATH = "requirements-dev.txt"
 
 CI_RUN = os.environ.get("CI") == "true"
+if CI_RUN:
+    print("Running on CI")
+else:
+    print("Running locally")
 
 LINE_LENGTH = 79
 
@@ -141,8 +145,10 @@ def install(session: Session, *args: str):
     """Install dependencies in the appropriate virtual environment
     (conda or virtualenv) and return the type of the environmment."""
     if session.virtualenv is nox.virtualenv.CondaEnv:
+        print("using conda installer")
         conda_install(session, *args)
     else:
+        print("using pip installer")
         session.install(*args)
 
 
@@ -168,9 +174,10 @@ def install_extras(
         for spec in REQUIRES[extra].values()
     ]
     if session.virtualenv is nox.virtualenv.CondaEnv:
+        print("using conda installer")
         conda_install(session, *specs)
     else:
-        # Not a conda venv
+        print("using pip installer")
         session.install(*specs)
     session.install("-e", ".", "--no-deps")  # install pandera
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,6 +12,7 @@ from distutils.core import run_setup  # pylint:disable=wrong-import-order
 import nox
 from nox import Session
 from pkg_resources import Requirement, parse_requirements
+from packaging import version
 
 
 nox.options.sessions = (
@@ -103,17 +104,46 @@ def _build_requires() -> Dict[str, Dict[str, str]]:
 
 REQUIRES: Dict[str, Dict[str, str]] = _build_requires()
 
+CONDA_ARGS = [
+    "--channel=conda-forge",
+    "--update-specs",
+]
 
-def install(session: Session, *args: str) -> str:
+
+def conda_install(session: Session, *args):
+    """Use mamba to install conda dependencies."""
+    run_args = [
+        "install",
+        "--yes",
+        *CONDA_ARGS,
+        "--prefix",
+        session.virtualenv.location,  # type: ignore
+        *args,
+    ]
+
+    # By default, all dependencies are re-installed from scratch with each
+    # session. Specifying external=True allows access to cached packages, which
+    # decreases runtime of the test sessions.
+    try:
+        session.run(
+            *["mamba", *run_args],
+            external=True,
+        )
+    # pylint: disable=broad-except
+    except Exception:
+        session.run(
+            *["conda", *run_args],
+            external=True,
+        )
+
+
+def install(session: Session, *args: str):
     """Install dependencies in the appropriate virtual environment
     (conda or virtualenv) and return the type of the environmment."""
-    try:
-        session.conda_install("--channel=conda-forge", *args)
-        return "conda"
-    except ValueError:
-        # Not a conda venv
+    if session.virtualenv is nox.virtualenv.CondaEnv:
+        conda_install(session, *args)
+    else:
         session.install(*args)
-        return "virtualenv"
 
 
 def install_from_requirements(session: Session, *packages: str) -> None:
@@ -128,15 +158,21 @@ def install_from_requirements(session: Session, *packages: str) -> None:
         install(session, specs)
 
 
-def install_extras(session: Session, extra: str = "core") -> None:
+def install_extras(
+    session: Session, pandas: str = "latest", extra: str = "core"
+) -> None:
     """Install dependencies."""
-    specs = REQUIRES[extra].values()
-    try:
-        session.conda_install("--channel=conda-forge", *specs)
-    except ValueError:
+    pandas_version = "" if pandas == "latest" else f"=={pandas}"
+    specs = [
+        spec if spec != "pandas" else f"pandas{pandas_version}"
+        for spec in REQUIRES[extra].values()
+    ]
+    if session.virtualenv is nox.virtualenv.CondaEnv:
+        conda_install(session, *specs)
+    else:
         # Not a conda venv
         session.install(*specs)
-    session.install(".")  # install pandera
+    session.install("-e", ".", "--no-deps")  # install pandera
 
 
 def _generate_pip_deps_from_conda(
@@ -227,18 +263,19 @@ def mypy(session: Session) -> None:
     session.run("mypy", "--follow-imports=silent", *args, silent=True)
 
 
-def _install_pandas(session: Session, pandas: str) -> bool:
-    python_version = cast(str, session.python)
-    if pandas == "0.25.3" and python_version >= "3.9":
+def _invalid_python_pandas_versions(session: Session, pandas: str) -> bool:
+    python_version = version.parse(cast(str, session.python))
+    if pandas == "0.25.3" and python_version >= version.parse("3.9"):
         print("Python 3.9 does not support pandas 0.25.3")
-        return False
-
-    pandas_version = "" if pandas == "latest" else f"=={pandas}"
-    install(session, f"pandas{pandas_version}")
-    return True
+        return True
+    return False
 
 
-EXTRA_NAMES = [extra for extra in REQUIRES if extra != "all"]
+EXTRA_NAMES = [
+    extra
+    for extra in REQUIRES
+    if extra != "all" and not extra.startswith(":python_version")
+]
 
 
 @nox.session(python=PYTHON_VERSIONS)
@@ -246,9 +283,9 @@ EXTRA_NAMES = [extra for extra in REQUIRES if extra != "all"]
 @nox.parametrize("extra", EXTRA_NAMES)
 def tests(session: Session, pandas: str, extra: str) -> None:
     """Run the test suite."""
-    if not _install_pandas(session, pandas):
+    if _invalid_python_pandas_versions(session, pandas):
         return
-    install_extras(session, extra)
+    install_extras(session, pandas, extra)
 
     if session.posargs:
         args = session.posargs
@@ -257,7 +294,11 @@ def tests(session: Session, pandas: str, extra: str) -> None:
         args = []
         if extra == "strategies":
             # enable threading via pytest-xdist
-            args = ["-n=auto", "-q", "--hypothesis-profile=ci"]
+            args = [
+                "-n=auto",
+                "-q",
+                f"--hypothesis-profile={'ci' if CI_RUN else 'dev'}",
+            ]
         args += [
             f"--cov={PACKAGE}",
             "--cov-report=term-missing",
@@ -275,9 +316,9 @@ def tests(session: Session, pandas: str, extra: str) -> None:
 @nox.parametrize("pandas", ["0.25.3", "latest"])
 def docs(session: Session, pandas: str) -> None:
     """Build the documentation."""
-    if not _install_pandas(session, pandas):
+    if _invalid_python_pandas_versions(session, pandas):
         return
-    install_extras(session, extra="all")
+    install_extras(session, pandas, extra="all")
     session.chdir("docs")
 
     args = session.posargs or ["-W", "-E", "-b=doctest", "source", "_build"]

--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -120,12 +120,11 @@ def null_dataframe_masks(
 def set_pandas_index(
     draw,
     df_or_series_strat: SearchStrategy,
-    index_strat: SearchStrategy,
+    index: IndexComponent,
 ):
     """Sets Index or MultiIndex object to pandas Series or DataFrame."""
     df_or_series = draw(df_or_series_strat)
-    index = draw(index_strat)
-    df_or_series.index = index
+    df_or_series.index = draw(index.strategy(size=df_or_series.shape[0]))
     return df_or_series
 
 
@@ -1014,7 +1013,7 @@ def dataframe_strategy(
             strategy = null_dataframe_masks(strategy, nullable_columns)
 
         if index is not None:
-            strategy = set_pandas_index(strategy, index.strategy(size=size))
+            strategy = set_pandas_index(strategy, index)
 
         for check in undefined_strat_df_checks:
             strategy = undefined_check_strategy(strategy, check)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,6 @@ collect_ignore = []
 if not HAS_HYPOTHESIS:
     collect_ignore.append("test_strategies.py")
 else:
-    settings.register_profile("ci", max_examples=100)
-    settings.register_profile("dev", max_examples=10)
+    settings.register_profile("ci", max_examples=100, deadline=5000)
+    settings.register_profile("dev", max_examples=10, deadline=2000)
     settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -137,7 +137,6 @@ def value_ranges(pdtype: pa.PandasDtype):
 )
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_check_strategy_chained_continuous(
@@ -184,7 +183,6 @@ def test_check_strategy_chained_continuous(
 @pytest.mark.parametrize("chained", [True, False])
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_in_range_strategy(pdtype, chained, data):
@@ -226,7 +224,6 @@ def test_in_range_strategy(pdtype, chained, data):
 @pytest.mark.parametrize("chained", [True, False])
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_isin_notin_strategies(pdtype, chained, data):
@@ -403,7 +400,6 @@ def test_register_check_strategy_exception():
 
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_series_strategy(data):
@@ -443,7 +439,6 @@ def test_column_example():
 )
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_dataframe_strategy(pdtype, size, data):
@@ -483,7 +478,6 @@ def test_dataframe_example():
 )
 @hypothesis.given(st.data(), st.integers(min_value=-10, max_value=30))
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_dataframe_with_regex(regex, data, n_regex_columns):
@@ -505,7 +499,6 @@ def test_dataframe_with_regex(regex, data, n_regex_columns):
 
 @pytest.mark.parametrize("pdtype", NUMERIC_DTYPES)
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 @hypothesis.given(st.data())
@@ -529,7 +522,6 @@ def test_dataframe_checks(pdtype, data):
 @pytest.mark.parametrize("pdtype", [pa.Int, pa.Float, pa.String, pa.DateTime])
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_dataframe_strategy_with_indexes(pdtype, data):
@@ -549,7 +541,6 @@ def test_dataframe_strategy_with_indexes(pdtype, data):
 
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_index_strategy(data):
@@ -575,7 +566,6 @@ def test_index_example():
 
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_multiindex_strategy(data):
@@ -639,7 +629,6 @@ def test_field_element_strategy(pdtype, data):
 @pytest.mark.parametrize("nullable", [True, False])
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_check_nullable_field_strategy(pdtype, field_strategy, nullable, data):
@@ -668,7 +657,6 @@ def test_check_nullable_field_strategy(pdtype, field_strategy, nullable, data):
 @pytest.mark.parametrize("nullable", [True, False])
 @hypothesis.given(st.data())
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )
 def test_check_nullable_dataframe_strategy(pdtype, nullable, data):
@@ -716,7 +704,6 @@ def test_check_nullable_dataframe_strategy(pdtype, nullable, data):
     ],
 )
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[
         hypothesis.HealthCheck.filter_too_much,
         hypothesis.HealthCheck.too_slow,
@@ -773,7 +760,6 @@ def test_series_strategy_undefined_check_strategy(schema, warning, data):
     ],
 )
 @hypothesis.settings(
-    deadline=2000,
     suppress_health_check=[
         hypothesis.HealthCheck.filter_too_much,
         hypothesis.HealthCheck.too_slow,

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -773,6 +773,7 @@ def test_series_strategy_undefined_check_strategy(schema, warning, data):
     ],
 )
 @hypothesis.settings(
+    deadline=2000,
     suppress_health_check=[
         hypothesis.HealthCheck.filter_too_much,
         hypothesis.HealthCheck.too_slow,

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -439,7 +439,7 @@ def test_column_example():
 )
 @pytest.mark.parametrize(
     "size",
-    [None, 0, 1, 3, 5, 10, 100],
+    [None, 0, 1, 3, 5],
 )
 @hypothesis.given(st.data())
 @hypothesis.settings(

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -476,7 +476,7 @@ def test_dataframe_example():
         "[a-z]+_[0-9]+_[a-z]+",
     ],
 )
-@hypothesis.given(st.data(), st.integers(min_value=-10, max_value=30))
+@hypothesis.given(st.data(), st.integers(min_value=-5, max_value=5))
 @hypothesis.settings(
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
 )


### PR DESCRIPTION
Fixes #399: this PR fixes a bug in the dataframe synthesis logic in the `strategies` module where a length mismatch in a generated dataframe and index would occur, see [here](https://github.com/pandera-dev/pandera/issues/399#issuecomment-776085393) for an example.

It also fixes an issue with the CI #409 where the latest version of pandas would be installed in the virtual environment regardless of whether `0.25.3` or the latest version were specified in the `nox` test suite. It also makes the following changes to the `nox` test suite:
- optional use of `mamba` in local CI
- use `mamba` in the github action
- specify `external=True` in the conda install command so that the installation process uses the underlying cache (the native `nox.session.conda_install` would re-install all dependencies from strach)