### PR TITLE
Feature/420

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - pyyaml >=5.1
   - typing_inspect >= 0.6.0
   - typing_extensions >= 3.7.4.3
+  - frictionless
 
   # testing and dependencies
   - black >= 20.8b1

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -430,7 +430,7 @@ class FrictionlessFieldParser:
         self.type = field.get("type", "string")
 
     @property
-    def dtype(self) -> str:
+    def pandas_dtype(self) -> str:
         """Determine what type of field this is, so we can feed that into
         :class:`~pandera.dtypes.PandasDtype`. If no type is specified in the
         frictionless schema, we default to string values.
@@ -548,7 +548,7 @@ class FrictionlessFieldParser:
             "checks": self.checks,
             "coerce": self.coerce,
             "nullable": self.nullable,
-            "pandas_dtype": self.dtype,
+            "pandas_dtype": self.pandas_dtype,
             "required": self.required,
             "name": self.name,
             "regex": self.regex,

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -523,28 +523,38 @@ class FrictionlessFieldParser:
         return not self.constraints.get("required", False)
 
     @property
-    def unique(self) -> bool:
-        """Determine whether this field can only contain unique values."""
-        if self.is_a_primary_key:
-            return True
-        return self.constraints.get("unique", False)
-
-    @property
     def allow_duplicates(self) -> bool:
         """Determine whether this field can contain duplicate values."""
-        return not self.unique
+        if self.is_a_primary_key:
+            return False
+        return not self.constraints.get("unique", False)
+
+    @property
+    def coerce(self) -> bool:
+        """Determine whether values within this field should be coerced."""
+        return True
+
+    @property
+    def required(self) -> bool:
+        """Determine whether this field must exist within the data."""
+        return True
+
+    @property
+    def regex(self) -> bool:
+        """Determine whether this field name should be used for regex matches."""
+        return False
 
     def to_pandera_column(self) -> Dict:
         """Export this field to a column spec dictionary."""
         return {
             "allow_duplicates": self.allow_duplicates,
             "checks": self.checks,
-            "coerce": True,
+            "coerce": self.coerce,
             "nullable": self.nullable,
             "pandas_dtype": self.dtype,
-            "required": True,
+            "required": self.required,
             "name": self.name,
-            "regex": False,
+            "regex": self.regex,
         }
 
 

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -550,11 +550,37 @@ def from_frictionless_schema(schema):
     json/yaml schema file on disk, or a frictionless schema already loaded
     into memory.
 
+    Each field from the frictionless schema will be converted to a pandera
+    column specification using :class:`~pandera.io.FrictionlessFieldParser`
+    to map field characteristics to pandera column specifications.
+
     :param frictionless_schema: the frictionless schema object (or a
         string/Path to the location on disk of a schema specification) to
         parse.
     :returns: dataframe schema with frictionless field specs converted to
         pandera column checks and constraints for use as normal.
+
+    :example:
+
+    >>> from pandera.io import from_frictionless_schema
+    >>>
+    >>> FRICTIONLESS_SCHEMA = {
+    ...     "fields": [
+    ...         {
+    ...             "name": "column_1",
+    ...             "type": "integer",
+    ...             "constraints": {"minimum": 10, "maximum": 99}
+    ...         }
+    ...     ],
+    ...     "primaryKey": "column_1"
+    ... }
+    >>> schema = from_frictionless_schema(FRICTIONLESS_SCHEMA)
+    >>> schema.columns["column_1"].checks
+    [<Check in_range: in_range(10, 99)>]
+    >>> schema.columns["column_1"].required
+    True
+    >>> schema.columns["column_1"].allow_duplicates
+    False
     """
     if not isinstance(schema, FrictionlessSchema):
         schema = FrictionlessSchema(schema)

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -470,9 +470,9 @@ class FrictionlessFieldParser:
         `here <https://specs.frictionlessdata.io/table-schema/#constraints>`_
         and maps them into the equivalent pandera checks.
 
-        :returns: a list of pandera :class:`pandera.checks.Check` objects
-            which capture the standard constraint logic of a frictionless
-            schema field.
+        :returns: a dictionary of pandera :class:`pandera.checks.Check`
+            objects which capture the standard constraint logic of a
+            frictionless schema field.
         """
         if not self.constraints:
             return None

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -409,7 +409,7 @@ def to_script(dataframe_schema, path_or_buf=None):
 
 class FrictionlessFieldParser:
     """Parses frictionless data schema field specifications so we can convert
