### PR TITLE
add copy button to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
     "recommonmark",
 ]
 

--- a/environment.yml
+++ b/environment.yml
@@ -36,6 +36,7 @@ dependencies:
   - sphinx >= 3.2.0
   - sphinx_rtd_theme
   - sphinx-autodoc-typehints
+  - sphinx-copybutton
   - recommonmark
   - furo
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,7 @@ importlib_metadata
 sphinx >= 3.2.0
 sphinx_rtd_theme
 sphinx-autodoc-typehints
+sphinx-copybutton
 recommonmark
 furo
 twine


### PR DESCRIPTION
This PR adds a copy button to python snippets in the docs.

![image](https://user-images.githubusercontent.com/16199817/112772205-d5d06880-902f-11eb-9d0e-a701287ccf68.png)
