### PR TITLE
coerce=True and pandas_dtype=None should be a noop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         args: ["--line-length=79"]
 
   - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.6.0
+    rev: pylint-2.8.1
     hooks:
       - id: pylint
         args: ["--disable=import-error"]

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,6 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx-copybutton
   - recommonmark
-  - furo
 
   # packaging
   - twine
@@ -48,3 +47,6 @@ dependencies:
 
   # optional
   - pre_commit
+
+  - pip:
+    - furo

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -50,7 +50,8 @@ class Column(SeriesSchemaBase):
         :param allow_duplicates: Whether or not column can contain duplicate
             values.
         :param coerce: If True, when schema.validate is called the column will
-            be coerced into the specified dtype.
+            be coerced into the specified dtype. This has no effect on columns
+            where ``pandas_dtype=None``.
         :param required: Whether or not column is allowed to be missing
         :param name: column name in dataframe to validate.
         :param regex: whether the ``name`` attribute should be treated as a
@@ -89,11 +90,6 @@ class Column(SeriesSchemaBase):
         self.required = required
         self._name = name
         self._regex = regex
-
-        if coerce and self._pandas_dtype is None:
-            raise errors.SchemaInitError(
-                "Must specify dtype if coercing a Column's type"
-            )
 
     @property
     def regex(self) -> bool:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ sphinx_rtd_theme
 sphinx-autodoc-typehints
 sphinx-copybutton
 recommonmark
-furo
 twine
 asv
 pre_commit
+furo

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -657,11 +657,12 @@ def test_no_dtype_series():
 def test_coerce_without_dtype():
     """Test that an error is thrown when a dtype isn't specified and coerce
     is True."""
-    with pytest.raises(errors.SchemaInitError):
-        DataFrameSchema({"col": Column(coerce=True)})
-
-    with pytest.raises(errors.SchemaInitError):
-        DataFrameSchema({"col": Column()}, coerce=True)
+    df = pd.DataFrame({"col": [1, 2, 3]})
+    for schema in [
+        DataFrameSchema({"col": Column(coerce=True)}),
+        DataFrameSchema({"col": Column()}, coerce=True),
+    ]:
+        assert isinstance(schema(df), pd.DataFrame)
 
 
 def test_required():
@@ -1027,15 +1028,10 @@ def test_rename_columns():
 
     # Check if new column names are indeed present in the new schema
     assert all(
-        [
-            col_name in rename_dict.values()
-            for col_name in schema_renamed.columns
-        ]
+        col_name in rename_dict.values() for col_name in schema_renamed.columns
     )
     # Check if original schema didn't change in the process
-    assert all(
-        [col_name in schema_original.columns for col_name in rename_dict]
-    )
+    assert all(col_name in schema_original.columns for col_name in rename_dict)
 
     with pytest.raises(errors.SchemaInitError):
         schema_original.rename_columns({"foo": "bar"})
@@ -1525,7 +1521,7 @@ def test_invalid_keys(schema_simple):
 
 
 def test_update_columns(schema_simple):
-    """ Catch-all test for update columns functionality """
+    """Catch-all test for update columns functionality"""
 
     # Basic function
     test_schema = schema_simple.update_columns({"col2": {"pandas_dtype": Int}})


### PR DESCRIPTION
fixes #471

before these two options were incompatible and pandera
would raise a SchemaInitError. This diff loosens this by
allowing for this combination, in which case no coercion
will happen if pandas_dtype=None