### PR TITLE
fix check_types input coercion and delayed annotations

### DIFF
--- a/pandera/model.py
+++ b/pandera/model.py
@@ -239,7 +239,7 @@ class SchemaModel:
                         + "\n Usage Tip: Drop 'typing.Annotated'."
                     )
                 dtype_kwargs = _get_dtype_kwargs(annotation)
-                dtype = annotation.arg(**dtype_kwargs)
+                dtype = annotation.arg(**dtype_kwargs)  # type: ignore
             else:
                 dtype = annotation.arg
 
@@ -420,10 +420,11 @@ def _regex_filter(seq: Iterable, regexps: Iterable[str]) -> Set[str]:
 
 
 def _get_dtype_kwargs(annotation: AnnotationInfo) -> Dict[str, Any]:
-    dtype_arg_names = list(inspect.signature(annotation.arg).parameters.keys())
+    sig = inspect.signature(annotation.arg)  # type: ignore
+    dtype_arg_names = list(sig.parameters.keys())
     if len(annotation.metadata) != len(dtype_arg_names):
         raise TypeError(
-            f"Annotation '{annotation.arg.__name__}' requires "
+            f"Annotation '{annotation.arg.__name__}' requires "  # type: ignore
             + f"all positional arguments {dtype_arg_names}."
         )
     return dict(zip(dtype_arg_names, annotation.metadata))

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -104,6 +104,7 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         literal: Whether the annotation is a literal.
         optional: Whether the annotation is optional.
         raw_annotation: The raw annotation.
+        metadata: Extra arguments passed to :data:`typing.Annotated`.
     """
 
     def __init__(self, raw_annotation: Type) -> None:
@@ -121,10 +122,11 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         :returns: Annotation
         """
         self.raw_annotation = raw_annotation
+        self.origin = self.arg = None
 
         self.optional = typing_inspect.is_optional_type(raw_annotation)
