### PR TITLE
Add missing inplace arg to SchemaModel's validate

### DIFF
--- a/docs/source/_static/default.css
+++ b/docs/source/_static/default.css
@@ -12,20 +12,27 @@ a {
 
 .sidebar-drawer {
   width: calc(50% - 25em);
-  min-width: 23em;
+  min-width: 22em;
 }
 
 .sidebar-drawer .sidebar-container {
   width: 23em;
 }
 
-@media (max-width: 67em) {
-  .sidebar-drawer {
-    width: 24em;
-    left: -24em;
-  }
-}
-
 li.toctree-l2 {
   font-size: 80%;
+}
+
+
+@media (max-width: 67em) {
+  .sidebar-drawer {
+    width: 22em;
+    left: -22em;
+  }
+  .sidebar-drawer .sidebar-container {
+    width: 22em;
+  }
+  li.toctree-l2 {
+    font-size: 75%;
+  }
 }

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -124,7 +124,8 @@ class SchemaModel:
         """Ensure :class:`~pandera.model_components.FieldInfo` instances."""
         super().__init_subclass__(**kwargs)
         # pylint:disable=no-member
-        for field_name in cls.__annotations__.keys():
+        subclass_annotations = cls.__dict__.get("__annotations__", {})
+        for field_name in subclass_annotations.keys():
             if _is_field(field_name) and field_name not in cls.__dict__:
                 # Field omitted
                 field = Field()

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -189,10 +189,11 @@ class SchemaModel:
         sample: Optional[int] = None,
         random_state: Optional[int] = None,
         lazy: bool = False,
+        inplace: bool = False,
     ) -> pd.DataFrame:
         """%(validate_doc)s"""
         return cls.to_schema().validate(
-            check_obj, head, tail, sample, random_state, lazy
+            check_obj, head, tail, sample, random_state, lazy, inplace
         )
 
     @classmethod


### PR DESCRIPTION
SchemaModel's validate() is missing an inplace argument. While DataFrameSchema's validate() function accepts this argument, it appears it was accidentally omitted from the SchemaModel implementation. In its current state, this can cause confusion as SchemaModel's documentation simply mirrors that of DataFrameSchema.