-    them to an equivalent pandera Column schema.
+    them to an equivalent :class:`pandera.schema_components.Column` schema.
 
     For this implementation, we are using field names, constraints and types
     but leaving other frictionless parameters out (e.g. foreign keys, type
@@ -468,7 +468,7 @@ class FrictionlessFieldParser:
         `here <https://specs.frictionlessdata.io/table-schema/#constraints>`_
         and maps them into the equivalent pandera checks.
 
-        :returns: a list of pandera checks which capture the standard constraint
+        :returns: a list of pandera :class:`pandera.checks.Check` objects which capture the standard constraint
             logic of a frictionless schema field.
         """
         if not self.constraints:
@@ -554,7 +554,7 @@ def from_frictionless_schema(schema):
     column specification using :class:`~pandera.io.FrictionlessFieldParser`
     to map field characteristics to pandera column specifications.
 
-    :param frictionless_schema: the frictionless schema object (or a
+    :param schema: the frictionless schema object (or a
         string/Path to the location on disk of a schema specification) to
         parse.
     :returns: dataframe schema with frictionless field specs converted to

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -482,10 +482,7 @@ class FrictionlessFieldParser:
         def _combine_constraints(check_name, min_constraint, max_constraint):
             """Catches bounded constraints where we need to combine a min and max
             pair of constraints into a single check."""
-            if (
-                min_constraint in constraints.keys()
-                and max_constraint in constraints.keys()
-            ):
+            if min_constraint in constraints and max_constraint in constraints:
                 checks[check_name] = {
                     "min_value": constraints.pop(min_constraint),
                     "max_value": constraints.pop(max_constraint),

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -556,7 +556,7 @@ class FrictionlessFieldParser:
 
 
 def from_frictionless_schema(
-    schema: Union[str, Path, FrictionlessSchema]
+    schema: Union[str, Path, Dict, FrictionlessSchema]
 ) -> DataFrameSchema:
     """Create a :class:`~pandera.schemas.DataFrameSchema` from a frictionless
     json/yaml schema file on disk, or a frictionless schema already loaded

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -424,7 +424,7 @@ class FrictionlessFieldParser:
     """
 
     def __init__(self, field, primary_keys) -> None:
-        self.constraints = field.constraints
+        self.constraints = field.constraints or {}
         self.name = field.name
         self.is_a_primary_key = self.name in primary_keys
         self.type = field.get("type", "string")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ wrapt
 pyyaml >=5.1
 typing_inspect >= 0.6.0
 typing_extensions >= 3.7.4.3
+frictionless
 black >= 20.8b1
 isort >= 5.7.0
 codecov

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("pandera/version.py") as fp:
 _extras_require = {
     "strategies": ["hypothesis >= 5.41.1"],
     "hypotheses": ["scipy"],
-    "io": ["pyyaml >= 5.1", "black"],
+    "io": ["pyyaml >= 5.1", "black", "frictionless"],
 }
 extras_require = {
     **_extras_require,

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -5,7 +5,6 @@ import tempfile
 import unittest.mock as mock
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 import pytest
 from packaging import version
@@ -855,9 +854,9 @@ def test_frictionless_schema_parses_correctly(frictionless_schema):
     with pytest.raises(pa.errors.SchemaErrors) as err:
         schema.validate(INVALID_FRICTIONLESS_DF, lazy=True)
     # check we're capturing all errors according to the frictionless schema:
-    assert err.value.failure_cases[["check", "failure_case"]].to_dict(
-        orient="records"
-    ) == [
+    assert err.value.failure_cases[["check", "failure_case"]].fillna(
+        "NaN"
+    ).to_dict(orient="records") == [
         {"check": "column_in_schema", "failure_case": "unexpected_column"},
         {"check": "column_in_dataframe", "failure_case": "date_col"},
         {"check": "coerce_dtype('float64')", "failure_case": "object"},
@@ -871,5 +870,5 @@ def test_frictionless_schema_parses_correctly(frictionless_schema):
         },
         {"check": "str_length(3, None)", "failure_case": "1A"},
         {"check": "str_length(None, 3)", "failure_case": "123A"},
-        {"check": "not_nullable", "failure_case": np.nan},
+        {"check": "not_nullable", "failure_case": "NaN"},
     ], "validation failure cases not as expected"

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -691,12 +691,18 @@ FRICTIONLESS_JSON = {
     "primaryKey": "integer_col",
 }
 
+# pandas dtype aliases to support testing across multiple pandas versions:
+STR_DTYPE = pa.dtypes.PandasDtype.from_str_alias("string").value
+STR_DTYPE_ALIAS = pa.dtypes.PandasDtype.from_str_alias("string").str_alias
+INT_DTYPE = pa.dtypes.PandasDtype.from_str_alias("int").value
+INT_DTYPE_ALIAS = pa.dtypes.PandasDtype.from_str_alias("int").str_alias
+
 YAML_FROM_FRICTIONLESS = f"""
 schema_type: dataframe
 version: {pa.__version__}
 columns:
   integer_col:
-    pandas_dtype: int
+    pandas_dtype: {INT_DTYPE}
     nullable: false
     checks:
       in_range:
@@ -707,7 +713,7 @@ columns:
     required: true
     regex: false
   integer_col_2:
-    pandas_dtype: int
+    pandas_dtype: {INT_DTYPE}
     nullable: true
     checks:
       less_than_or_equal_to: 30
@@ -716,7 +722,7 @@ columns:
     required: true
     regex: false
   string_col:
-    pandas_dtype: string
+    pandas_dtype: {STR_DTYPE}
     nullable: true
     checks:
       str_length:
@@ -727,7 +733,7 @@ columns:
     required: true
     regex: false
   string_col_2:
-    pandas_dtype: string
+    pandas_dtype: {STR_DTYPE}
     nullable: true
     checks:
       str_matches: ^\\d{{3}}[A-Z]$
@@ -736,7 +742,7 @@ columns:
     required: true
     regex: false
   string_col_3:
-    pandas_dtype: string
+    pandas_dtype: {STR_DTYPE}
     nullable: true
     checks:
       str_length: 3
@@ -745,7 +751,7 @@ columns:
     required: true
     regex: false
   string_col_4:
-    pandas_dtype: string
+    pandas_dtype: {STR_DTYPE}
     nullable: true
     checks:
       str_length: 3
@@ -774,7 +780,7 @@ columns:
     required: true
     regex: false
   date_col:
-    pandas_dtype: string
+    pandas_dtype: {STR_DTYPE}
     nullable: true
     checks:
       greater_than_or_equal_to: '20201231'
@@ -838,17 +844,17 @@ def test_frictionless_schema_parses_correctly(frictionless_schema):
 
     df = schema.validate(VALID_FRICTIONLESS_DF)
     assert dict(df.dtypes) == {
-        "integer_col": "int64",
-        "integer_col_2": "int64",
-        "string_col": pd.StringDtype(),
-        "string_col_2": pd.StringDtype(),
-        "string_col_3": pd.StringDtype(),
-        "string_col_4": pd.StringDtype(),
+        "integer_col": INT_DTYPE_ALIAS,
+        "integer_col_2": INT_DTYPE_ALIAS,
+        "string_col": STR_DTYPE_ALIAS,
+        "string_col_2": STR_DTYPE_ALIAS,
+        "string_col_3": STR_DTYPE_ALIAS,
+        "string_col_4": STR_DTYPE_ALIAS,
         "float_col": pd.CategoricalDtype(
             categories=[1.0, 2.0, 3.0], ordered=False
         ),
         "float_col_2": "float64",
-        "date_col": pd.StringDtype(),
+        "date_col": STR_DTYPE_ALIAS,
     }, "dtypes not parsed correctly from frictionless schema"
 
     with pytest.raises(pa.errors.SchemaErrors) as err:


### PR DESCRIPTION
Relates to #420 

Here's a first attempt at parsing frictionless schema, with the following capabilities:

- read from frictionless schema json/yaml files on disk
- accept a frictionless Schema object directly from memory
- map field names, types, constraints directly into pandera equivalents

The code to handle this is in `pandera.io`, and I've created a new `FrictionlessFieldParser` class to convert each field in the schema accordingly.

Currently `pa.io.from_frictionless_schema()` is as far as I've got in terms of an API - how/where do you want this to be imported from?

Documentation will also need updating - there are docstrings for everything I've added but nothing more than that at this point.

I've also added tests in `tests.io` to validate this functionality.