### PR TITLE
remove unnecessary warnings

### DIFF
--- a/pandera/io.py
+++ b/pandera/io.py
@@ -68,22 +68,13 @@ def _serialize_component_stats(component_stats):
     """
     Serialize column or index statistics into json/yaml-compatible format.
     """
-    # pylint: disable=import-outside-toplevel
-    from pandera.checks import Check
-
     serialized_checks = None
     if component_stats["checks"] is not None:
         serialized_checks = {}
         for check_name, check_stats in component_stats["checks"].items():
-            if check_name not in Check:
-                warnings.warn(
-                    f"Check {check_name} cannot be serialized. This check will be "
-                    "ignored. Did you forget to register it with the extension API?"
-                )
-            else:
-                serialized_checks[check_name] = _serialize_check_stats(
-                    check_stats, component_stats["pandas_dtype"]
-                )
+            serialized_checks[check_name] = _serialize_check_stats(
+                check_stats, component_stats["pandas_dtype"]
+            )
 
     pandas_dtype = component_stats.get("pandas_dtype")
     if pandas_dtype:
@@ -261,10 +252,7 @@ def to_yaml(dataframe_schema, stream=None):
     statistics = _serialize_schema(dataframe_schema)
 
     def _write_yaml(obj, stream):
-        try:
-            return yaml.safe_dump(obj, stream=stream, sort_keys=False)
-        except TypeError:
-            return yaml.safe_dump(obj, stream=stream)
+        return yaml.safe_dump(obj, stream=stream, sort_keys=False)
 
     try:
         with Path(stream).open("w") as f:

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -514,9 +514,17 @@ def test_to_yaml_lambda_check():
         pa.io.to_yaml(schema)
 
 
+def test_format_checks_warning():
+    """Test that unregistered checks raise a warning when formatting checks."""
+    with pytest.warns(UserWarning):
+        io._format_checks({"my_check": None})
+
+
 @mock.patch("pandera.Check.REGISTERED_CUSTOM_CHECKS", new_callable=dict)
 def test_to_yaml_registered_dataframe_check(_):
-    """Tests that writing DataFrameSchema with a registered dataframe check works."""
+    """
+    Tests that writing DataFrameSchema with a registered dataframe check works.
+    """
     ncols_gt_called = False
 
     @pa_ext.register_check_method(statistics=["column_count"])
@@ -571,7 +579,8 @@ def test_to_yaml_custom_dataframe_check():
     with pytest.warns(UserWarning, match=".*registered checks.*"):
         pa.io.to_yaml(schema)
 
-    # the unregistered column check case is tested in `test_to_yaml_lambda_check`
+    # the unregistered column check case is tested in
+    # `test_to_yaml_lambda_check`
 
 
 def test_to_yaml_bugfix_419():


### PR DESCRIPTION
since parse_checks handles cases of unregistered checks, the
parts of the io module that raised a user warning were are never
in the execution path and therefore never covered in tests