### PR TITLE
fix empty SchemaModel

### DIFF
--- a/pandera/model.py
+++ b/pandera/model.py
@@ -124,7 +124,8 @@ class SchemaModel:
         super().__init_subclass__(**kwargs)
         # pylint:disable=no-member
         for field_name in cls.__annotations__.keys():
-            if field_name not in cls.__dict__:  # Field omitted
+            if _is_field(field_name) and field_name not in cls.__dict__:
+                # Field omitted
                 field = Field()
                 field.__set_name__(cls, field_name)
                 setattr(cls, field_name, field)
@@ -298,8 +299,7 @@ class SchemaModel:
         for name, attr in attrs.items():
             if inspect.isroutine(attr):
                 continue
-            if name.startswith("_") or name == _CONFIG_KEY:
-                # ignore private and reserved keywords
+            if not _is_field(name):
                 annotations.pop(name, None)
             elif name not in annotations:
                 missing.append(name)
@@ -417,3 +417,8 @@ def _get_dtype_kwargs(annotation: AnnotationInfo) -> Dict[str, Any]:
             + f"all positional arguments {dtype_arg_names}."
         )
     return dict(zip(dtype_arg_names, annotation.metadata))
+
+
+def _is_field(name: str) -> bool:
+    """Ignore private and reserved keywords."""
+    return not name.startswith("_") and name != _CONFIG_KEY

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -29,6 +29,31 @@ def test_to_schema():
         Schema()
 
 
+def test_empty_schema():
+    """Test that SchemaModel supports empty schemas."""
+
+    empty_schema = pa.DataFrameSchema()
+
+    class EmptySchema(pa.SchemaModel):
+        pass
+
+    assert empty_schema == EmptySchema.to_schema()
+
+    class Schema(pa.SchemaModel):
+        a: Series[int]
+
+    class EmptySubSchema(Schema):
+        pass
+
+    schema = pa.DataFrameSchema({"a": pa.Column(int)})
+    assert schema == EmptySubSchema.to_schema()
+
+    class EmptyParentSchema(EmptySchema):
+        a: Series[int]
+
+    assert schema == EmptyParentSchema.to_schema()
+
+
 def test_invalid_annotations():
     """Test that SchemaModel.to_schema() fails if annotations or types are not
     recognized.


### PR DESCRIPTION
fixes #433 

This PR fixes a bug with empty `SchemaModel` raising a TypeError.

```python
import pandera as pa

class ASchema(pa.SchemaModel):
    pass

ASchema.to_schema()
# Traceback (most recent call last):
#   File "test.py", line 10, in <module>
#     ASchema.to_schema()
#   File ".../pandera/model.py", line 150, in to_schema
#     cls.__config__ = cls._collect_config()
#   File ".../pandera/model.py", line 331, in _collect_config
#     base_options = _extract_config_options(config)
#   File ".../pandera/model.py", line 97, in _extract_config_options
#     for name, value in vars(config).items()
# TypeError: vars() argument must have __dict__ attribute
```

The problem comes from `__annotations` returning its super's annotations (i.e `SchemaModel`) if the class doesn't have annotations itself. `Config` is then misinterpreted as a missing field and overwritten.