### PR TITLE
bugfix: SeriesSchema raises SchemaErrors on lazy validation

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 3
 
       - name: Cache conda
         uses: actions/cache@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,8 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        # with:
-        #  fetch-depth: 3
 
       - name: Cache conda
         uses: actions/cache@v2

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -540,6 +540,11 @@ class MultiIndex(DataFrameSchema):
         """Whether or not to coerce data types."""
         return self._coerce or any(index.coerce for index in self.indexes)
 
+    @coerce.setter
+    def coerce(self, value: bool) -> None:
+        """Set coerce attribute."""
+        self._coerce = value
+
     def coerce_dtype(self, obj: pd.MultiIndex) -> pd.MultiIndex:
         """Coerce type of a pd.Series by type specified in pandas_dtype.
 
@@ -611,9 +616,7 @@ class MultiIndex(DataFrameSchema):
         # pylint: disable=too-many-locals
         if self.coerce:
             try:
-                check_obj.index = self.coerce_dtype(
-                    check_obj.index if inplace else check_obj.index
-                )
+                check_obj.index = self.coerce_dtype(check_obj.index)
             except errors.SchemaErrors as err:
                 if lazy:
                     raise
@@ -624,9 +627,9 @@ class MultiIndex(DataFrameSchema):
         # DataFrameSchema.validate call. Need to fix this by having MultiIndex
         # not inherit from DataFrameSchema.
         self_copy = deepcopy(self)
-        self_copy._coerce = False
+        self_copy.coerce = False
         for index in self_copy.indexes:
-            index._coerce = False
+            index.coerce = False
 
         # rename integer-based column names in case of duplicate index names,
         # with at least one named index.

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1668,12 +1668,15 @@ class SeriesSchemaBase:
                 self._name,
                 series.name,
             )
-            raise errors.SchemaError(
-                self,
-                check_obj,
-                msg,
-                failure_cases=scalar_failure_case(series.name),
-                check=f"column_name('{self._name}')",
+            error_handler.collect_error(
+                "wrong_field_name",
+                errors.SchemaError(
+                    self,
+                    check_obj,
+                    msg,
+                    failure_cases=scalar_failure_case(series.name),
+                    check=f"field_name('{self._name}')",
+                ),
             )
 
         series_dtype = series.dtype
@@ -1761,9 +1764,6 @@ class SeriesSchemaBase:
                     check=f"pandas_dtype('{self.dtype}')",
                 ),
             )
-
-        if not self.checks:
-            return check_obj
 
         check_results = []
         if isinstance(check_obj, pd.Series):
@@ -1976,7 +1976,9 @@ class SeriesSchema(SeriesSchemaBase):
         # validate index
         if self.index:
             try:
-                self.index(check_obj, head, tail, sample, random_state, lazy)
+                self.index(
+                    check_obj, head, tail, sample, random_state, lazy, inplace
+                )
             except errors.SchemaErrors as err:
                 for schema_error_dict in err.schema_errors:
                     error_handler.collect_error(
@@ -1985,7 +1987,9 @@ class SeriesSchema(SeriesSchemaBase):
 
         # validate series
         try:
-            super().validate(check_obj, head, tail, sample, random_state, lazy)
+            super().validate(
+                check_obj, head, tail, sample, random_state, lazy, inplace
+            )
         except errors.SchemaErrors as err:
             for schema_error_dict in err.schema_errors:
                 error_handler.collect_error(

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -185,6 +185,11 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         """Whether to coerce series to specified type."""
         return self._coerce
 
+    @coerce.setter
+    def coerce(self, value: bool) -> None:
+        """Set coerce attribute"""
+        self._coerce = value
+
     @property
     def ordered(self):
         """Whether or not to validate the columns order."""
@@ -313,7 +318,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                 obj,
                 msg,
                 failure_cases=scalar_failure_case(str(obj.dtypes.to_dict())),
-                check=f"coerce_dtype({self.pdtype.str_alias})",
+                check=f"coerce_dtype('{self.pdtype.str_alias}')",
             ) from exc
 
     def coerce_dtype(self, obj: pd.DataFrame) -> pd.DataFrame:
@@ -1528,6 +1533,11 @@ class SeriesSchemaBase:
         """Whether to coerce series to specified type."""
         return self._coerce
 
+    @coerce.setter
+    def coerce(self, value: bool) -> None:
+        """Set coerce attribute."""
+        self._coerce = value
+
     @property
     def name(self) -> Union[str, None]:
         """Get SeriesSchema name."""
@@ -1592,8 +1602,8 @@ class SeriesSchemaBase:
                 self,
                 obj,
                 msg,
-                failure_cases=scalar_failure_case(obj.dtype),
-                check=f"coerce_dtype({self.dtype})",
+                failure_cases=scalar_failure_case(str(obj.dtype)),
+                check=f"coerce_dtype('{self.dtype}')",
             ) from exc
 
     @property
@@ -1967,24 +1977,23 @@ class SeriesSchema(SeriesSchemaBase):
             except errors.SchemaError as exc:
                 error_handler.collect_error("dtype_coercion_error", exc)
 
-        if self.index is not None and (self.index.coerce or self.coerce):
-            try:
-                check_obj.index = self.index.coerce_dtype(check_obj.index)
-            except errors.SchemaError as exc:
-                error_handler.collect_error("dtype_coercion_error", exc)
-
         # validate index
         if self.index:
+            # coerce data type using index schema copy to prevent mutation
+            # of original index schema attribute.
+            _index = copy.deepcopy(self.index)
+            _index.coerce = _index.coerce or self.coerce
             try:
-                self.index(
+                check_obj = _index(
                     check_obj, head, tail, sample, random_state, lazy, inplace
                 )
+            except errors.SchemaError as exc:
+                error_handler.collect_error("dtype_coercion_error", exc)
             except errors.SchemaErrors as err:
                 for schema_error_dict in err.schema_errors:
                     error_handler.collect_error(
                         "index_check", schema_error_dict["error"]
                     )
-
         # validate series
         try:
             super().validate(

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -193,6 +193,11 @@ def test_dataframe_pandas_dtype_coerce():
     with pytest.raises(ValueError):
         schema._coerce_dtype(df)
 
+    # test setting coerce as false at the dataframe level no longer coerces
+    # columns to int
+    schema.coerce = False
+    assert (schema(df).dtypes == "float64").all()
+
 
 def test_dataframe_coerce_regex():
     """Test dataframe pandas dtype coercion for regex columns"""
@@ -877,6 +882,10 @@ def test_add_and_remove_columns():
 
     assert schema4 == expected_schema_4 == schema1
 
+    # test raising error if column name is not in the schema
+    with pytest.raises(errors.SchemaInitError):
+        schema2.remove_columns(["foo", "bar"])
+
 
 def test_schema_get_dtype():
     """Test that schema dtype and get_dtype methods handle regex columns."""
@@ -1000,6 +1009,11 @@ def test_rename_columns():
 
     with pytest.raises(errors.SchemaInitError):
         schema_original.rename_columns({"foo": "bar"})
+
+    # Test raising error if new column name is already in schema
+    for rename_dict in [{"col1": "col2"}, {"col2": "col1"}]:
+        with pytest.raises(errors.SchemaInitError):
+            schema_original.rename_columns(rename_dict)
 
 
 @pytest.mark.parametrize(
@@ -1194,6 +1208,42 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
                 "data": pd.Series([0.1]),
                 "schema_errors": {
                     "SeriesSchema": {"pandas_dtype('int64')": ["float64"]},
+                },
+            },
+        ],
+        # case: series index doesn't satisfy schema index
+        [
+            SeriesSchema(index=Index(int)),
+            pd.Series([1, 2, 3], index=list("abc")),
+            {
+                "data": pd.Series([1, 2, 3], index=list("abc")),
+                "schema_errors": {
+                    "Index": {"pandas_dtype('int64')": ["object"]},
+                },
+            },
+        ],
+        # case: SeriesSchema data-type coercion error
+        [
+            SeriesSchema(float, coerce=True),
+            pd.Series(["1", "foo", "bar"]),
+            {
+                "data": pd.Series(["1", "foo", "bar"]),
+                "schema_errors": {
+                    "SeriesSchema": {
+                        "pandas_dtype('float64')": ["object"],
+                        "coerce_dtype('float64')": ["object"],
+                    },
+                },
+            },
+        ],
+        # case: series index coercion error
+        [
+            SeriesSchema(index=Index(int, coerce=True)),
+            pd.Series([1, 2, 3], index=list("abc")),
+            {
+                "data": pd.Series([1, 2, 3], index=list("abc")),
+                "schema_errors": {
+                    "Index": {"coerce_dtype('int64')": ["object"]},
                 },
             },
         ],


### PR DESCRIPTION
Fixes #407 and #408

This PR fixes a bug in `SeriesSchema` lazy validation where mismatching names or types would raise a `SchemaError` instead of `SchemaErrors`.