-        if self.optional:
-            # e.g: Typing.Union[pandera.typing.Index[str], NoneType]
+        if self.optional and typing_inspect.is_union_type(raw_annotation):
+            # Annotated with Optional or Union[..., NoneType]
             if LEGACY_TYPING:  # pragma: no cover
                 # get_args -> ((pandera.typing.Index, <class 'str'>), <class 'NoneType'>)
                 self.origin, self.arg = typing_inspect.get_args(

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -600,10 +600,20 @@ def test_check_types_coerce():
     """Test that check_types return the result of validate."""
 
     @check_types()
-    def transform() -> DataFrame[OutSchema]:
+    def transform_in(df: DataFrame[InSchema]):
+        return df
+
+    df = transform_in(pd.DataFrame({"a": ["1"]}, index=["1"]))
+    expected = InSchema.to_schema().columns["a"].pandas_dtype
+    assert PandasDtype(str(df["a"].dtype)) == expected == PandasDtype("int")
+
+    @check_types()
+    def transform_out() -> DataFrame[OutSchema]:
         # OutSchema.b should be coerced to an integer.
         return pd.DataFrame({"b": ["1"]})
 
-    df = transform()
+    out_df = transform_out()
     expected = OutSchema.to_schema().columns["b"].pandas_dtype
-    assert PandasDtype(str(df["b"].dtype)) == expected == PandasDtype("int")
+    assert (
+        PandasDtype(str(out_df["b"].dtype)) == expected == PandasDtype("int")
+    )

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -1,5 +1,4 @@
 """Testing the Decorators that check a functions input or output."""
-
 from typing import Optional
 
 import numpy as np
@@ -480,6 +479,11 @@ class InSchema(SchemaModel):  # pylint:disable=too-few-public-methods
     a: Series[int]
     idx: Index[str]
 
+    class Config:  # pylint: disable=too-few-public-methods
+        """Set coerce."""
+
+        coerce = True
+
 
 class DerivedOutSchema(InSchema):
     """Test schema derived from InSchema."""
@@ -506,7 +510,7 @@ def test_check_types_multiple_inputs():
         return pd.concat([df_1, df_2])
 
     correct = pd.DataFrame({"a": [1]}, index=["1"])
-    transform(correct, correct)
+    transform(correct, df_2=correct)
 
     wrong = pd.DataFrame({"b": [1]})
     with pytest.raises(
@@ -535,14 +539,32 @@ def test_check_types_error_input():
         assert exc.data.equals(df)
 
 
-@pytest.mark.parametrize("out_schema_cls", [DerivedOutSchema, OutSchema])
-def test_check_types_error_output(out_schema_cls):
+def test_check_types_error_output():
     """Test that check_types raises an error when the output is not correct."""
 
     df = pd.DataFrame({"a": [1]}, index=["1"])
 
     @check_types
-    def transform(df: DataFrame[InSchema]) -> DataFrame[out_schema_cls]:
+    def transform_derived(
+        df: DataFrame[InSchema],
+    ) -> DataFrame[DerivedOutSchema]:
+        return df
+
+    with pytest.raises(
+        errors.SchemaError, match="column 'b' not in dataframe"
+    ):
+        transform_derived(df)
+
+    try:
+        transform_derived(df)
+    except errors.SchemaError as exc:
+        assert exc.schema == DerivedOutSchema.to_schema()
+        assert exc.data.equals(df)
+
+    df = pd.DataFrame({"a": [1]}, index=["1"])
+
+    @check_types
+    def transform(df: DataFrame[InSchema]) -> DataFrame[OutSchema]:
         return df
 
     with pytest.raises(
@@ -553,18 +575,26 @@ def test_check_types_error_output(out_schema_cls):
     try:
         transform(df)
     except errors.SchemaError as exc:
-        assert exc.schema == out_schema_cls.to_schema()
+        assert exc.schema == OutSchema.to_schema()
         assert exc.data.equals(df)
 
 
-@pytest.mark.parametrize("out_schema_cls", [DerivedOutSchema, OutSchema])
-def test_check_types_optional_out(out_schema_cls):
+def test_check_types_optional_out():
     """Test the check_types behaviour when the output schema is optional."""
+
+    @check_types
+    def optional_derived_out(
+        df: DataFrame[InSchema],  # pylint: disable=unused-argument
+    ) -> Optional[DataFrame[DerivedOutSchema]]:
+        return None
+
+    df = pd.DataFrame({"a": [1]}, index=["1"])
+    assert optional_derived_out(df) is None
 
     @check_types
     def optional_out(
         df: DataFrame[InSchema],  # pylint: disable=unused-argument
-    ) -> Optional[DataFrame[out_schema_cls]]:
+    ) -> Optional[DataFrame[OutSchema]]:
         return None
 
     df = pd.DataFrame({"a": [1]}, index=["1"])
@@ -583,14 +613,21 @@ def test_check_types_optional_in():
     assert optional_in(None) is None
 
 
-@pytest.mark.parametrize("out_schema_cls", [DerivedOutSchema, OutSchema])
-def test_check_types_optional_in_out(out_schema_cls):
+def test_check_types_optional_in_out():
     """Test the check_types behaviour when both input and outputs schemas are optional."""
+
+    @check_types
+    def transform_derived(
+        df: Optional[DataFrame[InSchema]],  # pylint: disable=unused-argument
+    ) -> Optional[DataFrame[DerivedOutSchema]]:
+        return None
+
+    assert transform_derived(None) is None
 
     @check_types
     def transform(
         df: Optional[DataFrame[InSchema]],  # pylint: disable=unused-argument
-    ) -> Optional[DataFrame[out_schema_cls]]:
+    ) -> Optional[DataFrame[OutSchema]]:
         return None
 
     assert transform(None) is None

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,6 +1,7 @@
 """Tests schema creation and validation from type annotations."""
 # pylint:disable=missing-class-docstring,missing-function-docstring,too-few-public-methods
 import re
+from decimal import Decimal  # pylint:disable=C0415
 from typing import Iterable, Optional
 
 import pandas as pd
@@ -74,8 +75,6 @@ def test_invalid_annotations():
 
     with pytest.raises(pa.errors.SchemaInitError, match="Invalid annotation"):
         Invalid.to_schema()
-
-    from decimal import Decimal  # pylint:disable=C0415
 
     class InvalidDtype(pa.SchemaModel):
         d: Series[Decimal]  # type: ignore
@@ -604,15 +603,17 @@ def test_config():
     assert expected == Child.to_schema()
 
 
+class Input(pa.SchemaModel):
+    a: Series[int]
+    b: Series[int]
+    idx: Index[str]
+
+
+class Output(Input):
+    c: Series[int]
+
+
 def test_check_types():
-    class Input(pa.SchemaModel):
-        a: Series[int]
-        b: Series[int]
-        idx: Index[str]
-
-    class Output(Input):
-        c: Series[int]
-
     @pa.check_types
     def transform(df: DataFrame[Input]) -> DataFrame[Output]:
         return df.assign(c=lambda x: x.a + x.b)


### PR DESCRIPTION
This PR fixes a bug when using @check_types with a SchemaModel that has coerce=True set as the config, the input dataframe is not coerced to the specified types (closes #457).

While working on it, I had to restructure the code of `check_types()`. I also took the opportunity to address #396:
1. resolve the signature types during function wrapping
2. support for delayed annotations (`from __future__ import annotations`).

I checked 2.  locally by adding `from __future__ import annotations` at the top of `test_model.py` and `test_decorators.py`. I did not commit the future import because it doesn't work on py3.6. There is an [unofficial backport](https://github.com/asottile/future-annotations) but it breaks black and mypy (because of a magic header `# -*- coding: future_annotations -*-`). 

Solutions I can see are, in order of preference:
1. drop support for py 3.6
2. don't add future imports and hope for no regressions until 3.6 is deprecated
3. custom nox session that leverages the unofficial backport at runtime
