### PR TITLE
Allow attaching registered dataframe checks by using Config field names

### DIFF
--- a/docs/source/checks.rst
+++ b/docs/source/checks.rst
@@ -308,7 +308,7 @@ want the resulting table for further analysis.
 .. testoutput:: check_raise_warning
     :skipif: SKIP_PANDAS_LT_V1
 
-    <Schema Column(name=var2, type=None)> failed series validator 0:
+    <Schema Column(name=var2, type=None)> failed series or dataframe validator 0:
     <Check _hypothesis_check: normality test>
 
 

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -234,6 +234,8 @@ In this groupby check, we're verifying that the values of one column for
     3      15      y
 
 
+.. _class_based_api_dataframe_checks:
+
 Registered Custom Checks with the Class-based API
 -------------------------------------------------
 
@@ -264,3 +266,64 @@ you can also use custom checks with the :ref:`class-based API<schema_models>`:
     2  value     2
     3  value     3
     4  value     4
+
+DataFrame checks can be attached by using the :ref:`schema_model_config` class. Any field names that
+do not conflict with existing fields of :class:`~pandera.model.BaseConfig` and do not start
+with an underscore (``_``) are interpreted as the name of registered checks. If the value
+is a tuple or dict, it is interpreted as the positional or keyword arguments of the check, and
+as the first argument otherwise.
+
+For example, to register zero, one, and two statistic dataframe checks one could do the following:
+
+.. testcode:: extensions_df_checks
+
+    import pandera as pa
+    import pandera.extensions as extensions
+    import numpy as np
+    import pandas as pd
+
+
+    @extensions.register_check_method()
+    def is_small(df):
+        return sum(df.shape) < 1000
+
+
+    @extensions.register_check_method(statistics=["fraction"])
+    def total_missing_fraction_less_than(df, *, fraction: float):
+        return (1 - df.count().sum().item() / sum(df.shape)) < fraction
+
+
+    @extensions.register_check_method(statistics=["col_a", "colb"])
+    def col_mean_a_greater_than_b(df, *, col_a: str, col_b: str):
+        return df[col_a].mean() > df[col_b].mean()
+
+
+    from pandera.typing import Series
+
+
+    class Schema(pa.SchemaModel):
+        col1: Series[float] = pa.Field(nullable=True, ignore_na=False)
+        col2: Series[float] = pa.Field(nullable=True, ignore_na=False)
+
+        class Config:
+            is_small = ()
+            total_missing_fraction_less_than = 0.6
+            col_mean_a_greater_than_b = {"col_a": "col2", "col_b": "col1"}
+
+
+    data = pd.DataFrame({
+        "col1": [float('nan')] * 3 + [0.5, 0.3, 0.1],
+        "col2": np.arange(6.),
+    })
+
+    print(Schema.validate(data))
+
+.. testoutput:: extensions_df_checks
+
+       col1  col2
+    0   NaN   0.0
+    1   NaN   1.0
+    2   NaN   2.0
+    3   0.5   3.0
+    4   0.3   4.0
+    5   0.1   5.0

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -400,10 +400,12 @@ class.
             name = "BaseSchema"
             strict = True
             coerce = True
-            foo = "bar"  # not a valid option, ignored
+            foo = "bar"  # Interpreted as dataframe check
 
 It is not required for the ``Config`` to subclass :class:`~pandera.model.BaseConfig` but
 it **must** be named '**Config**'.
+
+See :ref:`class_based_api_dataframe_checks` for details on using registered dataframe checks.
 
 MultiIndex
 ----------

