### PR TITLE
Fix to_yaml serialization dropping global checks

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,7 +9,7 @@ env:
   DEFAULT_PYTHON: 3.8
   CI: "true"
   # Increase this value to reset cache if environment.yml has not changed
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
 
 jobs:
   codestyle:

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -214,6 +214,7 @@ is a convenience method for this functionality.
         coerce: false
         required: true
         regex: false
+    checks: null
     index:
     - pandas_dtype: int64
       nullable: false

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -1,4 +1,5 @@
 """Data validation checks."""
+# pylint: disable=fixme
 
 import inspect
 import operator
@@ -16,6 +17,7 @@ from typing import (
     Union,
     TypeVar,
     Type,
+    no_type_check,
 )
 
 import pandas as pd
@@ -462,11 +464,13 @@ class _CheckBase:
         )
 
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", bound=_CheckBase)
 
 
 class _CheckMeta(type):  # pragma: no cover
     """Check metaclass."""
+
+    # FIXME: this should probably just be moved to _CheckBase
 
     REGISTERED_CUSTOM_CHECKS: Dict[str, Callable] = {}  # noqa
 
@@ -481,6 +485,11 @@ class _CheckMeta(type):  # pragma: no cover
         """Allow custom checks to show up as attributes when autocompleting."""
         return chain(super().__dir__(), cls.REGISTERED_CUSTOM_CHECKS.keys())
 
+    # pylint: disable=line-too-long
+    # mypy has limited metaclass support so this doesn't pass typecheck
+    # see https://mypy.readthedocs.io/en/stable/metaclasses.html#gotchas-and-limitations-of-metaclass-support
+    # pylint: enable=line-too-long
+    @no_type_check
     def __contains__(cls: Type[_T], item: Union[_T, str]) -> bool:
         """Allow lookups for registered checks."""
         if isinstance(item, cls):

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -461,7 +461,7 @@ class _CheckBase:
         )
 
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
 class _CheckMeta(type):  # pragma: no cover
@@ -476,7 +476,7 @@ class _CheckMeta(type):  # pragma: no cover
             raise AttributeError(f"'{cls}' object has no attribute '{name}'")
         return attr
 
-    def __contains__(cls: Type[T], item: Union[T, str]) -> bool:
+    def __contains__(cls: Type[_T], item: Union[_T, str]) -> bool:
         """Allow lookups for registered checks."""
         if isinstance(item, cls):
             name = item.name

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -4,7 +4,7 @@
 import inspect
 import operator
 import re
-from collections import namedtuple, ChainMap
+from collections import ChainMap, namedtuple
 from functools import partial, wraps
 from itertools import chain
 from typing import (
@@ -14,9 +14,9 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Union,
-    TypeVar,
     Type,
+    TypeVar,
+    Union,
     no_type_check,
 )
 

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -411,7 +411,6 @@ class _CheckBase:
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
-            # we can only be equal if the same type
             return NotImplemented
 
         are_check_fn_objects_equal = (
@@ -478,7 +477,11 @@ class _CheckMeta(type):  # pragma: no cover
         """Prevent attribute errors for registered checks."""
         attr = ChainMap(cls.__dict__, cls.REGISTERED_CUSTOM_CHECKS).get(name)
         if attr is None:
-            raise AttributeError(f"'{cls}' object has no attribute '{name}'")
+            raise AttributeError(
+                f"'{cls}' object has no attribute '{name}'. "
+                "Make sure any custom checks have been registered "
+                "using the extensions api."
+            )
         return attr
 
     def __dir__(cls) -> Iterable[str]:

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -397,9 +397,12 @@ class _CheckBase:
         )
 
     def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            # we can only be equal if the same type
+            return False
+
         are_check_fn_objects_equal = (
-            self.__dict__["_check_fn"].__code__.co_code
-            == other.__dict__["_check_fn"].__code__.co_code
+            self._get_check_fn_code() == other._get_check_fn_code()
         )
 
         try:
@@ -427,8 +430,18 @@ class _CheckBase:
             and are_all_other_check_attributes_equal
         )
 
