### PR TITLE
bugfix/serialize-non-pdtype-enum

### DIFF
--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -185,7 +185,7 @@ Instead, you can use the :mod:`pandera.typing` counterparts:
 
     Traceback (most recent call last):
     ...
-    AttributeError: type object 'Generic' has no attribute 'value'
+    TypeError: python type '<class 'typing.Generic'>' not recognized as pandas data type
 
 Type Vs instance
 ^^^^^^^^^^^^^^^^

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -2,6 +2,7 @@
 """Schema datatypes."""
 
 from enum import Enum
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -281,42 +282,62 @@ class PandasDtype(Enum):
         return cls.from_str_alias(pd_dtype.name)
 
     @classmethod
-    def get_str_dtype(cls, pandas_dtype_arg):
-        """Get pandas-compatible string representation of dtype."""
+    def get_dtype(
+        cls,
+        pandas_dtype_arg: Union[str, type, "PandasDtype", np.dtype],
+    ):
+        """Get PandasDtype from schema argument.
+
+        :param pandas_dtype_arg: ``pandas_dtype`` argument specified in schema
+            definition.
+        """
         dtype_ = pandas_dtype_arg
         if dtype_ is None:
             return dtype_
+        elif isinstance(dtype_, PandasDtype):
+            return pandas_dtype_arg
 
         if is_extension_array_dtype(dtype_):
             if isinstance(dtype_, type):
                 try:
                     # Convert to str here because some pandas dtypes allow
-                    # an empty constructor for compatatibility but fail on
+                    # an empty constructor for compatibility but fail on
                     # str(). e.g: PeriodDtype
-                    return str(dtype_())
+                    str(dtype_().name)
+                    return dtype_()
                 except (TypeError, AttributeError) as err:
                     raise TypeError(
                         f"Pandas dtype {dtype_} cannot be instantiated: "
                         f"{err}\n Usage Tip: Use an instance or a string "
                         "representation."
                     ) from err
-            return str(dtype_)
+            return dtype_
 
         if dtype_ in NUMPY_TYPES:
-            dtype_ = cls.from_numpy_type(dtype_)
+            dtype_ = cls.from_numpy_type(dtype_)  # type: ignore
         elif isinstance(dtype_, str):
             dtype_ = cls.from_str_alias(dtype_)
         elif isinstance(dtype_, type):
             dtype_ = cls.from_python_type(dtype_)
 
         if isinstance(dtype_, cls):
-            return dtype_.str_alias
+            return dtype_
         raise TypeError(
             "type of `pandas_dtype` argument not recognized: "
             f"{type(pandas_dtype_arg)}. Please specify a pandera PandasDtype "
-            "enum, legal pandas data type, pandas data type string alias, or "
-            "numpy data type string alias"
+            "enum, built-in python type, pandas data type, pandas data type "
+            "string alias, or numpy data type string alias"
         )
+
+    @classmethod
+    def get_str_dtype(cls, pandas_dtype_arg) -> Optional[str]:
+        """Get pandas-compatible string representation of dtype."""
+        pandas_dtype = cls.get_dtype(pandas_dtype_arg)
+        if pandas_dtype is None:
+            return pandas_dtype
+        elif isinstance(pandas_dtype, PandasDtype):
+            return pandas_dtype.str_alias
+        return str(pandas_dtype)
 
     def __eq__(self, other):
         # pylint: disable=comparison-with-callable

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -283,9 +283,10 @@ class PandasDtype(Enum):
 
     @classmethod
     def get_dtype(
-        cls,
-        pandas_dtype_arg: Union[str, type, "PandasDtype", np.dtype],
-    ):
+        cls, pandas_dtype_arg: Union[str, type, "PandasDtype", np.dtype]
+    ) -> Optional[
+        Union["PandasDtype", "pd.core.dtypes.dtypes.ExtensionDtype"]
+    ]:
         """Get PandasDtype from schema argument.
 
         :param pandas_dtype_arg: ``pandas_dtype`` argument specified in schema

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -138,7 +138,7 @@ def _deserialize_component_stats(serialized_component_stats):
         serialized_component_stats["pandas_dtype"]
     )
     checks = None
-    if serialized_component_stats["checks"] is not None:
+    if serialized_component_stats.get("checks") is not None:
         checks = [
             _deserialize_check_stats(
                 getattr(Check, check_name), check_stats, pandas_dtype
@@ -149,12 +149,12 @@ def _deserialize_component_stats(serialized_component_stats):
         ]
     return {
         "pandas_dtype": pandas_dtype,
-        "nullable": serialized_component_stats["nullable"],
         "checks": checks,
         **{
             key: serialized_component_stats.get(key)
             for key in [
                 "name",
+                "nullable",
                 "allow_duplicates",
                 "coerce",
                 "required",

--- a/pandera/schema_statistics.py
+++ b/pandera/schema_statistics.py
@@ -105,7 +105,7 @@ def get_dataframe_schema_statistics(dataframe_schema):
     statistics = {
         "columns": {
             col_name: {
-                "pandas_dtype": column._pandas_dtype,
+                "pandas_dtype": column.pdtype,
                 "nullable": column.nullable,
                 "allow_duplicates": column.allow_duplicates,
                 "coerce": column.coerce,

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -292,11 +292,10 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
     @property
     def pdtype(self) -> Optional[PandasDtype]:
         """PandasDtype of the dataframe."""
-        if self.pandas_dtype is None:
-            return self.pandas_dtype
-        return PandasDtype.from_str_alias(
-            PandasDtype.get_str_dtype(self.pandas_dtype)
-        )
+        pandas_dtype = PandasDtype.get_str_dtype(self.pandas_dtype)
+        if pandas_dtype is None:
+            return pandas_dtype
+        return PandasDtype.from_str_alias(pandas_dtype)
 
     def _coerce_dtype(self, obj: pd.DataFrame) -> pd.DataFrame:
         if self.pandas_dtype is dtypes.PandasDtype.String:


### PR DESCRIPTION
fixes #418

this diff makes sure pandas_dtype args that are non-PandasDtype
enums can be serialized in yaml format