### PR TITLE
[bugfix] pa.Object coerce should preserve object type

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,11 +78,10 @@ source_suffix = {
 }
 
 # copy CONTRIBUTING.md docs into source directory
+root_dir = os.path.dirname(__file__)
 shutil.copyfile(
-    os.path.join(
-        os.path.dirname(__file__), "..", "..", ".github", "CONTRIBUTING.md"
-    ),
-    "CONTRIBUTING.md",
+    os.path.join(root_dir, "..", "..", ".github", "CONTRIBUTING.md"),
+    os.path.join(root_dir, "CONTRIBUTING.md"),
 )
 
 # Add any paths that contain templates here, relative to this directory.

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - isort >= 5.7.0
   - codecov
   - mypy
-  - pylint>=2.4.4
+  - pylint = 2.6.0
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1631,9 +1631,10 @@ class SeriesSchemaBase:
         :returns: ``Series`` with coerced data type
         """
         if (
-            self._pandas_dtype is dtypes.PandasDtype.String
+            self._pandas_dtype is PandasDtype.String
             or self._pandas_dtype is str
             or self._pandas_dtype == "str"
+            and self._pandas_dtype is not PandasDtype.Object
         ):
             # only coerce non-null elements to string, make sure series is of
             # object dtype

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ black >= 20.8b1
 isort >= 5.7.0
 codecov
 mypy
-pylint>=2.4.4
+pylint == 2.6.0
 pytest
 pytest-cov
 pytest-xdist

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -592,6 +592,26 @@ def test_coerce_dtype_nullable_str(
             assert pd.isna(element)
 
 
+@pytest.mark.parametrize(
+    "data, expected_type",
+    [
+        [{"a": 1, "b": 2, "c": 3}, dict],
+        [[1, 2, 3, 4], list],
+        [[1, {"a": 5}], list],
+        [{1, 2, 3}, set],
+    ],
+)
+@pytest.mark.parametrize("dtype", ["object", object, Object])
+def test_coerce_object_dtype(data, expected_type, dtype):
+    """Test coercing on object dtype."""
+    schema = DataFrameSchema({"col": Column(dtype)}, coerce=True)
+    df = pd.DataFrame({"col": [data] * 3})
+    validated_df = schema(df)
+    assert isinstance(validated_df, pd.DataFrame)
+    for _, x in validated_df["col"].iteritems():
+        assert isinstance(x, expected_type)
+
+
 def test_no_dtype_dataframe():
     """Test how nullability is handled in DataFrameSchemas where no type is
     specified."""


### PR DESCRIPTION
fixes #422

this diff fixes a bug that coerced values in a pa.Object
datatype into a string, e.g. dicts would be coerced into
string representation