### PR TITLE
Dataframe schemas in yaml do not require any field

### DIFF
--- a/pandera/io.py
+++ b/pandera/io.py
@@ -1,9 +1,8 @@
 """Module for reading and writing schema objects."""
-
+from collections.abc import Mapping
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import Mapping
 
 import pandas as pd
 
@@ -195,12 +194,10 @@ def _deserialize_schema(serialized_schema):
     # GH#475
     serialized_schema = serialized_schema if serialized_schema else {}
 
-    # pylint: disable=isinstance-second-argument-not-valid-type
     if not isinstance(serialized_schema, Mapping):
         raise pandera.errors.SchemaDefinitionError(
             "Schema representation must be a mapping."
         )
-    # pylint: enable=isinstance-second-argument-not-valid-type
 
     columns = serialized_schema.get("columns")
     index = serialized_schema.get("index")

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -2,12 +2,13 @@
 
 import warnings
 from functools import partial
-from typing import Mapping
 from pathlib import Path
+from typing import Mapping
 
 import pandas as pd
 
 import pandera.errors
+
 from .dtypes import PandasDtype
 from .schema_statistics import get_dataframe_schema_statistics
 
@@ -194,7 +195,9 @@ def _deserialize_schema(serialized_schema):
     # GH#475
     serialized_schema = serialized_schema if serialized_schema else {}
     if not isinstance(serialized_schema, Mapping):
-        raise pandera.errors.SchemaDefinitionError("Schema representation must be a mapping.")
+        raise pandera.errors.SchemaDefinitionError(
+            "Schema representation must be a mapping."
+        )
 
     columns = serialized_schema.get("columns")
     index = serialized_schema.get("index")

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -1,6 +1,7 @@
 """Module for reading and writing schema objects."""
-from collections.abc import Mapping
+
 import warnings
+from collections.abc import Mapping
 from functools import partial
 from pathlib import Path
 

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -194,10 +194,13 @@ def _deserialize_schema(serialized_schema):
 
     # GH#475
     serialized_schema = serialized_schema if serialized_schema else {}
+
+    # pylint: disable=isinstance-second-argument-not-valid-type
     if not isinstance(serialized_schema, Mapping):
         raise pandera.errors.SchemaDefinitionError(
             "Schema representation must be a mapping."
         )
+    # pylint: enable=isinstance-second-argument-not-valid-type
 
     columns = serialized_schema.get("columns")
     index = serialized_schema.get("index")

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -407,6 +407,16 @@ def test_from_yaml_unregistered_checks():
         io.from_yaml(YAML_SCHEMA_MISSING_GLOBAL_CHECK)
 
 
+def test_from_yaml_load_required_fields():
+    """Test that dataframe schemas do not require any field."""
+    io.from_yaml("")
+
+    with pytest.raises(pa.errors.SchemaDefinitionError, match=".*must be a mapping.*"):
+        io.from_yaml("""
+        - value
+        """)
+
+
 def test_io_yaml_file_obj():
     """Test read and write operation on file object."""
     schema = _create_schema()

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -411,10 +411,14 @@ def test_from_yaml_load_required_fields():
     """Test that dataframe schemas do not require any field."""
     io.from_yaml("")
 
-    with pytest.raises(pa.errors.SchemaDefinitionError, match=".*must be a mapping.*"):
-        io.from_yaml("""
+    with pytest.raises(
+        pa.errors.SchemaDefinitionError, match=".*must be a mapping.*"
+    ):
+        io.from_yaml(
+            """
         - value
-        """)
+        """
+        )
 
 
 def test_io_yaml_file_obj():


### PR DESCRIPTION
Fixes #475 . 

After merging #428, the dataframe `checks` field became required. Yaml files written before v0.6.3 did not have this field, so they became unreadable with the new version. 

This PR relaxes the constraints on what is an acceptable yaml file to read as a dataframe schema representation. No changes are made to the serialization side.