--- a/pandera/error_formatters.py
+++ b/pandera/error_formatters.py
@@ -18,7 +18,7 @@ def format_generic_error_message(
     :param check: check that generated error.
     :param check_index: The validator that failed.
     """
-    return "%s failed series validator %d:\n%s" % (
+    return "%s failed series or dataframe validator %d:\n%s" % (
         parent_schema,
         check_index,
         check,

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -87,17 +87,52 @@ class BaseConfig:  # pylint:disable=R0903
     multiindex_ordered: bool = True
 
 
-_config_options = [
-    attr for attr in vars(BaseConfig) if not attr.startswith("_")
-]
+def _is_field(name: str) -> bool:
+    """Ignore private and reserved keywords."""
+    return not name.startswith("_") and name != _CONFIG_KEY
 
 
-def _extract_config_options(config: Type) -> Dict[str, Any]:
-    return {
-        name: value
-        for name, value in vars(config).items()
-        if name in _config_options
-    }
+_config_options = [attr for attr in vars(BaseConfig) if _is_field(attr)]
+
+
+def _extract_config_options_and_extras(
+    config: Type,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    config_options, extras = {}, {}
+    for name, value in vars(config).items():
+        if name in _config_options:
+            config_options[name] = value
+        elif _is_field(name):
+            extras[name] = value
+        # drop private/reserved keywords
+
+    return config_options, extras
+
+
+def _convert_extras_to_checks(extras: Dict[str, Any]) -> List[Check]:
+    """
+    New in GH#383.
+    Any key not in BaseConfig keys is interpreted as defining a dataframe check. This function
+    defines this conversion as follows:
+        - Look up the key name in Check
+        - If value is
+            - tuple: interpret as args
+            - dict: interpret as kwargs
+            - anything else: interpret as the only argument to pass to Check
+    """
+    checks = []
+    for name, value in extras.items():
+        if isinstance(value, tuple):
+            args, kwargs = value, {}
+        elif isinstance(value, dict):
+            args, kwargs = (), value
+        else:
+            args, kwargs = (value,), {}
+
+        # dispatch directly to getattr to raise the correct exception
+        checks.append(Check.__getattr__(name)(*args, **kwargs))
+
+    return checks
 
 
 class SchemaModel:
@@ -138,6 +173,13 @@ class SchemaModel:
         if cls in MODEL_CACHE:
             return MODEL_CACHE[cls]
 
+        cls.__config__, extras = cls._collect_config_and_extras()
+        mi_kwargs = {
+            name[len("multiindex_") :]: value
+            for name, value in vars(cls.__config__).items()
+            if name.startswith("multiindex_")
+        }
+
         cls.__fields__ = cls._collect_fields()
         check_infos = typing.cast(
             List[FieldCheckInfo], cls._collect_check_infos(CHECK_KEY)
@@ -148,14 +190,10 @@ class SchemaModel:
         )
 
         df_check_infos = cls._collect_check_infos(DATAFRAME_CHECK_KEY)
-        cls.__dataframe_checks__ = cls._extract_df_checks(df_check_infos)
+        df_custom_checks = cls._extract_df_checks(df_check_infos)
+        df_registered_checks = _convert_extras_to_checks(extras)
+        cls.__dataframe_checks__ = df_custom_checks + df_registered_checks
 
-        cls.__config__ = cls._collect_config()
-        mi_kwargs = {
-            name[len("multiindex_") :]: value
-            for name, value in vars(cls.__config__).items()
-            if name.startswith("multiindex_")
-        }
         columns, index = cls._build_columns_index(
             cls.__fields__, cls.__checks__, **mi_kwargs
         )
@@ -329,18 +367,25 @@ class SchemaModel:
         return fields
 
     @classmethod
-    def _collect_config(cls) -> Type[BaseConfig]:
-        """Collect config options from bases."""
+    def _collect_config_and_extras(
+        cls,
+    ) -> Tuple[Type[BaseConfig], Dict[str, Any]]:
+        """Collect config options from bases, splitting off unknown options."""
         bases = inspect.getmro(cls)[:-1]
         bases = typing.cast(Tuple[Type[SchemaModel]], bases)
         root_model, *models = reversed(bases)
 
-        options = _extract_config_options(root_model.Config)
+        options, extras = _extract_config_options_and_extras(root_model.Config)
+
         for model in models:
             config = getattr(model, _CONFIG_KEY, {})
-            base_options = _extract_config_options(config)
+            base_options, base_extras = _extract_config_options_and_extras(
+                config
+            )
             options.update(base_options)
-        return type("Config", (BaseConfig,), options)
+            extras.update(base_extras)
+
+        return type("Config", (BaseConfig,), options), extras
 
     @classmethod
     def _collect_check_infos(cls, key: str) -> List[CheckInfo]:
@@ -428,8 +473,3 @@ def _get_dtype_kwargs(annotation: AnnotationInfo) -> Dict[str, Any]:
             + f"all positional arguments {dtype_arg_names}."
         )
     return dict(zip(dtype_arg_names, annotation.metadata))
-
-
-def _is_field(name: str) -> bool:
-    """Ignore private and reserved keywords."""
-    return not name.startswith("_") and name != _CONFIG_KEY

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 import pandera as pa
+import pandera.extensions as pax
 from pandera.typing import DataFrame, Index, Series, String
 
 
@@ -560,6 +561,62 @@ def test_dataframe_check():
         pa.errors.SchemaErrors, match="2 schema errors were found"
     ):
         schema.validate(df, lazy=True)
+
+
+def test_registered_dataframe_checks(
+    extra_registered_checks,
+):  # pylint: disable=unused-argument
+    """Check that custom check inheritance works"""
+    # pylint: disable=unused-variable
+
+    @pax.register_check_method(statistics=["one_arg"])
+    def base_check(df, *, one_arg):
+        # pylint: disable=unused-argument
+        return True
+
+    @pax.register_check_method(statistics=["one_arg", "two_arg"])
+    def child_check(df, *, one_arg, two_arg):
+        # pylint: disable=unused-argument
+        return True
+
+    # pylint: enable=unused-variable
+
+    check_vals = {"one_arg": 150, "two_arg": "hello"}
+
+    class Base(pa.SchemaModel):
+        a: Series[int]
+        b: Series[int]
+
+        class Config:
+            no_param_check = ()
+            base_check = check_vals["one_arg"]
+
+    class Child(Base):
+        class Config:
+            child_check = check_vals
+
+    child = Child.to_schema()
+
+    expected_stats = {
+        "no_param_check": {},
+        "base_check": {"one_arg": check_vals["one_arg"]},
+        "child_check": check_vals,
+    }
+
+    assert {c.name: c.statistics for c in child.checks} == expected_stats
+
+    # check that unregistered checks raise
+    with pytest.raises(AttributeError, match=".*custom checks.*"):
+
+        class ErrorSchema(pa.SchemaModel):
+            class Config:
+                unknown_check = {}
+
+        # Check lookup happens at validation/to_schema conversion time
+        # This means that you can register checks after defining a Config,
+        # but also because of caching you can refer to a check that no longer
+        # exists for some order of operations.
+        ErrorSchema.to_schema()
 
 
 def test_config():


### PR DESCRIPTION
This PR resolves #383 following the discussion [comment](https://github.com/pandera-dev/pandera/issues/383#issuecomment-805809804).

The implementation turned out to be fairly simple. We just walk through the class hierarchy, splitting field names into those defined in `BaseConfig` and everything else. These "everything else" fields are looked up using `Check.__getattr__`, so they should be aware of custom checks that are added. I've updated the documentation to reflect this new feature. 

Some areas of concern:

- The dataframe checks are only looked up at validation time, or when converting to `DataFrameSchema`. Since we do a caching op, if somebody creates a Schema, converts to DataFrameSchema, and then overwrites a previous check definition, they would be in for a surprise. This may be a concern when using pandera from a notebook. Oh well.
- A minor wart is that zero-statistic registered checks look weird.

TLDR:

```python
import pandas as pd
import pandera as pa
import pandera.extensions as extensions
from pandera.typing import Series

@extensions.register_check_method()
def is_small(df):
    return sum(df.shape) < 1000


@extensions.register_check_method(statistics=["fraction"])
def total_missing_fraction_less_than(df, *, fraction: float):
    return (1 - df.count().sum().item() / sum(df.shape)) < fraction


@extensions.register_check_method(statistics=["col_a", "colb"])
def col_mean_a_greater_than_b(df, *, col_a: str, col_b: str):
    return df[col_a].mean() > df[col_b].mean()

class Schema(pa.SchemaModel):
    col1: Series[float] = pa.Field(nullable=True, ignore_na=False)
    col2: Series[float] = pa.Field(nullable=True, ignore_na=False)

    class Config:
        is_small = ()
        total_missing_fraction_less_than = 0.6
        col_mean_a_greater_than_b = {"col_a": "col2", "col_b": "col1"}
```