+    def _get_check_fn_code(self):
+        check_fn = self.__dict__["_check_fn"]
+        try:
+            code = check_fn.__code__.co_code
+        except AttributeError:
+            # try accessing the functools.partial wrapper
+            code = check_fn.func.__code__.co_code
+
+        return code
+
     def __hash__(self):
-        return hash(self.__dict__["_check_fn"].__code__.co_code)
+        return hash(self._get_check_fn_code())
 
     def __repr__(self):
         return (

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -399,7 +399,7 @@ class _CheckBase:
     def __eq__(self, other):
         if not isinstance(other, type(self)):
             # we can only be equal if the same type
-            return False
+            return NotImplemented
 
         are_check_fn_objects_equal = (
             self._get_check_fn_code() == other._get_check_fn_code()
@@ -470,11 +470,10 @@ class _CheckMeta(type):  # pragma: no cover
         """Allow lookups for registered checks."""
         if isinstance(item, cls):
             name = item.name
-            ref = getattr(cls, name, None)
-            return False if ref is None else ref == item
-        else:
-            # assume item is str
-            return hasattr(cls, item)
+            return hasattr(cls, name)
+
+        # assume item is str
+        return hasattr(cls, item)
 
 
 class Check(_CheckBase, metaclass=_CheckMeta):

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -5,7 +5,17 @@ import operator
 import re
 from collections import namedtuple
 from functools import partial, wraps
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union, TypeVar, Type
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Union,
+    TypeVar,
+    Type,
+)
 
 import pandas as pd
 
@@ -478,6 +488,7 @@ class _CheckMeta(type):  # pragma: no cover
 
 class Check(_CheckBase, metaclass=_CheckMeta):
     """Check a pandas Series or DataFrame for certain properties."""
+
     @classmethod
     @st.register_check_strategy(st.eq_strategy)
     @register_check_statistics(["value"])

--- a/pandera/extensions.py
+++ b/pandera/extensions.py
@@ -161,9 +161,8 @@ def register_check_method(
         if strategy is not None:
             check_method = st.register_check_strategy(strategy)(check_method)
 
-        setattr(Check, check_fn.__name__, classmethod(check_method))
-        Check.REGISTERED_CUSTOM_CHECKS[check_fn.__name__] = getattr(
-            Check, check_fn.__name__
+        Check.REGISTERED_CUSTOM_CHECKS[check_fn.__name__] = partial(
+            check_method, Check
         )
 
     return register_check_wrapper(check_fn)

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -59,6 +59,7 @@ def _serialize_dataframe_stats(dataframe_checks):
     """
     Serialize global dataframe check statistics into json/yaml-compatible format.
     """
+    # pylint: disable=import-outside-toplevel
     from pandera.checks import Check
 
     serialized_checks = {}
@@ -69,7 +70,7 @@ def _serialize_dataframe_stats(dataframe_checks):
     for check_name, check_stats in dataframe_checks.items():
         if check_name not in Check:
             warnings.warn(
-                f"Check {check_name} cannot be serialized. This check will be "
+                f"Check `{check_name}` cannot be serialized. This check will be "
                 "ignored. Did you forget to register it with the extension API?"
             )
         else:
@@ -83,6 +84,7 @@ def _serialize_component_stats(component_stats):
     """
     Serialize column or index statistics into json/yaml-compatible format.
     """
+    # pylint: disable=import-outside-toplevel
     from pandera.checks import Check
 
     serialized_checks = None

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -1,4 +1,5 @@
 """Module for reading and writing schema objects."""
+# pylint: disable=fixme
 
 import warnings
 from functools import partial
@@ -30,7 +31,7 @@ def _serialize_check_stats(check_stats, pandas_dtype=None):
     # pylint: disable=unused-argument
 
     def handle_stat_dtype(stat):
-        # infer dtype if not passed
+        # fixme: change interface to not require a dtype spec
         nonlocal pandas_dtype
 
         if pandas_dtype is None:
@@ -154,6 +155,7 @@ def _serialize_schema(dataframe_schema):
 def _deserialize_check_stats(check, serialized_check_stats, pandas_dtype=None):
     # pylint: disable=unused-argument
     def handle_stat_dtype(stat):
+        # fixme: change interface to not require a dtype spec
         nonlocal pandas_dtype
 
         if pandas_dtype is None:

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -62,9 +62,6 @@ def _serialize_dataframe_stats(dataframe_checks):
     """
     serialized_checks = {}
 
-    if dataframe_checks is None:
-        return serialized_checks
-
     for check_name, check_stats in dataframe_checks.items():
         # The case that `check_name` is not registered is handled in `parse_checks`,
         # so we know that `check_name` exists.

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -28,7 +28,7 @@ NOT_JSON_SERIALIZABLE = {PandasDtype.DateTime, PandasDtype.Timedelta}
 def _serialize_check_stats(check_stats, pandas_dtype=None):
     """Serialize check statistics into json/yaml-compatible format."""
 
-    def handle_stat_dtype(stat, pandas_dtype):
+    def handle_stat_dtype(stat):
         if pandas_dtype == PandasDtype.DateTime:
             return stat.strftime(DATETIME_FORMAT)
         elif pandas_dtype == PandasDtype.Timedelta:
@@ -39,12 +39,12 @@ def _serialize_check_stats(check_stats, pandas_dtype=None):
 
     # for unary checks, return a single value instead of a dictionary
     if len(check_stats) == 1:
-        return handle_stat_dtype(list(check_stats.values())[0], pandas_dtype)
+        return handle_stat_dtype(list(check_stats.values())[0])
 
     # otherwise return a dictionary of keyword args needed to create the Check
     serialized_check_stats = {}
     for arg, stat in check_stats.items():
-        serialized_check_stats[arg] = handle_stat_dtype(stat, pandas_dtype)
+        serialized_check_stats[arg] = handle_stat_dtype(stat)
     return serialized_check_stats
 
 
@@ -141,7 +141,7 @@ def _serialize_schema(dataframe_schema):
 
 
 def _deserialize_check_stats(check, serialized_check_stats, pandas_dtype=None):
-    def handle_stat_dtype(stat, pandas_dtype):
+    def handle_stat_dtype(stat):
         if pandas_dtype == PandasDtype.DateTime:
             return pd.to_datetime(stat, format=DATETIME_FORMAT)
         elif pandas_dtype == PandasDtype.Timedelta:
@@ -154,10 +154,10 @@ def _deserialize_check_stats(check, serialized_check_stats, pandas_dtype=None):
         # dictionary mapping Check arg names to values.
         check_stats = {}
         for arg, stat in serialized_check_stats.items():
-            check_stats[arg] = handle_stat_dtype(stat, pandas_dtype)
+            check_stats[arg] = handle_stat_dtype(stat)
         return check(**check_stats)
     # otherwise assume unary check function signature
-    return check(handle_stat_dtype(serialized_check_stats, pandas_dtype))
+    return check(handle_stat_dtype(serialized_check_stats))
 
 
 def _deserialize_component_stats(serialized_component_stats):

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -25,7 +25,7 @@ DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 NOT_JSON_SERIALIZABLE = {PandasDtype.DateTime, PandasDtype.Timedelta}
 
 
-def _serialize_check_stats(check_stats, pandas_dtype = None):
+def _serialize_check_stats(check_stats, pandas_dtype=None):
     """Serialize check statistics into json/yaml-compatible format."""
     # pylint: disable=unused-argument
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -1,8 +1,8 @@
 """Class-based api"""
 import inspect
+import os
 import re
 import sys
-import os
 import typing
 from typing import (
     Any,

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -2,6 +2,7 @@
 import inspect
 import re
 import sys
+import os
 import typing
 from typing import (
     Any,
@@ -168,6 +169,13 @@ class SchemaModel:
         if cls not in MODEL_CACHE:
             MODEL_CACHE[cls] = cls.__schema__
         return cls.__schema__
+
+    @classmethod
+    def to_yaml(cls, stream: Optional[os.PathLike] = None):
+        """
+        Convert `Schema` to yaml using `io.to_yaml`.
+        """
+        return cls.to_schema().to_yaml(stream)
 
     @classmethod
     @pd.util.Substitution(validate_doc=DataFrameSchema.validate.__doc__)

--- a/pandera/schema_statistics.py
+++ b/pandera/schema_statistics.py
@@ -161,7 +161,8 @@ def parse_checks(checks) -> Union[Dict[str, Any], None]:
     for check in checks:
         if check not in Check:
             warnings.warn(
-                "only registered checks may be converted to statistics. "
+                "Only registered checks may be converted to statistics. "
+                "Did you forget to register it with the extension API? "
                 f"Check `{check.name}` will be skipped."
             )
             continue

--- a/pandera/schema_statistics.py
+++ b/pandera/schema_statistics.py
@@ -159,7 +159,12 @@ def parse_checks(checks) -> Union[Dict[str, Any], None]:
     check_statistics = {}
     _check_memo = {}
     for check in checks:
-        check_statistics[check.name] = check.statistics
+        if check not in Check:
+            warnings.warn("only registered checks may be converted to statistics. "
+                          f"Check `{check.name}` will be skipped.")
+            continue
+
+        check_statistics[check.name] = {} if check.statistics is None else check.statistics
         _check_memo[check.name] = check
 
     # raise ValueError on incompatible checks

--- a/pandera/schema_statistics.py
+++ b/pandera/schema_statistics.py
@@ -160,11 +160,15 @@ def parse_checks(checks) -> Union[Dict[str, Any], None]:
     _check_memo = {}
     for check in checks:
         if check not in Check:
-            warnings.warn("only registered checks may be converted to statistics. "
-                          f"Check `{check.name}` will be skipped.")
+            warnings.warn(
+                "only registered checks may be converted to statistics. "
+                f"Check `{check.name}` will be skipped."
+            )
             continue
 
-        check_statistics[check.name] = {} if check.statistics is None else check.statistics
+        check_statistics[check.name] = (
+            {} if check.statistics is None else check.statistics
+        )
         _check_memo[check.name] = check
 
     # raise ValueError on incompatible checks

--- a/pandera/schema_statistics.py
+++ b/pandera/schema_statistics.py
@@ -115,6 +115,7 @@ def get_dataframe_schema_statistics(dataframe_schema):
             }
             for col_name, column in dataframe_schema.columns.items()
         },
+        "checks": parse_checks(dataframe_schema.checks),
         "index": (
             None
             if dataframe_schema.index is None

--- a/pandera/schema_statistics.py
+++ b/pandera/schema_statistics.py
@@ -161,7 +161,7 @@ def parse_checks(checks) -> Union[Dict[str, Any], None]:
     for check in checks:
         if check not in Check:
             warnings.warn(
-                "Only registered checks may be converted to statistics. "
+                "Only registered checks may be serialized to statistics. "
                 "Did you forget to register it with the extension API? "
                 f"Check `{check.name}` will be skipped."
             )

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1,6 +1,7 @@
 """Core pandera schema class definitions."""
 # pylint: disable=too-many-lines
 
+import os
 import copy
 import itertools
 import warnings
@@ -1186,17 +1187,16 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         return pandera.io.from_yaml(yaml_schema)
 
-    def to_yaml(self, fp: Union[str, Path] = None):
+    def to_yaml(self, stream: Optional[os.PathLike] = None):
         """Write DataFrameSchema to yaml file.
 
-        :param dataframe_schema: schema to write to file or dump to string.
         :param stream: file stream to write to. If None, dumps to string.
         :returns: yaml string if stream is None, otherwise returns None.
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         import pandera.io
 
-        return pandera.io.to_yaml(self, fp)
+        return pandera.io.to_yaml(self, stream=stream)
 
     def set_index(
         self, keys: List[str], drop: bool = True, append: bool = False

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1,9 +1,9 @@
 """Core pandera schema class definitions."""
 # pylint: disable=too-many-lines
 
-import os
 import copy
 import itertools
+import os
 import warnings
 from functools import wraps
 from pathlib import Path

--- a/tests/core/checks_fixtures.py
+++ b/tests/core/checks_fixtures.py
@@ -1,7 +1,8 @@
 """Pytest fixtures for testing custom checks."""
 import unittest.mock as mock
-import pytest
+
 import pandas as pd
+import pytest
 
 import pandera as pa
 import pandera.extensions as pa_ext

--- a/tests/core/checks_fixtures.py
+++ b/tests/core/checks_fixtures.py
@@ -1,0 +1,32 @@
+"""Pytest fixtures for testing custom checks."""
+import unittest.mock as mock
+import pytest
+import pandas as pd
+
+import pandera as pa
+import pandera.extensions as pa_ext
+
+__all__ = "custom_check_teardown", "extra_registered_checks"
+
+
+@pytest.fixture(scope="function")
+def custom_check_teardown():
+    """Remove all custom checks after execution of each pytest function."""
+    yield
+    for check_name in list(pa.Check.REGISTERED_CUSTOM_CHECKS):
+        del pa.Check.REGISTERED_CUSTOM_CHECKS[check_name]
+
+
+@pytest.fixture(scope="function")
+def extra_registered_checks():
+    """temporarily registers custom checks onto the Check class"""
+    # pylint: disable=unused-variable
+    with mock.patch(
+        "pandera.Check.REGISTERED_CUSTOM_CHECKS", new_callable=dict
+    ):
+        # register custom checks here
+        @pa_ext.register_check_method()
+        def no_param_check(_: pd.DataFrame) -> bool:
+            return True
+
+        yield

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,4 @@
+"""Registers fixtures for core"""
+
+# pylint: disable=unused-import
+from .checks_fixtures import custom_check_teardown, extra_registered_checks

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -353,12 +353,14 @@ def test_reshape_failure_cases_exceptions():
 
 
 def test_check_equality_operators():
-    """Test the usage of == between a Check and an entirely different Check."""
+    """Test the usage of == between a Check and an entirely different Check,
+    and a non-Check."""
     check = Check(lambda g: g["foo"]["col1"].iat[0] == 1, groupby="col3")
 
     not_equal_check = Check(lambda x: x.isna().sum() == 0)
     assert check == copy.deepcopy(check)
     assert check != not_equal_check
+    assert check != "not a check"
 
 
 def test_equality_operators_functional_equivalence():

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -13,13 +13,9 @@ from pandera import PandasDtype, extensions
 from pandera.checks import Check
 
 
-@pytest.fixture(scope="function")
-def custom_check_teardown():
-    """Remove all custom checks after execution of each pytest function."""
-    yield
-    for check_name in list(pa.Check.REGISTERED_CUSTOM_CHECKS):
-        delattr(pa.Check, check_name)
-        del pa.Check.REGISTERED_CUSTOM_CHECKS[check_name]
+def test_custom_checks_in_dir(extra_registered_checks):
+    """Ensures that autocomplete works with registered custom checks."""
+    assert "no_param_check" in dir(pa.Check)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_schema_statistics.py
+++ b/tests/core/test_schema_statistics.py
@@ -1,31 +1,14 @@
 # pylint: disable=W0212
 """Unit tests for inferring statistics of pandas objects."""
 
-import unittest.mock as mock
 import pandas as pd
 import pytest
 
 import pandera as pa
-import pandera.extensions as pa_ext
 from pandera import PandasDtype, dtypes, schema_statistics
 
 DEFAULT_INT = PandasDtype.from_str_alias(dtypes._DEFAULT_PANDAS_INT_TYPE)
 DEFAULT_FLOAT = PandasDtype.from_str_alias(dtypes._DEFAULT_PANDAS_FLOAT_TYPE)
-
-
-@pytest.fixture(scope="function")
-def extra_registered_checks():
-    """temporarily registers custom checks onto the Check class"""
-    # pylint: disable=unused-variable
-    with mock.patch(
-        "pandera.Check.REGISTERED_CUSTOM_CHECKS", new_callable=dict
-    ):
-        # register custom checks here
-        @pa_ext.register_check_method()
-        def no_param_check(_: pd.DataFrame) -> bool:
-            return True
-
-        yield
 
 
 def _create_dataframe(multi_index=False, nullable=False):
@@ -581,8 +564,7 @@ def test_parse_checks_and_statistics_roundtrip(checks, expectation):
     assert set(check_list) == set(checks)
 
 
-# The next line is a workaround for pylint's confusion about pytest fixtures
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=unused-argument
 def test_parse_checks_and_statistics_no_param(extra_registered_checks):
     """Ensure that an edge case where a check does not have parameters is appropriately handled."""
 
@@ -595,4 +577,4 @@ def test_parse_checks_and_statistics_no_param(extra_registered_checks):
     assert set(check_list) == set(checks)
 
 
-# pylint: enable=redefined-outer-name,unused-argument
+# pylint: enable=unused-argument

--- a/tests/core/test_schema_statistics.py
+++ b/tests/core/test_schema_statistics.py
@@ -16,6 +16,7 @@ DEFAULT_FLOAT = PandasDtype.from_str_alias(dtypes._DEFAULT_PANDAS_FLOAT_TYPE)
 @pytest.fixture(scope="function")
 def extra_registered_checks():
     """temporarily registers custom checks onto the Check class"""
+    # pylint: disable=unused-variable
     with mock.patch(
         "pandera.Check.REGISTERED_CUSTOM_CHECKS", new_callable=dict
     ):
@@ -580,6 +581,8 @@ def test_parse_checks_and_statistics_roundtrip(checks, expectation):
     assert set(check_list) == set(checks)
 
 
+# The next line is a workaround for pylint's confusion about pytest fixtures
+# pylint: disable=redefined-outer-name,unused-argument
 def test_parse_checks_and_statistics_no_param(extra_registered_checks):
     """Ensure that an edge case where a check does not have parameters is appropriately handled."""
 
@@ -590,3 +593,6 @@ def test_parse_checks_and_statistics_no_param(extra_registered_checks):
     check_statistics = {check.name: check.statistics for check in checks}
     check_list = schema_statistics.parse_check_statistics(check_statistics)
     assert set(check_list) == set(checks)
+
+
+# pylint: enable=redefined-outer-name,unused-argument

--- a/tests/core/test_schema_statistics.py
+++ b/tests/core/test_schema_statistics.py
@@ -388,6 +388,7 @@ def test_get_dataframe_schema_statistics():
         ),
     )
     expectation = {
+        "checks": None,
         "columns": {
             "int": {
                 "pandas_dtype": pa.Int,

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -485,5 +485,5 @@ def test_to_yaml_custom_dataframe_check():
         checks=[pa.Check(lambda obj: len(obj.index) > 1)],
     )
 
-    with pytest.warns(UserWarning, match=".*only registered checks.*"):
+    with pytest.warns(UserWarning, match=".*registered checks.*"):
         pa.io.to_yaml(schema)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -102,7 +102,9 @@ def _create_schema(index="single"):
                 regex=True,
                 checks=[pa.Check.str_length(1, 3)],
             ),
-            "empty_column": pa.Column(),
+            "notype_column": pa.Column(
+                checks=pa.Check.isin(["foo", "bar", "x", "xy"]),
+            ),
         },
         index=index,
         coerce=False,
@@ -187,10 +189,15 @@ columns:
     coerce: true
     required: false
     regex: true
-  empty_column:
+  notype_column:
     pandas_dtype: null
     nullable: false
-    checks: null
+    checks:
+      isin:
+      - foo
+      - bar
+      - x
+      - xy
     allow_duplicates: true
     coerce: false
     required: true

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -11,6 +11,7 @@ from packaging import version
 
 import pandera as pa
 import pandera.extensions as pa_ext
+import pandera.typing as pat
 
 try:
     from pandera import io
@@ -487,3 +488,22 @@ def test_to_yaml_custom_dataframe_check():
 
     with pytest.warns(UserWarning, match=".*registered checks.*"):
         pa.io.to_yaml(schema)
+
+
+def test_to_yaml_bugfix_419():
+    """Ensure that GH#419 is fixed"""
+    # pylint: disable=no-self-use
+
+    class CheckedSchemaModel(pa.SchemaModel):
+        """Schema with a global check"""
+
+        a: pat.Series[pat.Int64]
+        b: pat.Series[pat.Int64]
+
+        @pa.dataframe_check()
+        def unregistered_check(self, _):
+            """sample unregistered check"""
+            ...
+
+    with pytest.warns(UserWarning, match=".*registered checks.*"):
+        CheckedSchemaModel.to_yaml()

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -471,3 +471,19 @@ def test_to_yaml_registered_dataframe_check(_):
         schema.validate(pd.DataFrame(data={"a": [1]}))
 
     assert ncols_gt_called, "did not call ncols_gt"
+
+
+def test_to_yaml_custom_dataframe_check():
+    """Tests that writing DataFrameSchema with a registered dataframe raises."""
+
+    schema = pa.DataFrameSchema(
+        {
+            "a": pa.Column(
+                pa.Int,
+            ),
+        },
+        checks=[pa.Check(lambda obj: len(obj.index) > 1)],
+    )
+
+    with pytest.raises(UserWarning, match=".*register custom checks.*"):
+        pa.io.to_yaml(schema)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -485,5 +485,5 @@ def test_to_yaml_custom_dataframe_check():
         checks=[pa.Check(lambda obj: len(obj.index) > 1)],
     )
 
-    with pytest.raises(UserWarning, match=".*register custom checks.*"):
+    with pytest.warns(UserWarning, match=".*only registered checks.*"):
         pa.io.to_yaml(schema)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -381,27 +381,6 @@ def test_to_yaml():
     SKIP_YAML_TESTS,
     reason="pyyaml >= 5.1.0 required",
 )
