### PR TITLE
bugfix: preserve pandas extension types during validation

### DIFF
--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -274,7 +274,14 @@ class PandasDtype(Enum):
 
     @classmethod
     def get_dtype(
-        cls, pandas_dtype_arg: Union[str, type, "PandasDtype", np.dtype]
+        cls,
+        pandas_dtype_arg: Union[
+            str,
+            type,
+            "PandasDtype",
+            "pd.core.dtypes.dtypes.ExtensionDtype",
+            np.dtype,
+        ],
     ) -> Optional[
         Union["PandasDtype", "pd.core.dtypes.dtypes.ExtensionDtype"]
     ]:


### PR DESCRIPTION
The `SchemaModel` and `DataFrameSchema` interfaces currently contain all the metadata needed to validate `pandas.CategoricalDtype` extension type, however the underlying validation routine converted all types to their `str` representation, losing granularity if the user provided a `categories` argument.

This diff implements the minimal change needed to solve the issue articulated in #439 without having to revamp the entire pandera type system.