### PR TITLE
fix DataFrameSchema comparison with non-DataFrameSchema

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,7 +9,7 @@ env:
   DEFAULT_PYTHON: 3.8
   CI: "true"
   # Increase this value to reset cache if environment.yml has not changed
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
 
 jobs:
   codestyle:

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -723,6 +723,9 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         )
 
     def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
         def _compare_dict(obj):
             return {
                 k: v for k, v in obj.__dict__.items() if k != "_IS_INFERRED"

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -104,7 +104,6 @@ def test_dataframe_schema():
 def test_dataframe_schema_equality():
     """Test DataframeSchema equality."""
     schema = DataFrameSchema({"a": Column(Int)})
-    assert schema == schema
     assert schema == copy.copy(schema)
     assert schema != "schema"
     assert DataFrameSchema(coerce=True) != DataFrameSchema(coerce=False)

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -101,6 +101,17 @@ def test_dataframe_schema():
         schema.validate(df.assign(a=[1.7, 2.3, 3.1]))
 
 
+def test_dataframe_schema_equality():
+    """Test DataframeSchema equality."""
+    schema = DataFrameSchema({"a": Column(Int)})
+    assert schema == schema
+    assert schema == copy.copy(schema)
+    assert schema != "schema"
+    assert DataFrameSchema(coerce=True) != DataFrameSchema(coerce=False)
+    assert schema != schema.update_column("a", pandas_dtype=Float)
+    assert schema != schema.update_column("a", checks=Check.eq(1))
+
+
 def test_dataframe_schema_strict():
     """
     Checks if strict=True whether a schema error is raised because 'a' is


### PR DESCRIPTION
fixes #430 

This PR fixes a bug where `DataFrameSchema.__eq__()` raises an error when the other object is not a DataFrameSchema.