-def test_to_yaml_missing_checks():
-    """Test that to_yaml warns when using unregistered checks on columns/globally."""
-    schema = _create_schema()
-    unregistered = pa.Check(lambda _: False)
-    schema.columns["int_column"]._checks.append(unregistered)
-
-    with pytest.warns(UserWarning, match=".*registered checks.*"):
-        io.to_yaml(schema)
-
-    del schema.columns["int_column"]._checks[-1]
-
-    schema.checks.append(unregistered)
-
-    with pytest.warns(UserWarning, match=".*registered checks.*"):
-        io.to_yaml(schema)
-
-
-@pytest.mark.skipif(
-    SKIP_YAML_TESTS,
-    reason="pyyaml >= 5.1.0 required",
-)
 @pytest.mark.parametrize(
     "yaml_str, schema_creator",
     [
@@ -578,7 +557,7 @@ def test_to_yaml_registered_dataframe_check(_):
 
 
 def test_to_yaml_custom_dataframe_check():
-    """Tests that writing DataFrameSchema with a registered dataframe raises."""
+    """Tests that writing DataFrameSchema with an unregistered check raises."""
 
     schema = pa.DataFrameSchema(
         {
@@ -591,6 +570,8 @@ def test_to_yaml_custom_dataframe_check():
 
     with pytest.warns(UserWarning, match=".*registered checks.*"):
         pa.io.to_yaml(schema)
+
+    # the unregistered column check case is tested in `test_to_yaml_lambda_check`
 
 
 def test_to_yaml_bugfix_419():


### PR DESCRIPTION
Fix #419 .

In hindsight, perhaps I've opened up a whole can of worms here and this PR should be broken up into smaller pieces. If that's so, let me know.

I've discovered a few issues while working on this that have also taken the liberty to fix.

- [x] When parsing `Checks` into statistics, there is an implicit assumption that if the check does not have arguments, then it is not serializable. This used to skip `lambda` Checks. 
- [x] The dataframe `checks:` field is not filled at all, nor are the global checks collected. This is the main issue of this PR.
- [x] Comparing checks/hashing fails when those checks are registered with the extension API. This is because the `functools.partial` function does not have the `__code__` field.
- [x] Missing `to_yaml` helper method to `Schema` + unit test as requested from #419,
- [x] Confusing implementation of `REGISTERED_CUSTOM_CHECKS`. Instead, custom checks are only added there, but there is additional support in the `metaclass` to look there for custom checks when using `getattr` lookups and dir.
- [x] Added test to show that `to_script` fails, instead of having the silent strip behavior.
- [x] Added test that checks that `from_yaml` fails when deserializing unknown checks. This is currently an `AttributeError`, but should probably be a `SchemaInitError` or maybe a warning. I'm open to suggestions.