### PR TITLE
Refactor PandasDtype

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,12 +6,14 @@ on:
     - dev
     - bugfix
     - 'release/*'
+    - dtypes
   pull_request:
     branches:
     - master
     - dev
     - bugfix
     - 'release/*'
+    - dtypes
 
 env:
   DEFAULT_PYTHON: 3.8

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - pyyaml >=5.1
   - typing_inspect >= 0.6.0
   - typing_extensions >= 3.7.4.3
+  - frictionless
 
   # testing and dependencies
   - black >= 20.8b1

--- a/noxfile.py
+++ b/noxfile.py
@@ -180,6 +180,9 @@ def install_extras(
         for spec in REQUIRES[extra].values()
         if spec not in ALWAYS_USE_PIP
     ]
+    if extra == "core":
+        specs.append(REQUIRES["all"]["hypothesis"])
+
     session.install(*ALWAYS_USE_PIP)
     if (
         isinstance(session.virtualenv, nox.virtualenv.CondaEnv)

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,4 +1,18 @@
 """A flexible and expressive pandas validation library."""
+from pandera.dtypes_ import *
+from pandera.engines.numpy_engine import Object
+from pandera.engines.pandas_engine import (
+    BOOL,
+    INT8,
+    INT16,
+    INT32,
+    INT64,
+    STRING,
+    UINT8,
+    UINT16,
+    UINT32,
+    UINT64,
+)
 
 from . import constants, errors, pandas_accessor
 from .checks import Check
@@ -11,33 +25,3 @@ from .schema_components import Column, Index, MultiIndex
 from .schema_inference import infer_schema
 from .schemas import DataFrameSchema, SeriesSchema
 from .version import __version__
-
-# pylint: disable=invalid-name
-Bool = PandasDtype.Bool
-DateTime = PandasDtype.DateTime
-Category = PandasDtype.Category
-Float = PandasDtype.Float
-Float16 = PandasDtype.Float16
-Float32 = PandasDtype.Float32
-Float64 = PandasDtype.Float64
-Int = PandasDtype.Int
-Int8 = PandasDtype.Int8
-Int16 = PandasDtype.Int16
-Int32 = PandasDtype.Int32
-Int64 = PandasDtype.Int64
-UInt8 = PandasDtype.UInt8
-UInt16 = PandasDtype.UInt16
-UInt32 = PandasDtype.UInt32
-UInt64 = PandasDtype.UInt64
-INT8 = PandasDtype.INT8
-INT16 = PandasDtype.INT16
-INT32 = PandasDtype.INT32
-INT64 = PandasDtype.INT64
-UINT8 = PandasDtype.UINT8
-UINT16 = PandasDtype.UINT16
-UINT32 = PandasDtype.UINT32
-UINT64 = PandasDtype.UINT64
-Object = PandasDtype.Object
-String = PandasDtype.String
-STRING = PandasDtype.STRING
-Timedelta = PandasDtype.Timedelta

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,5 +1,32 @@
 """A flexible and expressive pandas validation library."""
-from pandera.dtypes_ import *
+from pandera.dtypes_ import (
+    Bool,
+    Category,
+    Complex,
+    Complex64,
+    Complex128,
+    Complex256,
+    DataType,
+    DateTime,
+    Float,
+    Float16,
+    Float32,
+    Float64,
+    Float128,
+    Int,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    String,
+    Timedelta,
+    Timestamp,
+    UInt,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+)
 from pandera.engines.numpy_engine import Object
 from pandera.engines.pandas_engine import (
     BOOL,

--- a/pandera/dtypes_.py
+++ b/pandera/dtypes_.py
@@ -18,10 +18,10 @@ class DataType:
         """Coerce object to the dtype."""
         raise NotImplementedError()
 
-    def check(self, datatype: "DataType") -> bool:
-        if not isinstance(datatype, DataType):
+    def check(self, pandera_dtype: "DataType") -> bool:
+        if not isinstance(pandera_dtype, DataType):
             return False
-        return self == datatype
+        return self == pandera_dtype
 
     def __repr__(self) -> str:
         return f"DataType({str(self)})"

--- a/pandera/dtypes_.py
+++ b/pandera/dtypes_.py
@@ -1,0 +1,284 @@
+import functools
+from dataclasses import dataclass, field
+from typing import Any, Tuple, Type, Union
+from devtools import debug
+
+try:  # python 3.8+
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
+
+
+def immutable(dtype=None, **kwargs) -> Type:
+    dataclass_kwargs = {"frozen": True, "init": False, "repr": False}
+    dataclass_kwargs.update(kwargs)
+
+    if dtype is None:
+        return functools.partial(dataclass, **dataclass_kwargs)
+    return dataclass(**dataclass_kwargs)(dtype)
+
+
+class DisableInitMixin:
+    def __init__(self) -> None:
+        pass
+
+
+class DataType:
+    def __init__(self):
+        if self.__class__ is DataType:
+            raise TypeError(
+                f"{self.__class__.__name__} may not be instantiated."
+            )
+
+    def __call__(self, obj: Any):
+        """Coerce object to the dtype."""
+        return self.coerce(obj)
+
+    def coerce(self, obj: Any):
+        """Coerce object to the dtype."""
+        raise NotImplementedError()
+
+    def __repr__(self) -> str:
+        return f"DataType({str(self)})"
+
+    def __str__(self) -> str:
+        """Must be implemented by subclasses."""
+        raise NotImplementedError()
+
+    def check(self, datatype: "DataType") -> bool:
+        if not isinstance(datatype, DataType):
+            return False
+        return self == datatype
+
+
+################################################################################
+# boolean
+################################################################################
+
+
+@immutable
+class Bool(DataType):
+    """Semantic representation of a boolean data type."""
+
+    def __str__(self) -> str:
+        return "bool"
+
+
+Boolean = Bool
+
+################################################################################
+# number
+################################################################################
+
+
+@immutable
+class _Number(DataType):
+    continuous: bool = None
+    exact: bool = None
+
+    def check(self, datatype: "DataType") -> bool:
+        if self.__class__ is _Number:
+            return isinstance(datatype, (Int, Float, Complex))
+        return super().check(datatype)
+
+
+@immutable
+class _PhysicalNumber(_Number):
+    bit_width: int = None
+    _base_name: str = field(default=None, init=False, repr=False)
+
+    def __eq__(self, obj: object) -> bool:
+        if isinstance(obj, type(self)):
+            return obj.bit_width == self.bit_width
+        return super().__eq__(obj)
+
+    def __str__(self) -> str:
+        return f"{self._base_name}{self.bit_width}"
+
+
+################################################################################
+## signed integer
+################################################################################
+
+
+@immutable(eq=False)
+class Int(_PhysicalNumber):
+    _base_name = "int"
+    continuous = False
+    exact = True
+    bit_width = 64
+    signed: bool = field(default=True, init=False)
+
+
+@immutable
+class Int64(Int, _PhysicalNumber):
+    bit_width = 64
+
+
+@immutable
+class Int32(Int64):
+    bit_width = 32
+
+
+@immutable
+class Int16(Int32):
+    bit_width = 16
+
+
+@immutable
+class Int8(Int16):
+    bit_width = 8
+
+
+################################################################################
+## unsigned integer
+################################################################################
+
+
+@immutable
+class UInt(Int):
+    _base_name = "uint"
+    signed: bool = field(default=False, init=False)
+
+
+@immutable
+class UInt64(UInt):
+    bit_width = 64
+
+
+@immutable
+class UInt32(UInt64):
+    bit_width = 32
+
+
+@immutable
+class UInt16(UInt32):
+    bit_width = 16
+
+
+@immutable
+class UInt8(UInt16):
+    bit_width = 8
+
+
+################################################################################
+## float
+################################################################################
+
+
+@immutable(eq=False)
+class Float(_PhysicalNumber):
+    _base_name = "float"
+    continuous = True
+    exact = False
+    bit_width = 64
+
+
+@immutable
+class Float128(Float):
+    bit_width = 128
+
+
+@immutable
+class Float64(Float128):
+    bit_width = 64
+
+
+@immutable
+class Float32(Float64):
+    bit_width = 32
+
+
+@immutable
+class Float16(Float32):
+    bit_width = 16
+
+
+################################################################################
+## complex
+################################################################################
+
+
+@immutable(eq=False)
+class Complex(_PhysicalNumber):
+    _base_name = "complex"
+    bit_width = 128
+
+
+@immutable
+class Complex256(Complex):
+    bit_width = 256
+
+
+@immutable
+class Complex128(Complex):
+    bit_width = 128
+
+
+@immutable
+class Complex64(Complex128):
+    bit_width = 64
+
+
+################################################################################
+# nominal
+################################################################################
+
+
+@dataclass(frozen=True)
+class Category(DataType):
+    categories: Tuple[Any] = None  # immutable sequence to ensure safe hash
+    ordered: bool = False
+
+    def __post_init__(self) -> "Category":
+        if self.categories is not None and not isinstance(
+            self.categories, tuple
+        ):
+            object.__setattr__(self, "categories", tuple(self.categories))
+
+    def check(self, datatype: "DataType") -> bool:
+        if (
+            isinstance(datatype, Category)
+            and self.categories is None
+            or datatype.categories is None
+        ):
+            # Category without categories is a superset of any Category
+            # Allow end-users to not list categories when validating.
+            return True
+
+        return super().check(datatype)
+
+    def __str__(self) -> str:
+        return "category"
+
+
+@immutable
+class String(DataType):
+    def __str__(self) -> str:
+        return "string"
+
+
+################################################################################
+# time
+################################################################################
+
+
+@immutable
+class Date(DataType):
+    def __str__(self) -> str:
+        return "date"
+
+
+@immutable
+class Timestamp(Date):
+    def __str__(self) -> str:
+        return "timestamp"
+
+
+DateTime = Timestamp
+
+
+@immutable
+class Timedelta(DataType):
+    def __str__(self) -> str:
+        return "timedelta"

--- a/pandera/dtypes_.py
+++ b/pandera/dtypes_.py
@@ -227,8 +227,8 @@ class Complex64(Complex128):
 ################################################################################
 
 
-@dataclass(frozen=True)
-class Category(DataType):
+@immutable(init=True)
+class Category(DisableInitMixin, DataType):
     categories: Tuple[Any] = None  # immutable sequence to ensure safe hash
     ordered: bool = False
 

--- a/pandera/dtypes_.py
+++ b/pandera/dtypes_.py
@@ -1,7 +1,6 @@
 import functools
 from dataclasses import dataclass, field
 from typing import Any, Tuple, Type, Union
-from devtools import debug
 
 try:  # python 3.8+
     from typing import Literal  # type: ignore
@@ -49,6 +48,9 @@ class DataType:
         if not isinstance(datatype, DataType):
             return False
         return self == datatype
+
+    def __hash__(self) -> int:
+        pass
 
 
 ################################################################################

--- a/pandera/dtypes_.py
+++ b/pandera/dtypes_.py
@@ -40,26 +40,6 @@ def immutable(
     """:func:`dataclasses.dataclass` decorator with different default values:
     `frozen=True`, `init=False`, `repr=False`.
 
-    :param dtype: :class:`DataType` to decorate.
-    :param dataclass_kwargs: Keywords arguments forwarded to
-        :func:`dataclasses.dataclass`.
-    :returns: Immutable :class:`DataType`
-    """
-    kwargs = {"frozen": True, "init": False, "repr": False}
-    kwargs.update(dataclass_kwargs)
-
-
-#     if dtype is None:
-#         return functools.partial(dataclasses.dataclass, **kwargs)
-#     return dataclasses.dataclass(**kwargs)(dtype)
-
-
-def immutable(
-    dtype: Type[DataType] = None, **dataclass_kwargs: Any
-) -> Type[DataType]:
-    """:func:`dataclasses.dataclass` decorator with different default values:
-    `frozen=True`, `init=False`, `repr=False`.
-
     In addition, `init=False` disables inherited `__init__` method to ensure
     the DataType's default attributes are not altered during initialization.
 

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -5,7 +5,6 @@ from abc import ABCMeta
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Type, Union, get_type_hints
 
-
 import typing_inspect
 
 from pandera.dtypes_ import DataType
@@ -57,7 +56,8 @@ class Engine(ABCMeta):
         func = method.__func__
         annotations = get_type_hints(func).values()
         dtype = next(iter(annotations))  # get 1st annotation
-        dtypes = typing_inspect.get_args(dtype) or [dtype]  # parse typing.Union
+        # parse typing.Union
+        dtypes = typing_inspect.get_args(dtype) or [dtype]
 
         def _method(*args, **kwargs):
             return func(target_dtype, *args, **kwargs)

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -27,7 +27,7 @@ class Engine(ABCMeta):
 
     def __new__(mcs, name, bases, namespace, **kwargs):
         base_datatype = kwargs.pop("base_datatype")
-        try:
+        try:  # allow multiple base datatypes
             base_datatype = tuple(base_datatype)
         except TypeError:
             pass

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -1,0 +1,157 @@
+import functools
+import inspect
+import warnings
+from abc import ABCMeta
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Type, Union, get_type_hints
+
+
+import typing_inspect
+
+from pandera.dtypes_ import DataType
+
+
+@dataclass
+class _DtypeRegistry:
+    dispatcher: Callable[[Any], DataType]
+    lookup: Dict[Any, Type[DataType]]
+
+
+class Engine(ABCMeta):
+    """Base Engine.
+
+    Keep a registry of concrete Engines (currently, only pandas).
+    """
+
+    _registry: Dict["Engine", _DtypeRegistry] = {}
+    _base_datatype: Type[DataType]
+
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        base_datatype = kwargs.pop("base_datatype")
+        try:
+            base_datatype = tuple(base_datatype)
+        except TypeError:
+            pass
+        namespace["_base_datatype"] = base_datatype
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+
+        @functools.singledispatch
+        def dtype(obj: Any) -> DataType:
+            raise ValueError(f"Data type '{obj}' not understood")
+
+        mcs._registry[cls] = _DtypeRegistry(dispatcher=dtype, lookup={})
+        return cls
+
+    def _check_source_dtype(cls, obj: Any) -> None:
+        if isinstance(obj, cls._base_datatype) or (
+            inspect.isclass(obj) and issubclass(obj, cls._base_datatype)
+        ):
+            raise ValueError(
+                f"{cls._base_datatype.__name__} subclasses cannot be registered"
+                f" with {cls.__name__}."
+            )
+
+    def _register_from_parametrized_dtype(
+        cls, target_dtype: Union[DataType, Type[DataType]], method: classmethod
+    ) -> None:
+        func = method.__func__
+        annotations = get_type_hints(func).values()
+        dtype = next(iter(annotations))  # get 1st annotation
+        dtypes = typing_inspect.get_args(dtype) or [dtype]  # parse typing.Union
+
+        def _method(*args, **kwargs):
+            return func(target_dtype, *args, **kwargs)
+
+        for source_dtype in dtypes:
+            cls._check_source_dtype(source_dtype)
+            cls._registry[cls].dispatcher.register(source_dtype, _method)
+
+    def _register_lookup(
+        cls,
+        target_dtype: Union[DataType, Type[DataType]],
+        *source_dtypes: Any,
+    ) -> None:
+        value = target_dtype()
+        for source_dtype in source_dtypes:
+            cls._check_source_dtype(source_dtype)
+            cls._registry[cls].lookup[source_dtype] = value
+
+    def register_dtype(
+        cls,
+        dtype: Type[DataType] = None,
+        *,
+        equivalents: List[DataType] = None,
+    ):
+        """Register a DataType
+
+        :param dtype: The DataType to register.
+        :param equivalents: Equivalent scalar dtype class or
+            non-parametrized dtype instance.
+
+        .. note::
+            Register the classmethod ``from_parametrized_dtype`` if present.
+        """
+
+        def _wrapper(dtype: Union[DataType, Type[DataType]]):
+            if not inspect.isclass(dtype):
+                raise ValueError(
+                    f"{cls.__name__}.register_dtype can only decorate a class, "
+                    + f"got {dtype}"
+                )
+
+            if equivalents:
+                cls._register_lookup(dtype, *equivalents)
+
+            from_parametrized_dtype = dtype.__dict__.get(
+                "from_parametrized_dtype"
+            )
+            if from_parametrized_dtype:
+                if not isinstance(from_parametrized_dtype, classmethod):
+                    raise ValueError(
+                        f"{dtype.__name__}.from_parametrized_dtype "
+                        + "must be a classmethod."
+                    )
+                cls._register_from_parametrized_dtype(
+                    dtype,
+                    from_parametrized_dtype,
+                )
+            elif not equivalents:
+                warnings.warn(
+                    f"register_dtype({dtype}) on a class without a "
+                    + "'from_parametrized_dtype' classmethod has no effect."
+                )
+
+            return dtype
+
+        if dtype:
+            return _wrapper(dtype)
+
+        return _wrapper
+
+    def dtype(cls, obj: Any) -> DataType:
+        """Convert input into a DataType object."""
+        if isinstance(obj, cls._base_datatype):
+            return obj
+
+        if inspect.isclass(obj) and issubclass(obj, cls._base_datatype):
+            try:
+                return obj()
+            except (TypeError, AttributeError) as err:
+                raise TypeError(
+                    f"DataType '{obj.__name__}' cannot be instantiated: "
+                    f"{err}\n "
+                    + "Usage Tip: Use an instance or a string representation."
+                ) from err
+
+        registry = cls._registry[cls]
+
+        data_type = registry.lookup.get(obj)
+        if data_type is not None:
+            return data_type
+
+        try:
+            return registry.dispatcher(obj)
+        except (KeyError, ValueError):
+            raise TypeError(
+                f"Data type '{obj}' not understood by {cls.__name__}."
+            ) from None

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -1,45 +1,81 @@
+"""Data types engine interface."""
+# https://github.com/PyCQA/pylint/issues/3268
+# pylint:disable=no-value-for-parameter
 import functools
 import inspect
 import warnings
 from abc import ABCMeta
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Type, Union, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Type,
+    TypeVar,
+    Union,
+    get_type_hints,
+)
 
 import typing_inspect
 
 from pandera.dtypes_ import DataType
 
+_DataType = TypeVar("_DataType", bound=DataType)
+_Engine = TypeVar("_Engine", bound="Engine")
+_EngineType = Type[_Engine]
+
+if TYPE_CHECKING:
+
+    class Dispatch:
+        """Only used for type annotation."""
+
+        def __call__(self, data_type: Any, **kwds: Any) -> Any:
+            pass
+
+        @staticmethod
+        def register(
+            data_type: Any, func: Callable[[Any], DataType]
+        ) -> Callable[[Any], DataType]:
+            """Register a new implementation for the given cls."""
+
+
+else:
+    Dispatch = Callable[[Any], DataType]
+
 
 @dataclass
 class _DtypeRegistry:
-    dispatch: Callable[[Any], DataType]
-    equivalents: Dict[Any, Type[DataType]]
+    dispatch: Dispatch
+    equivalents: Dict[Any, DataType]
 
 
 class Engine(ABCMeta):
-    """Base Engine.
+    """Base Engine metaclass.
 
-    Keep a registry of concrete Engines (currently, only pandas).
+    Keep a registry of concrete Engines.
     """
 
     _registry: Dict["Engine", _DtypeRegistry] = {}
     _base_pandera_dtypes: Type[DataType]
 
-    def __new__(mcs, name, bases, namespace, **kwargs):
+    def __new__(cls, name, bases, namespace, **kwargs):
+
         base_pandera_dtypes = kwargs.pop("base_pandera_dtypes")
         try:  # allow multiple base datatypes
             base_pandera_dtypes = tuple(base_pandera_dtypes)
         except TypeError:
             pass
         namespace["_base_pandera_dtypes"] = base_pandera_dtypes
-        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        engine = super().__new__(cls, name, bases, namespace, **kwargs)
 
         @functools.singledispatch
         def dtype(data_type: Any) -> DataType:
             raise ValueError(f"Data type '{data_type}' not understood")
 
-        mcs._registry[cls] = _DtypeRegistry(dispatch=dtype, equivalents={})
-        return cls
+        cls._registry[engine] = _DtypeRegistry(dispatch=dtype, equivalents={})
+        return engine
 
     def _check_source_dtype(cls, data_type: Any) -> None:
         if isinstance(data_type, cls._base_pandera_dtypes) or (
@@ -52,8 +88,15 @@ class Engine(ABCMeta):
             )
 
     def _register_from_parametrized_dtype(
-        cls, target_dtype: Union[DataType, Type[DataType]], method: classmethod
+        cls,
+        pandera_dtype_cls: Type[DataType],
     ) -> None:
+        method = pandera_dtype_cls.__dict__["from_parametrized_dtype"]
+        if not isinstance(method, classmethod):
+            raise ValueError(
+                f"{pandera_dtype_cls.__name__}.from_parametrized_dtype "
+                + "must be a classmethod."
+            )
         func = method.__func__
         annotations = get_type_hints(func).values()
         dtype = next(iter(annotations))  # get 1st annotation
@@ -61,7 +104,7 @@ class Engine(ABCMeta):
         dtypes = typing_inspect.get_args(dtype) or [dtype]
 
         def _method(*args, **kwargs):
-            return func(target_dtype, *args, **kwargs)
+            return func(pandera_dtype_cls, *args, **kwargs)
 
         for source_dtype in dtypes:
             cls._check_source_dtype(source_dtype)
@@ -69,19 +112,19 @@ class Engine(ABCMeta):
 
     def _register_equivalents(
         cls,
-        target_dtype: Union[DataType, Type[DataType]],
+        pandera_dtype_cls: Type[DataType],
         *source_dtypes: Any,
     ) -> None:
-        value = target_dtype()
+        pandera_dtype = pandera_dtype_cls()  # type: ignore
         for source_dtype in source_dtypes:
             cls._check_source_dtype(source_dtype)
-            cls._registry[cls].equivalents[source_dtype] = value
+            cls._registry[cls].equivalents[source_dtype] = pandera_dtype
 
     def register_dtype(
-        cls,
-        pandera_dtype: Type[DataType] = None,
+        cls: _EngineType,
+        pandera_dtype_cls: Type[DataType] = None,
         *,
-        equivalents: List[DataType] = None,
+        equivalents: List[Any] = None,
     ):
         """Register a Pandera :class:`DataType`.
 
@@ -103,19 +146,8 @@ class Engine(ABCMeta):
             if equivalents:
                 cls._register_equivalents(pandera_dtype, *equivalents)
 
-            from_parametrized_dtype = pandera_dtype.__dict__.get(
-                "from_parametrized_dtype"
-            )
-            if from_parametrized_dtype:
-                if not isinstance(from_parametrized_dtype, classmethod):
-                    raise ValueError(
-                        f"{pandera_dtype.__name__}.from_parametrized_dtype "
-                        + "must be a classmethod."
-                    )
-                cls._register_from_parametrized_dtype(
-                    pandera_dtype,
-                    from_parametrized_dtype,
-                )
+            if "from_parametrized_dtype" in pandera_dtype.__dict__:
+                cls._register_from_parametrized_dtype(pandera_dtype)
             elif not equivalents:
                 warnings.warn(
                     f"register_dtype({pandera_dtype}) on a class without a "
@@ -124,12 +156,12 @@ class Engine(ABCMeta):
 
             return pandera_dtype
 
-        if pandera_dtype:
-            return _wrapper(pandera_dtype)
+        if pandera_dtype_cls:
+            return _wrapper(pandera_dtype_cls)
 
         return _wrapper
 
-    def dtype(cls, data_type: Any) -> DataType:
+    def dtype(cls: _EngineType, data_type: Any) -> _DataType:
         """Convert input into a Pandera :class:`DataType` object."""
         if isinstance(data_type, cls._base_pandera_dtypes):
             return data_type

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -32,7 +32,7 @@ class DataType(dtypes_.DataType):
         return f"DataType({self})"
 
 
-class Engine(metaclass=engine.Engine, base_datatype=DataType):
+class Engine(metaclass=engine.Engine, base_pandera_dtypes=DataType):
     @classmethod
     def dtype(cls, data_type: Any) -> "DataType":
         try:
@@ -264,8 +264,8 @@ class String(DataType, dtypes_.String):
         arr[notna] = arr[notna].astype(str)
         return arr
 
-    def check(self, datatype: "dtypes_.DataType") -> bool:
-        return isinstance(datatype, (Object, type(self)))
+    def check(self, pandera_dtype: "dtypes_.DataType") -> bool:
+        return isinstance(pandera_dtype, (Object, type(self)))
 
 
 ################################################################################

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -1,18 +1,23 @@
 import builtins
+import dataclasses
 import datetime
-from dataclasses import field
 from typing import Any, List
 
 import numpy as np
 
 from .. import dtypes_
-from ..dtypes_ import DisableInitMixin, immutable
+from ..dtypes_ import immutable
 from . import engine
 
 
 @immutable(init=True)
 class DataType(dtypes_.DataType):
-    type: np.dtype = field(default=np.dtype("object"), repr=False)
+    type: np.dtype = dataclasses.field(
+        default=np.dtype("object"), repr=False, init=False
+    )
+
+    def __init__(self, dtype: Any):
+        object.__setattr__(self, "type", np.dtype(dtype))
 
     def __post_init__(self):
         object.__setattr__(self, "type", np.dtype(self.type))
@@ -39,6 +44,7 @@ class Engine(metaclass=engine.Engine, base_datatype=DataType):
                 raise TypeError(
                     f"data type '{data_type}' not understood by {cls.__name__}."
                 ) from None
+
             try:
                 return engine.Engine.dtype(cls, np_dtype)
             except TypeError:
@@ -54,7 +60,7 @@ class Engine(metaclass=engine.Engine, base_datatype=DataType):
     equivalents=["bool", bool, np.bool_, dtypes_.Bool, dtypes_.Bool()]
 )
 @immutable
-class Bool(DisableInitMixin, DataType, dtypes_.Bool):
+class Bool(DataType, dtypes_.Bool):
     """representation of a boolean data type."""
 
     type = np.dtype("bool")
@@ -106,7 +112,7 @@ _int_equivalents = _build_number_equivalents(
 
 @Engine.register_dtype(equivalents=_int_equivalents[64])
 @immutable
-class Int64(DisableInitMixin, DataType, dtypes_.Int64):
+class Int64(DataType, dtypes_.Int64):
     type = np.dtype("int64")
     bit_width: int = 64
 
@@ -145,7 +151,7 @@ _uint_equivalents = _build_number_equivalents(
 
 @Engine.register_dtype(equivalents=_uint_equivalents[64])
 @immutable
-class UInt64(DisableInitMixin, DataType, dtypes_.UInt64):
+class UInt64(DataType, dtypes_.UInt64):
     type = np.dtype("uint64")
     bit_width: int = 64
 
@@ -184,7 +190,7 @@ _float_equivalents = _build_number_equivalents(
 
 @Engine.register_dtype(equivalents=_float_equivalents[128])
 @immutable
-class Float128(DisableInitMixin, DataType, dtypes_.Float128):
+class Float128(DataType, dtypes_.Float128):
     type = np.dtype("float128")
     bit_width: int = 128
 
@@ -223,7 +229,7 @@ _complex_equivalents = _build_number_equivalents(
 
 @Engine.register_dtype(equivalents=_complex_equivalents[256])
 @immutable
-class Complex256(DisableInitMixin, DataType, dtypes_.Complex256):
+class Complex256(DataType, dtypes_.Complex256):
     type = np.dtype("complex256")
     bit_width: int = 256
 
@@ -249,7 +255,7 @@ class Complex64(Complex128):
 
 @Engine.register_dtype(equivalents=["str", "string", str, np.str_])
 @immutable
-class String(DisableInitMixin, DataType, dtypes_.String):
+class String(DataType, dtypes_.String):
     type = np.dtype("str")
 
     def coerce(self, arr: np.ndarray) -> np.ndarray:
@@ -269,11 +275,9 @@ class String(DisableInitMixin, DataType, dtypes_.String):
 
 @Engine.register_dtype(equivalents=["object", "O", object, np.object_])
 @immutable
-class Object(DisableInitMixin, DataType):
+class Object(DataType):
     type = np.dtype("object")
 
-
-Object = Object
 
 ################################################################################
 # time
@@ -289,7 +293,7 @@ Object = Object
     ]
 )
 @immutable
-class DateTime64(DisableInitMixin, DataType, dtypes_.Timestamp):
+class DateTime64(DataType, dtypes_.Timestamp):
     type = np.dtype("datetime64")
 
 
@@ -302,5 +306,5 @@ class DateTime64(DisableInitMixin, DataType, dtypes_.Timestamp):
     ]
 )
 @immutable
-class Timedelta64(DisableInitMixin, DataType, dtypes_.Timedelta):
+class Timedelta64(DataType, dtypes_.Timedelta):
     type = np.dtype("timedelta64")

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -2,12 +2,12 @@ import builtins
 import datetime
 from dataclasses import field
 from typing import Any, List
+
 import numpy as np
 
 import pandera.dtypes_
 from pandera.dtypes_ import *
 from pandera.engines.engine import Engine
-from typing import Any
 
 
 @immutable(init=True)

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -1,0 +1,304 @@
+import builtins
+import datetime
+from dataclasses import field
+from typing import Any, List
+import numpy as np
+
+import pandera.dtypes_
+from pandera.dtypes_ import *
+from pandera.engines.engine import Engine
+from typing import Any
+
+
+@immutable(init=True)
+class NumpyDataType(DataType):
+    type: np.dtype = field(default=np.dtype("object"), repr=False)
+
+    def __post_init__(self):
+        object.__setattr__(self, "type", np.dtype(self.type))
+
+    def coerce(self, arr: np.ndarray) -> np.ndarray:
+        return arr.astype(self.type)
+
+    def __str__(self) -> str:
+        return self.type.name
+
+    def __repr__(self) -> str:
+        return f"NumpyDataType({self})"
+
+
+class NumpyEngine(metaclass=Engine, base_datatype=NumpyDataType):
+    @classmethod
+    def dtype(cls, data_type: Any) -> "NumpyDataType":
+        try:
+            return Engine.dtype(cls, data_type)
+        except TypeError:
+            try:
+                np_dtype = np.dtype(data_type).type
+            except TypeError:
+                raise TypeError(
+                    f"data type '{data_type}' not understood by {cls.__name__}."
+                ) from None
+            try:
+                return Engine.dtype(cls, np_dtype)
+            except TypeError:
+                return NumpyDataType(data_type)
+
+
+################################################################################
+# boolean
+################################################################################
+
+
+@NumpyEngine.register_dtype(equivalents=["bool", bool, np.bool_, Bool, Bool()])
+@immutable
+class NumpyBool(DisableInitMixin, NumpyDataType, Bool):
+    """Numpy representation of a boolean data type."""
+
+    type = np.dtype("bool")
+
+
+def _build_number_equivalents(
+    builtin_name: str, pandera_name: str, sizes: List[int]
+) -> None:
+    """Return a dict of equivalent builtin, numpy, pandera dtypes
+    indexed by size in bit_width."""
+    builtin_type = getattr(builtins, builtin_name, None)
+    default_np_dtype = np.dtype(builtin_name)
+    default_size = int(default_np_dtype.name.replace(builtin_name, ""))
+
+    default_equivalents = [
+        # e.g.: np.int64
+        np.dtype(builtin_name).type,
+        # e.g: pandera.dtypes.Int
+        getattr(pandera.dtypes_, pandera_name),
+    ]
+    if builtin_type:
+        default_equivalents.append(builtin_type)
+
+    return {
+        bit_width: set(
+            (
+                # e.g.: numpy.int64
+                getattr(np, f"{builtin_name}{bit_width}"),
+                # e.g.: pandera.dtypes.Int64
+                getattr(pandera.dtypes_, f"{pandera_name}{bit_width}"),
+                getattr(pandera.dtypes_, f"{pandera_name}{bit_width}")(),
+                # e.g.: pandera.dtypes.Int(64)
+                getattr(pandera.dtypes_, pandera_name)(),
+            )
+        )
+        | set(default_equivalents if bit_width == default_size else [])
+        for bit_width in sizes
+    }
+
+
+################################################################################
+## signed integer
+################################################################################
+
+_int_equivalents = _build_number_equivalents(
+    builtin_name="int", pandera_name="Int", sizes=[64, 32, 16, 8]
+)
+
+
+@NumpyEngine.register_dtype(equivalents=_int_equivalents[64])
+@immutable
+class NumpyInt64(DisableInitMixin, NumpyDataType, Int64):
+    type = np.dtype("int64")
+    bit_width: int = 64
+
+
+@NumpyEngine.register_dtype(equivalents=_int_equivalents[32])
+@immutable
+class NumpyInt32(NumpyInt64):
+    type = np.dtype("int32")
+    bit_width: int = 32
+
+
+@NumpyEngine.register_dtype(equivalents=_int_equivalents[16])
+@immutable
+class NumpyInt16(NumpyInt32):
+    type = np.dtype("int16")
+    bit_width: int = 16
+
+
+@NumpyEngine.register_dtype(equivalents=_int_equivalents[8])
+@immutable
+class NumpyInt8(NumpyInt16):
+    type = np.dtype("int8")
+    bit_width: int = 8
+
+
+################################################################################
+## unsigned integer
+################################################################################
+
+_uint_equivalents = _build_number_equivalents(
+    builtin_name="uint",
+    pandera_name="UInt",
+    sizes=[64, 32, 16, 8],
+)
+
+
+@NumpyEngine.register_dtype(equivalents=_uint_equivalents[64])
+@immutable
+class NumpyUInt64(DisableInitMixin, NumpyDataType, UInt64):
+    type = np.dtype("uint64")
+    bit_width: int = 64
+
+
+@NumpyEngine.register_dtype(equivalents=_uint_equivalents[32])
+@immutable
+class NumpyUInt32(NumpyUInt64):
+    type = np.dtype("uint32")
+    bit_width: int = 32
+
+
+@NumpyEngine.register_dtype(equivalents=_uint_equivalents[16])
+@immutable
+class NumpyUInt16(NumpyUInt32):
+    type = np.dtype("uint16")
+    bit_width: int = 16
+
+
+@NumpyEngine.register_dtype(equivalents=_uint_equivalents[8])
+@immutable
+class NumpyUInt8(NumpyUInt16):
+    type = np.dtype("uint8")
+    bit_width: int = 8
+
+
+################################################################################
+## float
+################################################################################
+
+_float_equivalents = _build_number_equivalents(
+    builtin_name="float",
+    pandera_name="Float",
+    sizes=[128, 64, 32, 16],
+)
+
+
+@NumpyEngine.register_dtype(equivalents=_float_equivalents[128])
+@immutable
+class NumpyFloat128(DisableInitMixin, NumpyDataType, Float128):
+    type = np.dtype("float128")
+    bit_width: int = 128
+
+
+@NumpyEngine.register_dtype(equivalents=_float_equivalents[64])
+@immutable
+class NumpyFloat64(NumpyFloat128):
+    type = np.dtype("float64")
+    bit_width: int = 64
+
+
+@NumpyEngine.register_dtype(equivalents=_float_equivalents[32])
+@immutable
+class NumpyFloat32(NumpyFloat64):
+    type = np.dtype("float32")
+    bit_width: int = 32
+
+
+@NumpyEngine.register_dtype(equivalents=_float_equivalents[16])
+@immutable
+class NumpyFloat16(NumpyFloat32):
+    type = np.dtype("float16")
+    bit_width: int = 16
+
+
+################################################################################
+## complex
+################################################################################
+
+_complex_equivalents = _build_number_equivalents(
+    builtin_name="complex",
+    pandera_name="Complex",
+    sizes=[256, 128, 64],
+)
+
+
+@NumpyEngine.register_dtype(equivalents=_complex_equivalents[256])
+@immutable
+class NumpyComplex256(DisableInitMixin, NumpyDataType, Complex256):
+    type = np.dtype("complex256")
+    bit_width: int = 256
+
+
+@NumpyEngine.register_dtype(equivalents=_complex_equivalents[128])
+@immutable
+class NumpyComplex128(NumpyComplex256):
+    type = np.dtype("complex128")
+    bit_width: int = 128
+
+
+@NumpyEngine.register_dtype(equivalents=_complex_equivalents[64])
+@immutable
+class NumpyComplex64(NumpyComplex128):
+    type = np.dtype("complex64")
+    bit_width: int = 64
+
+
+################################################################################
+# string
+################################################################################
+
+
+@NumpyEngine.register_dtype(equivalents=["str", "string", str, np.str_])
+@immutable
+class NumpyString(DisableInitMixin, NumpyDataType, String):
+    type = np.dtype("str")
+
+    def coerce(self, arr: np.ndarray) -> np.ndarray:
+        arr = arr.astype(object)
+        notna = ~arr.isna()
+        arr[notna] = arr[notna].astype(str)
+        return arr
+
+    def check(self, datatype: "DataType") -> bool:
+        return isinstance(datatype, (NumpyObject, type(self)))
+
+
+################################################################################
+# object
+################################################################################
+
+
+@NumpyEngine.register_dtype(equivalents=["object", "O", object, np.object_])
+@immutable
+class NumpyObject(DisableInitMixin, NumpyDataType):
+    type = np.dtype("object")
+
+
+Object = NumpyObject
+
+################################################################################
+# time
+################################################################################
+
+
+@NumpyEngine.register_dtype(
+    equivalents=[
+        datetime.datetime,
+        np.datetime64,
+        Timestamp,
+        Timestamp(),
+    ]
+)
+@immutable
+class NumpyDateTime64(DisableInitMixin, NumpyDataType, Timestamp):
+    type = np.dtype("datetime64")
+
+
+@NumpyEngine.register_dtype(
+    equivalents=[
+        datetime.datetime,
+        np.timedelta64,
+        Timedelta,
+        Timedelta(),
+    ]
+)
+@immutable
+class NumpyTimedelta64(DisableInitMixin, NumpyDataType, Timedelta):
+    type = np.dtype("timedelta64")

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -18,6 +18,13 @@ class DataType(dtypes_.DataType):
 
     def __init__(self, dtype: Any):
         object.__setattr__(self, "type", np.dtype(dtype))
+        dtype_cls = dtype if inspect.isclass(dtype) else dtype.__class__
+        warnings.warn(
+            f"'{dtype_cls}' support is not guaranteed.\n"
+            + "Usage Tip: Consider writing a custom "
+            + "pandera.dtypes.DataType or opening an issue at "
+            + "https://github.com/pandera-dev/pandera"
+        )
 
     def __post_init__(self):
         object.__setattr__(self, "type", np.dtype(self.type))

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -2,17 +2,17 @@ import builtins
 import datetime
 from dataclasses import field
 from typing import Any, Dict, List, Union
+
 import numpy as np
 import pandas as pd
 
-from pandera.engines.engine import Engine
+import pandera.dtypes_
 import pandera.engines.numpy_engine
+from pandera.engines.engine import Engine
 from pandera.engines.numpy_engine import *
 
-import pandera.dtypes_
 from ..dtypes_ import *
 from .engine import Engine
-import numpy as np
 
 PandasObject = Union[pd.Series, pd.Index, pd.DataFrame]
 PandasExtensionType = pd.core.dtypes.base.ExtensionDtype
@@ -297,7 +297,9 @@ class PandasCategorical(PandasDataType, Category):
         )
 
     @classmethod
-    def from_parametrized_dtype(cls, cat: Union[Category, pd.CategoricalDtype]):
+    def from_parametrized_dtype(
+        cls, cat: Union[Category, pd.CategoricalDtype]
+    ):
         return cls(categories=cat.categories, ordered=cat.ordered)
 
 
@@ -516,7 +518,9 @@ class PandasInterval(PandasDataType):
     subtype: Union[str, np.dtype]
 
     def __post_init__(self):
-        object.__setattr__(self, "type", pd.IntervalDtype(subtype=self.subtype))
+        object.__setattr__(
+            self, "type", pd.IntervalDtype(subtype=self.subtype)
+        )
 
     @classmethod
     def from_parametrized_dtype(cls, pd_dtype: pd.IntervalDtype):

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -29,6 +29,13 @@ class DataType(dtypes_.DataType):
 
     def __init__(self, dtype: Any):
         object.__setattr__(self, "type", pd.api.types.pandas_dtype(dtype))
+        dtype_cls = dtype if inspect.isclass(dtype) else dtype.__class__
+        warnings.warn(
+            f"'{dtype_cls}' support is not guaranteed.\n"
+            + "Usage Tip: Consider writing a custom "
+            + "pandera.dtypes.DataType or opening an issue at "
+            + "https://github.com/pandera-dev/pandera"
+        )
 
     def __post_init__(self):
         object.__setattr__(self, "type", pd.api.types.pandas_dtype(self.type))

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1,0 +1,523 @@
+import builtins
+import datetime
+from dataclasses import field
+from typing import Any, Dict, List, Union
+import numpy as np
+import pandas as pd
+
+from pandera.engines.engine import Engine
+import pandera.engines.numpy_engine
+from pandera.engines.numpy_engine import *
+
+import pandera.dtypes_
+from ..dtypes_ import *
+from .engine import Engine
+import numpy as np
+
+PandasObject = Union[pd.Series, pd.Index, pd.DataFrame]
+PandasExtensionType = pd.core.dtypes.base.ExtensionDtype
+
+
+def is_extension_dtype(dtype):
+    """Check if a value is a pandas extension type or instance of one."""
+    return isinstance(dtype, PandasExtensionType) or (
+        isinstance(dtype, type) and issubclass(dtype, PandasExtensionType)
+    )
+
+
+@immutable(init=True)
+class PandasDataType(DataType):
+    type: Any = field(repr=False)
+
+    def __post_init__(self):
+        object.__setattr__(self, "type", pd.api.types.pandas_dtype(self.type))
+
+    def coerce(self, obj: PandasObject) -> PandasObject:
+        return obj.astype(self.type)
+
+    def check(self, datatype: "PandasDataType") -> bool:
+        try:
+            datatype = PandasEngine.dtype(datatype)
+        except TypeError:
+            return False
+        return super().check(datatype)
+
+    def __str__(self) -> str:
+        return str(self.type)
+
+    def __repr__(self) -> str:
+        return f"PandasDataType({self})"
+
+
+class PandasEngine(
+    metaclass=Engine, base_datatype=(PandasDataType, NumpyDataType)
+):
+    @classmethod
+    def dtype(cls, obj: Any) -> "PandasDataType":
+        try:
+            return Engine.dtype(cls, obj)
+        except TypeError:
+            if is_extension_dtype(obj) and isinstance(obj, type):
+                try:
+                    np_or_pd_dtype = obj()
+                    # Convert to str here because some pandas dtypes allow
+                    # an empty constructor for compatibility but fail on
+                    # str(). e.g: PeriodDtype
+                    str(np_or_pd_dtype.name)
+                except (TypeError, AttributeError) as err:
+                    raise TypeError(
+                        f"Pandas dtype {obj} cannot be instantiated: {err}\n"
+                        "Usage Tip: Use an instance or a string representation."
+                    ) from None
+            else:
+                # let pandas transform any acceptable value
+                # into a numpy or pandas dtype.
+                np_or_pd_dtype = pd.api.types.pandas_dtype(obj)
+                if isinstance(np_or_pd_dtype, np.dtype):
+                    np_or_pd_dtype = np_or_pd_dtype.type
+
+            try:
+                return Engine.dtype(cls, np_or_pd_dtype)
+            except TypeError:
+                return PandasDataType(np_or_pd_dtype)
+
+
+################################################################################
+# boolean
+################################################################################
+
+
+PandasEngine.register_dtype(
+    NumpyBool,
+    equivalents=["bool", bool, np.bool_, Bool, Bool()],
+)
+
+
+@PandasEngine.register_dtype(
+    equivalents=["boolean", pd.BooleanDtype, pd.BooleanDtype()],
+)
+@immutable
+class PandasBool(DisableInitMixin, PandasDataType, Bool):
+    type = pd.BooleanDtype()
+
+
+BOOL = PandasBool
+
+################################################################################
+# number
+################################################################################
+
+
+def _register_numpy_numbers(
+    builtin_name: str, pandera_name: str, sizes: List[int]
+) -> None:
+    """Return a dict of equivalent builtin, numpy, pandera dtypes
+    indexed by size in bits."""
+
+    builtin_type = getattr(builtins, builtin_name, None)  # uint doesn't exist
+    default_pd_dtype = pd.Series([1], dtype=builtin_name).dtype
+
+    for bit_width in sizes:
+        # e.g.: numpy.int64
+        np_dtype = getattr(np, f"{builtin_name}{bit_width}")
+
+        equivalents = set(
+            (
+                np_dtype,
+                getattr(np, f"{builtin_name}{bit_width}"),
+                # e.g.: pandera.dtypes.Int64
+                getattr(pandera.dtypes_, f"{pandera_name}{bit_width}"),
+                getattr(pandera.dtypes_, f"{pandera_name}{bit_width}")(),
+            )
+        )
+
+        if np_dtype == default_pd_dtype:
+            equivalents |= set(
+                (
+                    # e.g: numpy.int_
+                    default_pd_dtype,
+                    # e.g: pandera.dtypes.Int
+                    getattr(pandera.dtypes_, pandera_name),
+                    getattr(pandera.dtypes_, pandera_name)(),
+                )
+            )
+            if builtin_type:
+                equivalents.add(builtin_type)
+
+            # results from pd.api.types.infer_dtype
+            if builtin_type is float:
+                equivalents.add("floating")
+                equivalents.add("mixed-integer-float")
+            elif builtin_type is int:
+                equivalents.add("integer")
+
+        numpy_data_type = getattr(
+            pandera.engines.numpy_engine, f"Numpy{pandera_name}{bit_width}"
+        )
+        PandasEngine.register_dtype(numpy_data_type, equivalents=equivalents)
+
+
+################################################################################
+## signed integer
+################################################################################
+
+_register_numpy_numbers(
+    builtin_name="int",
+    pandera_name="Int",
+    sizes=[64, 32, 16, 8],
+)
+
+
+@PandasEngine.register_dtype(equivalents=[pd.Int64Dtype, pd.Int64Dtype()])
+@immutable
+class PandasInt64(DisableInitMixin, PandasDataType, Int):
+    type = pd.Int64Dtype()
+    bit_width: int = 64
+
+
+INT64 = PandasInt64
+
+
+@PandasEngine.register_dtype(equivalents=[pd.Int32Dtype, pd.Int32Dtype()])
+@immutable
+class PandasInt32(PandasInt64):
+    type = pd.Int32Dtype()
+    bit_width: int = 32
+
+
+INT32 = PandasInt32
+
+
+@PandasEngine.register_dtype(equivalents=[pd.Int16Dtype, pd.Int16Dtype()])
+@immutable
+class PandasInt16(PandasInt32):
+    type = pd.Int16Dtype()
+    bit_width: int = 16
+
+
+INT16 = PandasInt16
+
+
+@PandasEngine.register_dtype(equivalents=[pd.Int8Dtype, pd.Int8Dtype()])
+@immutable
+class PandasInt8(PandasInt16):
+    type = pd.Int8Dtype()
+    bit_width: int = 8
+
+
+INT8 = PandasInt8
+
+################################################################################
+## unsigned integer
+################################################################################
+
+_register_numpy_numbers(
+    builtin_name="uint",
+    pandera_name="UInt",
+    sizes=[64, 32, 16, 8],
+)
+
+
+@PandasEngine.register_dtype(equivalents=[pd.UInt64Dtype, pd.UInt64Dtype()])
+@immutable
+class PandasUInt64(DisableInitMixin, PandasDataType, UInt):
+    type = pd.UInt64Dtype()
+    bit_width: int = 64
+
+
+@PandasEngine.register_dtype(equivalents=[pd.UInt32Dtype, pd.UInt32Dtype()])
+@immutable
+class PandasUInt32(PandasUInt64):
+    type = pd.UInt32Dtype()
+    bit_width: int = 32
+
+
+@PandasEngine.register_dtype(equivalents=[pd.UInt16Dtype, pd.UInt16Dtype()])
+@immutable
+class PandasUInt16(PandasUInt32):
+    type = pd.UInt16Dtype()
+    bit_width: int = 16
+
+
+@PandasEngine.register_dtype(equivalents=[pd.UInt8Dtype, pd.UInt8Dtype()])
+@immutable
+class PandasUInt8(PandasUInt16):
+    type = pd.UInt8Dtype()
+    bit_width: int = 8
+
+
+UINT64 = PandasUInt64
+UINT32 = PandasUInt32
+UINT16 = PandasUInt16
+UINT8 = PandasUInt8
+
+# ################################################################################
+# ## float
+# ################################################################################
+
+_register_numpy_numbers(
+    builtin_name="float",
+    pandera_name="Float",
+    sizes=[128, 64, 32, 16],
+)
+
+# ################################################################################
+# ## complex
+# ################################################################################
+
+_register_numpy_numbers(
+    builtin_name="complex",
+    pandera_name="Complex",
+    sizes=[128, 64],
+)
+
+# ################################################################################
+# # nominal
+# ################################################################################
+
+
+@PandasEngine.register_dtype(
+    equivalents=[
+        "category",
+        "categorical",
+        Category,
+        pd.CategoricalDtype,
+    ]
+)
+@immutable(init=True)
+class PandasCategorical(PandasDataType, Category):
+    type: pd.CategoricalDtype = field(default=None, init=False)
+
+    def __post_init__(self):
+        Category.__post_init__(self)
+        object.__setattr__(
+            self,
+            "type",
+            pd.CategoricalDtype(self.categories, self.ordered),
+        )
+
+    @classmethod
+    def from_parametrized_dtype(cls, cat: Union[Category, pd.CategoricalDtype]):
+        return cls(categories=cat.categories, ordered=cat.ordered)
+
+
+@PandasEngine.register_dtype(
+    equivalents=["string", pd.StringDtype, pd.StringDtype()]
+)
+@immutable
+class PandasString(DisableInitMixin, PandasDataType, String):
+    type = pd.StringDtype()
+
+
+STRING = PandasString
+
+
+@PandasEngine.register_dtype(
+    equivalents=["str", str, String, String(), np.str_]
+)
+@immutable
+class PandasNpString(NumpyString):
+    """Specializes NumpyString.coerce to handle pd.NA values."""
+
+    def coerce(self, obj: PandasObject) -> np.ndarray:
+        # Convert to object first to avoid
+        # TypeError: object cannot be converted to an IntegerDtype
+        obj = obj.astype(object)
+        return obj.where(obj.isna(), obj.astype(str))
+
+    def check(self, datatype: "DataType") -> bool:
+        return isinstance(datatype, (NumpyObject, type(self)))
+
+
+PandasEngine.register_dtype(
+    NumpyObject,
+    equivalents=[
+        "object",
+        "O",
+        "bytes",
+        "decimal",
+        "mixed-integer",
+        "mixed",
+        object,
+        np.object_,
+    ],
+)
+
+# ################################################################################
+# # time
+# ################################################################################
+@PandasEngine.register_dtype(
+    equivalents=[
+        "time",
+        "datetime",
+        "datetime64",
+        datetime.date,
+        datetime.datetime,
+        np.datetime64,
+        Timestamp,
+        Timestamp(),
+        pd.Timestamp,
+    ]
+)
+@immutable(init=True)
+class PandasDateTime(PandasDataType, Timestamp):
+    type: Union[np.datetime64, pd.DatetimeTZDtype] = field(
+        default=None, init=False
+    )
+    unit: str = "ns"
+    tz: datetime.tzinfo = None
+    to_datetime_kwargs: Dict[str, Any] = field(
+        default=None, compare=False, repr=False
+    )
+
+    def __post_init__(self):
+        if self.tz is None:
+            type_ = np.dtype("datetime64")
+        else:
+            type_ = pd.DatetimeTZDtype(self.unit, self.tz)
+            # DatetimeTZDtype converted tz to tzinfo for us
+            object.__setattr__(self, "tz", type_.tz)
+
+        object.__setattr__(self, "type", type_)
+
+    def coerce(self, obj: PandasObject) -> PandasObject:
+        kwargs = self.to_datetime_kwargs or {}
+
+        def _to_datetime(col: pd.Series) -> pd.Series:
+            return pd.to_datetime(col, **kwargs).astype(self.type)
+
+        if isinstance(obj, pd.DataFrame):
+            # pd.to_datetime transforms a df input into a series.
+            # We actually want to coerce every columns.
+            return obj.transform(_to_datetime)
+        return _to_datetime(obj)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pd_dtype: pd.DatetimeTZDtype):
+        return cls(unit=pd_dtype.unit, tz=pd_dtype.tz)
+
+    def __str__(self) -> str:
+        if self.type == np.dtype("datetime64"):
+            return "datetime64[ns]"
+        return str(self.type)
+
+
+@PandasEngine.register_dtype(
+    equivalents=[
+        "time",
+        "datetime",
+        "datetime64",
+        datetime.datetime,
+        np.datetime64,
+        Timestamp,
+        Timestamp(),
+        pd.Timestamp,
+    ]
+)
+@immutable(init=True)
+class PandasDateTime(PandasDataType, Timestamp):
+    type: Union[np.datetime64, pd.DatetimeTZDtype] = field(
+        default=None, init=False
+    )
+    unit: str = "ns"
+    tz: datetime.tzinfo = None
+    to_datetime_kwargs: Dict[str, Any] = field(
+        default=None, compare=False, repr=False
+    )
+
+    def __post_init__(self):
+        if self.tz is None:
+            type_ = np.dtype("datetime64")
+        else:
+            type_ = pd.DatetimeTZDtype(self.unit, self.tz)
+            # DatetimeTZDtype converted tz to tzinfo for us
+            object.__setattr__(self, "tz", type_.tz)
+
+        object.__setattr__(self, "type", type_)
+
+    def coerce(self, obj: PandasObject) -> PandasObject:
+        kwargs = self.to_datetime_kwargs or {}
+
+        def _to_datetime(col: pd.Series) -> pd.Series:
+            return pd.to_datetime(col, **kwargs).astype(self.type)
+
+        if isinstance(obj, pd.DataFrame):
+            # pd.to_datetime transforms a df input into a series.
+            # We actually want to coerce every columns.
+            return obj.transform(_to_datetime)
+        return _to_datetime(obj)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pd_dtype: pd.DatetimeTZDtype):
+        return cls(unit=pd_dtype.unit, tz=pd_dtype.tz)
+
+    def __str__(self) -> str:
+        if self.type == np.dtype("datetime64"):
+            return "datetime64[ns]"
+        return str(self.type)
+
+
+PandasEngine.register_dtype(
+    Timedelta,
+    equivalents=[
+        "timedelta",
+        "timedelta64",
+        datetime.timedelta,
+        np.timedelta64,
+        pd.Timedelta,
+        Timedelta,
+        Timedelta(),
+    ],
+)
+
+
+@PandasEngine.register_dtype
+@immutable(init=True)
+class PandasPeriod(PandasDataType):
+    type: pd.PeriodDtype = field(default=None, init=False)
+    freq: Union[str, pd.tseries.offsets.DateOffset]
+
+    def __post_init__(self):
+        object.__setattr__(self, "type", pd.PeriodDtype(freq=self.freq))
+
+    @classmethod
+    def from_parametrized_dtype(cls, pd_dtype: pd.PeriodDtype):
+        return cls(freq=pd_dtype.freq)
+
+
+# ################################################################################
+# # misc
+# ################################################################################
+
+
+@PandasEngine.register_dtype(equivalents=[pd.SparseDtype])
+@immutable(init=True)
+class PandasSparse(PandasDataType):
+    type: pd.SparseDtype = field(default=None, init=False)
+    dtype: Union[str, PandasExtensionType, np.dtype, "type"] = np.float_
+    fill_value: Any = np.nan
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "type",
+            pd.SparseDtype(dtype=self.dtype, fill_value=self.fill_value),
+        )
+
+    @classmethod
+    def from_parametrized_dtype(cls, pd_dtype: pd.SparseDtype):
+        return cls(dtype=pd_dtype.subtype, fill_value=pd_dtype.fill_value)
+
+
+@PandasEngine.register_dtype
+@immutable(init=True)
+class PandasInterval(PandasDataType):
+    type: pd.IntervalDtype = field(default=None, init=False)
+    subtype: Union[str, np.dtype]
+
+    def __post_init__(self):
+        object.__setattr__(self, "type", pd.IntervalDtype(subtype=self.subtype))
+
+    @classmethod
+    def from_parametrized_dtype(cls, pd_dtype: pd.IntervalDtype):
+        return cls(subtype=pd_dtype.subtype)

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -4,21 +4,27 @@ import warnings
 from collections.abc import Mapping
 from functools import partial
 from pathlib import Path
+from typing import Dict, Optional, Union
 
 import pandas as pd
 
 import pandera.errors
 
+from .checks import Check
 from .dtypes import PandasDtype
+from .schema_components import Column
 from .schema_statistics import get_dataframe_schema_statistics
+from .schemas import DataFrameSchema
 
 try:
     import black
     import yaml
+    from frictionless import Schema as FrictionlessSchema
 except ImportError as exc:  # pragma: no cover
     raise ImportError(
-        'IO and formatting requires "pyyaml" and "black" to be installed. \n'
-        "You can install pandera together with the IO dependencies with: \n"
+        "IO and formatting requires 'pyyaml', 'black' and 'frictionless'"
+        "to be installed.\n"
+        "You can install pandera together with the IO dependencies with:\n"
         "pip install pandera[io]\n"
     ) from exc
 
@@ -156,8 +162,6 @@ def _deserialize_check_stats(check, serialized_check_stats, pandas_dtype=None):
 
 
 def _deserialize_component_stats(serialized_component_stats):
-    from pandera import Check  # pylint: disable=import-outside-toplevel
-
     pandas_dtype = serialized_component_stats.get("pandas_dtype")
     if pandas_dtype:
         pandas_dtype = PandasDtype.from_str_alias(pandas_dtype)
@@ -190,7 +194,7 @@ def _deserialize_component_stats(serialized_component_stats):
 
 def _deserialize_schema(serialized_schema):
     # pylint: disable=import-outside-toplevel
-    from pandera import Check, Column, DataFrameSchema, Index, MultiIndex
+    from pandera import Index, MultiIndex
 
     # GH#475
     serialized_schema = serialized_schema if serialized_schema else {}
@@ -323,8 +327,7 @@ def _format_checks(checks_dict):
             )
         else:
             args = ", ".join(
-                "{}={}".format(k, v.__repr__())
-                for k, v in check_kwargs.items()
+                f"{k}={v.__repr__()}" for k, v in check_kwargs.items()
             )
             checks.append(f"Check.{check_name}({args})")
     return f"[{', '.join(checks)}]"
@@ -395,7 +398,7 @@ def to_script(dataframe_schema, path_or_buf=None):
         else _format_index(statistics["index"])
     )
 
-    column_str = ", ".join("'{}': {}".format(k, v) for k, v in columns.items())
+    column_str = ", ".join(f"'{k}': {v}" for k, v in columns.items())
 
     script = SCRIPT_TEMPLATE.format(
         columns=column_str,
@@ -418,3 +421,206 @@ def to_script(dataframe_schema, path_or_buf=None):
 
     with Path(path_or_buf).open("w") as f:
         f.write(formatted_script)
+
+
+class FrictionlessFieldParser:
+    """Parses frictionless data schema field specifications so we can convert
+    them to an equivalent :class:`pandera.schema_components.Column` schema.
+
+    For this implementation, we are using field names, constraints and types
+    but leaving other frictionless parameters out (e.g. foreign keys, type
+    formats, titles, descriptions).
+
+    :param field: a field object from a frictionless schema.
+    :primary_keys: the primary keys from a frictionless schema. These are used
+        to ensure primary key fields are treated properly - no duplicates,
+        no missing values etc.
+    """
+
+    def __init__(self, field, primary_keys) -> None:
+        self.constraints = field.constraints or {}
+        self.name = field.name
+        self.is_a_primary_key = self.name in primary_keys
+        self.type = field.get("type", "string")
+
+    @property
+    def pandas_dtype(self) -> str:
+        """Determine what type of field this is, so we can feed that into
+        :class:`~pandera.dtypes.PandasDtype`. If no type is specified in the
+        frictionless schema, we default to string values.
+
+        :returns: the pandas-compatible representation of this field type as a
+            string.
+        """
+        types = {
+            "string": "string",
+            "number": "float",
+            "integer": "int",
+            "boolean": "bool",
+            "object": "object",
+            "array": "object",
+            "date": "string",
+            "time": "string",
+            "datetime": "datetime64[ns]",
+            "year": "int",
+            "yearmonth": "string",
+            "duration": "timedelta64[ns]",
+            "geopoint": "object",
+            "geojson": "object",
+            "any": "string",
+        }
+        return (
+            "category"
+            if self.constraints.get("enum", None)
+            else types[self.type]
+        )
+
+    @property
+    def checks(self) -> Optional[Dict]:
+        """Convert a set of frictionless schema field constraints into checks.
+
+        This parses the standard set of frictionless constraints which can be
+        found
+        `here <https://specs.frictionlessdata.io/table-schema/#constraints>`_
+        and maps them into the equivalent pandera checks.
+
+        :returns: a dictionary of pandera :class:`pandera.checks.Check`
+            objects which capture the standard constraint logic of a
+            frictionless schema field.
+        """
+        if not self.constraints:
+            return None
+        constraints = self.constraints.copy()
+        checks = {}
+
+        def _combine_constraints(check_name, min_constraint, max_constraint):
+            """Catches bounded constraints where we need to combine a min and max
+            pair of constraints into a single check."""
+            if min_constraint in constraints and max_constraint in constraints:
+                checks[check_name] = {
+                    "min_value": constraints.pop(min_constraint),
+                    "max_value": constraints.pop(max_constraint),
+                }
+
+        _combine_constraints("in_range", "minimum", "maximum")
+        _combine_constraints("str_length", "minLength", "maxLength")
+
+        for constraint_type, constraint_value in constraints.items():
+            if constraint_type == "maximum":
+                checks["less_than_or_equal_to"] = constraint_value
+            elif constraint_type == "minimum":
+                checks["greater_than_or_equal_to"] = constraint_value
+            elif constraint_type == "maxLength":
+                checks["str_length"] = {
+                    "min_value": None,
+                    "max_value": constraint_value,
+                }
+            elif constraint_type == "minLength":
+                checks["str_length"] = {
+                    "min_value": constraint_value,
+                    "max_value": None,
+                }
+            elif constraint_type == "pattern":
+                checks["str_matches"] = rf"^{constraint_value}$"
+            elif constraint_type == "enum":
+                checks["isin"] = constraint_value
+        return checks or None
+
+    @property
+    def nullable(self) -> bool:
+        """Determine whether this field can contain missing values."""
+        if self.is_a_primary_key:
+            return False
+        return not self.constraints.get("required", False)
+
+    @property
+    def allow_duplicates(self) -> bool:
+        """Determine whether this field can contain duplicate values."""
+        if self.is_a_primary_key:
+            return False
+        return not self.constraints.get("unique", False)
+
+    @property
+    def coerce(self) -> bool:
+        """Determine whether values within this field should be coerced."""
+        return True
+
+    @property
+    def required(self) -> bool:
+        """Determine whether this field must exist within the data."""
+        return True
+
+    @property
+    def regex(self) -> bool:
+        """Determine whether this field name should be used for regex matches."""
+        return False
+
+    def to_pandera_column(self) -> Dict:
+        """Export this field to a column spec dictionary."""
+        return {
+            "allow_duplicates": self.allow_duplicates,
+            "checks": self.checks,
+            "coerce": self.coerce,
+            "nullable": self.nullable,
+            "pandas_dtype": self.pandas_dtype,
+            "required": self.required,
+            "name": self.name,
+            "regex": self.regex,
+        }
+
+
+def from_frictionless_schema(
+    schema: Union[str, Path, Dict, FrictionlessSchema]
+) -> DataFrameSchema:
+    """Create a :class:`~pandera.schemas.DataFrameSchema` from a frictionless
+    json/yaml schema file on disk, or a frictionless schema already loaded
+    into memory.
+
+    Each field from the frictionless schema will be converted to a pandera
+    column specification using :class:`~pandera.io.FrictionlessFieldParser`
+    to map field characteristics to pandera column specifications.
+
+    :param schema: the frictionless schema object (or a
+        string/Path to the location on disk of a schema specification) to
+        parse.
+    :returns: dataframe schema with frictionless field specs converted to
+        pandera column checks and constraints for use as normal.
+
+    :example:
+
+    >>> from pandera.io import from_frictionless_schema
+    >>>
+    >>> FRICTIONLESS_SCHEMA = {
+    ...     "fields": [
+    ...         {
+    ...             "name": "column_1",
+    ...             "type": "integer",
+    ...             "constraints": {"minimum": 10, "maximum": 99}
+    ...         }
+    ...     ],
+    ...     "primaryKey": "column_1"
+    ... }
+    >>> schema = from_frictionless_schema(FRICTIONLESS_SCHEMA)
+    >>> schema.columns["column_1"].checks
+    [<Check in_range: in_range(10, 99)>]
+    >>> schema.columns["column_1"].required
+    True
+    >>> schema.columns["column_1"].allow_duplicates
+    False
+    """
+    if not isinstance(schema, FrictionlessSchema):
+        schema = FrictionlessSchema(schema)
+
+    assembled_schema = {
+        "columns": {
+            field.name: FrictionlessFieldParser(
+                field, schema.primary_key
+            ).to_pandera_column()
+            for field in schema.fields
+        },
+        "index": None,
+        "checks": None,
+        "coerce": True,
+        "strict": True,
+    }
+    return _deserialize_schema(assembled_schema)

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -337,20 +337,20 @@ class Index(SeriesSchemaBase):
     ) -> Union[pd.DataFrame, pd.Series]:
         """Validate DataFrameSchema or SeriesSchema Index.
 
-            :check_obj: pandas DataFrame of Series containing index to validate.
-            :param head: validate the first n rows. Rows overlapping with `tail` or
-                `sample` are de-duplicated.
-            :param tail: validate the last n rows. Rows overlapping with `head` or
-                `sample` are de-duplicated.
-            :param sample: validate a random sample of n rows. Rows overlapping
-                with `head` or `tail` are de-duplicated.
+        :check_obj: pandas DataFrame of Series containing index to validate.
+        :param head: validate the first n rows. Rows overlapping with `tail` or
+            `sample` are de-duplicated.
+        :param tail: validate the last n rows. Rows overlapping with `head` or
+            `sample` are de-duplicated.
+        :param sample: validate a random sample of n rows. Rows overlapping
+            with `head` or `tail` are de-duplicated.
         :param random_state: random seed for the ``sample`` argument.
-            :param lazy: if True, lazily evaluates dataframe against all validation
-                checks and raises a ``SchemaErrors``. Otherwise, raise
-                ``SchemaError`` as soon as one occurs.
-            :param inplace: if True, applies coercion to the object of validation,
-                otherwise creates a copy of the data.
-            :returns: validated DataFrame or Series.
+        :param lazy: if True, lazily evaluates dataframe against all validation
+            checks and raises a ``SchemaErrors``. Otherwise, raise
+            ``SchemaError`` as soon as one occurs.
+        :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
+        :returns: validated DataFrame or Series.
         """
         if self.coerce:
             check_obj.index = self.coerce_dtype(check_obj.index)

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -554,7 +554,9 @@ class MultiIndex(DataFrameSchema):
                     try:
                         index_array = index.coerce_dtype(index_array)
                     except errors.SchemaError as err:
-                        error_handler.collect_error("dtype_coercion_error", err)
+                        error_handler.collect_error(
+                            "dtype_coercion_error", err
+                        )
                 coerced_multi_index[index_level] = index_array
 
         if error_handler.collected_errors:

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -89,11 +89,6 @@ class Column(SeriesSchemaBase):
         self._name = name
         self._regex = regex
 
-        if coerce and self._dtype is None:
-            raise errors.SchemaInitError(
-                "Must specify dtype if coercing a Column's type"
-            )
-
     @property
     def regex(self) -> bool:
         """True if ``name`` attribute should be treated as a regex pattern."""
@@ -559,9 +554,7 @@ class MultiIndex(DataFrameSchema):
                     try:
                         index_array = index.coerce_dtype(index_array)
                     except errors.SchemaError as err:
-                        error_handler.collect_error(
-                            "dtype_coercion_error", err
-                        )
+                        error_handler.collect_error("dtype_coercion_error", err)
                 coerced_multi_index[index_level] = index_array
 
         if error_handler.collected_errors:

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -142,17 +142,6 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         self.columns = {} if columns is None else columns
 
-        if coerce:
-            missing_pandas_type = [
-                name for name, col in self.columns.items() if col.dtype is None
-            ]
-            if missing_pandas_type:
-                raise errors.SchemaInitError(
-                    "Must specify dtype in all Columns if coercing "
-                    "DataFrameSchema ; columns with missing pandas_type:"
-                    + ", ".join(missing_pandas_type)
-                )
-
         if transformer is not None:
             warnings.warn(
                 "The `transformers` argument has been deprecated and will no "
@@ -520,9 +509,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             ):
                 if lazy:
                     lazy_exclude_columns.append(colname)
-                msg = (
-                    f"column '{colname}' not in dataframe\n{check_obj.head()}"
-                )
+                msg = f"column '{colname}' not in dataframe\n{check_obj.head()}"
                 error_handler.collect_error(
                     "column_not_in_dataframe",
                     errors.SchemaError(
@@ -602,9 +589,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                 error_handler.collect_error("dataframe_check", err)
 
         if lazy and error_handler.collected_errors:
-            raise errors.SchemaErrors(
-                error_handler.collected_errors, check_obj
-            )
+            raise errors.SchemaErrors(error_handler.collected_errors, check_obj)
 
         assert all(check_results)
         return check_obj
@@ -1423,9 +1408,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             else Index(
                 dtype=new_index.columns[list(new_index.columns)[0]].dtype,
                 checks=new_index.columns[list(new_index.columns)[0]].checks,
-                nullable=new_index.columns[
-                    list(new_index.columns)[0]
-                ].nullable,
+                nullable=new_index.columns[list(new_index.columns)[0]].nullable,
                 allow_duplicates=new_index.columns[
                     list(new_index.columns)[0]
                 ].allow_duplicates,
@@ -1589,6 +1572,9 @@ class SeriesSchemaBase:
             (including time series).
         :returns: ``Series`` with coerced data type
         """
+        if self.dtype is None:
+            return obj
+
         try:
             return self.dtype.coerce(obj)
         except (ValueError, TypeError) as exc:
@@ -1723,9 +1709,7 @@ class SeriesSchemaBase:
                         self,
                         check_obj,
                         msg,
-                        failure_cases=reshape_failure_cases(
-                            series[duplicates]
-                        ),
+                        failure_cases=reshape_failure_cases(series[duplicates]),
                         check="no_duplicates",
                     ),
                 )
@@ -1782,9 +1766,7 @@ class SeriesSchemaBase:
                 )
 
         if lazy and error_handler.collected_errors:
-            raise errors.SchemaErrors(
-                error_handler.collected_errors, check_obj
-            )
+            raise errors.SchemaErrors(error_handler.collected_errors, check_obj)
 
         assert all(check_results)
         return check_obj
@@ -1985,9 +1967,7 @@ class SeriesSchema(SeriesSchemaBase):
                 )
 
         if error_handler.collected_errors:
-            raise errors.SchemaErrors(
-                error_handler.collected_errors, check_obj
-            )
+            raise errors.SchemaErrors(error_handler.collected_errors, check_obj)
 
         return check_obj
 
@@ -2053,9 +2033,7 @@ def _handle_check_results(
         if check_result.failure_cases is None:
             # encode scalar False values explicitly
             failure_cases = scalar_failure_case(check_result.check_passed)
-            error_msg = format_generic_error_message(
-                schema, check, check_index
-            )
+            error_msg = format_generic_error_message(schema, check, check_index)
         else:
             failure_cases = reshape_failure_cases(
                 check_result.failure_cases, check.ignore_na

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -233,7 +233,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         }
 
     @property
-    def dtypes(self) -> Dict[str, str]:
+    def dtypes(self) -> Dict[str, dtypes_.DataType]:
         """
         A pandas style dtypes dict where the keys are column names and values
         are pandas dtype for the column. Excludes columns where regex=True.

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -16,7 +16,7 @@ from . import constants, dtypes, errors
 from . import strategies as st
 from .checks import Check
 from .dtypes_ import DataType
-from .engines.pandas_engine import PandasEngine, PandasExtensionType
+from .engines import pandas_engine
 from .error_formatters import (
     format_generic_error_message,
     format_vectorized_error_message,
@@ -36,7 +36,7 @@ PandasDtypeInputTypes = Union[
     str,
     type,
     DataType,
-    PandasExtensionType,
+    pandas_engine.PandasExtensionType,
     np.dtype,
 ]
 
@@ -281,7 +281,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
     @dtype.setter
     def dtype(self, value: PandasDtypeInputTypes) -> None:
         """Set the pandas dtype property."""
-        self._dtype = PandasEngine.dtype(value) if value else None
+        self._dtype = pandas_engine.Engine.dtype(value) if value else None
 
     def _coerce_dtype(self, obj: pd.DataFrame) -> pd.DataFrame:
         if self.dtype is None:
@@ -1569,7 +1569,7 @@ class SeriesSchemaBase:
     @dtype.setter
     def dtype(self, value: PandasDtypeInputTypes) -> None:
         """Set the pandas dtype"""
-        self._dtype = PandasEngine.dtype(value) if value else None
+        self._dtype = pandas_engine.Engine.dtype(value) if value else None
 
     def coerce_dtype(self, obj: Union[pd.Series, pd.Index]) -> pd.Series:
         """Coerce type of a pd.Series by type specified in dtype.
@@ -1723,7 +1723,7 @@ class SeriesSchemaBase:
                 )
 
         if self._dtype is not None and (
-            not self._dtype.check(PandasEngine.dtype(series.dtype))
+            not self._dtype.check(pandas_engine.Engine.dtype(series.dtype))
         ):
             msg = (
                 f"expected series '{series.name}' to have type {self._dtype}, "

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -12,7 +12,9 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import numpy as np
 import pandas as pd
 
-from . import constants, dtypes, errors
+from pandera import dtypes_
+
+from . import constants, errors
 from . import strategies as st
 from .checks import Check
 from .dtypes_ import DataType
@@ -36,7 +38,7 @@ PandasDtypeInputTypes = Union[
     str,
     type,
     DataType,
-    pandas_engine.PandasExtensionType,
+    pd.core.dtypes.base.ExtensionDtype,
     np.dtype,
 ]
 
@@ -166,7 +168,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         self.index = index
         self.strict = strict
         self.name = name
-        self.dtype = dtype
+        self.dtype = dtype  # type: ignore
         self._coerce = coerce
         self._ordered = ordered
         self._validate_schema()
@@ -274,9 +276,9 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
     @property
     def dtype(
         self,
-    ) -> PandasDtypeInputTypes:
+    ) -> dtypes_.DataType:
         """Get the dtype property."""
-        return self._dtype
+        return self._dtype  # type: ignore
 
     @dtype.setter
     def dtype(self, value: PandasDtypeInputTypes) -> None:
@@ -1485,7 +1487,7 @@ class SeriesSchemaBase:
             checks = []
         if isinstance(checks, (Check, Hypothesis)):
             checks = [checks]
-        self.dtype = dtype
+        self.dtype = dtype  # type: ignore
         self._nullable = nullable
         self._allow_duplicates = allow_duplicates
         self._coerce = coerce
@@ -1562,9 +1564,9 @@ class SeriesSchemaBase:
     @property
     def dtype(
         self,
-    ) -> PandasDtypeInputTypes:
+    ) -> dtypes_.DataType:
         """Get the pandas dtype"""
-        return self._dtype
+        return self._dtype  # type: ignore
 
     @dtype.setter
     def dtype(self, value: PandasDtypeInputTypes) -> None:

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -509,7 +509,9 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             ):
                 if lazy:
                     lazy_exclude_columns.append(colname)
-                msg = f"column '{colname}' not in dataframe\n{check_obj.head()}"
+                msg = (
+                    f"column '{colname}' not in dataframe\n{check_obj.head()}"
+                )
                 error_handler.collect_error(
                     "column_not_in_dataframe",
                     errors.SchemaError(
@@ -589,7 +591,9 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                 error_handler.collect_error("dataframe_check", err)
 
         if lazy and error_handler.collected_errors:
-            raise errors.SchemaErrors(error_handler.collected_errors, check_obj)
+            raise errors.SchemaErrors(
+                error_handler.collected_errors, check_obj
+            )
 
         assert all(check_results)
         return check_obj
@@ -1408,7 +1412,9 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             else Index(
                 dtype=new_index.columns[list(new_index.columns)[0]].dtype,
                 checks=new_index.columns[list(new_index.columns)[0]].checks,
-                nullable=new_index.columns[list(new_index.columns)[0]].nullable,
+                nullable=new_index.columns[
+                    list(new_index.columns)[0]
+                ].nullable,
                 allow_duplicates=new_index.columns[
                     list(new_index.columns)[0]
                 ].allow_duplicates,
@@ -1709,7 +1715,9 @@ class SeriesSchemaBase:
                         self,
                         check_obj,
                         msg,
-                        failure_cases=reshape_failure_cases(series[duplicates]),
+                        failure_cases=reshape_failure_cases(
+                            series[duplicates]
+                        ),
                         check="no_duplicates",
                     ),
                 )
@@ -1766,7 +1774,9 @@ class SeriesSchemaBase:
                 )
 
         if lazy and error_handler.collected_errors:
-            raise errors.SchemaErrors(error_handler.collected_errors, check_obj)
+            raise errors.SchemaErrors(
+                error_handler.collected_errors, check_obj
+            )
 
         assert all(check_results)
         return check_obj
@@ -1967,7 +1977,9 @@ class SeriesSchema(SeriesSchemaBase):
                 )
 
         if error_handler.collected_errors:
-            raise errors.SchemaErrors(error_handler.collected_errors, check_obj)
+            raise errors.SchemaErrors(
+                error_handler.collected_errors, check_obj
+            )
 
         return check_obj
 
@@ -2033,7 +2045,9 @@ def _handle_check_results(
         if check_result.failure_cases is None:
             # encode scalar False values explicitly
             failure_cases = scalar_failure_case(check_result.check_passed)
-            error_msg = format_generic_error_message(schema, check, check_index)
+            error_msg = format_generic_error_message(
+                schema, check, check_index
+            )
         else:
             failure_cases = reshape_failure_cases(
                 check_result.failure_cases, check.ignore_na

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -9,22 +9,74 @@ import typing_inspect
 from . import dtypes_
 from .engines import numpy_engine, pandas_engine
 
-try:  # python 3.8+
-    from typing import Literal  # type: ignore
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
-
-
 LEGACY_TYPING = sys.version_info[:2] < (3, 7)
+
+Bool = dtypes_.Bool  #: ``"bool"`` numpy dtype
+DateTime = dtypes_.DateTime  #: ``"datetime64[ns]"`` numpy dtype
+Timedelta = dtypes_.Timedelta  #: ``"timedelta64[ns]"`` numpy dtype
+Category = dtypes_.Category  #: pandas ``"categorical"`` datatype
+Float = dtypes_.Float  #: ``"float"`` numpy dtype
+Float16 = dtypes_.Float16  #: ``"float16"`` numpy dtype
+Float32 = dtypes_.Float32  #: ``"float32"`` numpy dtype
+Float64 = dtypes_.Float64  #: ``"float64"`` numpy dtype
+Int = dtypes_.Int  #: ``"int"`` numpy dtype
+Int8 = dtypes_.Int8  #: ``"int8"`` numpy dtype
+Int16 = dtypes_.Int16  #: ``"int16"`` numpy dtype
+Int32 = dtypes_.Int32  #: ``"int32"`` numpy dtype
+Int64 = dtypes_.Int64  #: ``"int64"`` numpy dtype
+UInt8 = dtypes_.UInt8  #: ``"uint8"`` numpy dtype
+UInt16 = dtypes_.UInt16  #: ``"uint16"`` numpy dtype
+UInt32 = dtypes_.UInt32  #: ``"uint32"`` numpy dtype
+UInt64 = dtypes_.UInt64  #: ``"uint64"`` numpy dtype
+INT8 = pandas_engine.INT8  #: ``"Int8"`` pandas dtype:: pandas 0.24.0+
+INT16 = pandas_engine.INT16  #: ``"Int16"`` pandas dtype: pandas 0.24.0+
+INT32 = pandas_engine.INT32  #: ``"Int32"`` pandas dtype: pandas 0.24.0+
+INT64 = pandas_engine.INT64  #: ``"Int64"`` pandas dtype: pandas 0.24.0+
+UINT8 = pandas_engine.UINT8  #: ``"UInt8"`` pandas dtype:: pandas 0.24.0+
+UINT16 = pandas_engine.UINT16  #: ``"UInt16"`` pandas dtype: pandas 0.24.0+
+UINT32 = pandas_engine.UINT32  #: ``"UInt32"`` pandas dtype: pandas 0.24.0+
+UINT64 = pandas_engine.UINT64  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
+Object = numpy_engine.Object  #: ``"object"`` numpy dtype
+String = dtypes_.String  #: ``"str"`` numpy dtype
+#: ``"string"`` pandas dtypes: pandas 1.0.0+. For <1.0.0, this enum will
+#: fall back on the str-as-object-array representation.
+STRING = pandas_engine.STRING  #: ``"str"`` numpy dtype
 
 GenericDtype = TypeVar(  # type: ignore
     "GenericDtype",
-    dtypes_.DataType,
-    pandas_engine.PandasExtensionType,
     bool,
     int,
     str,
     float,
+    pd.core.dtypes.base.ExtensionDtype,
+    Bool,
+    DateTime,
+    Timedelta,
+    Category,
+    Float,
+    Float16,
+    Float32,
+    Float64,
+    Int,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    INT8,
+    INT16,
+    INT32,
+    INT64,
+    UINT8,
+    UINT16,
+    UINT32,
+    UINT64,
+    Object,
+    String,
+    STRING,
     covariant=True,
 )
 Schema = TypeVar("Schema", bound="SchemaModel")  # type: ignore
@@ -120,37 +172,3 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         self.literal = typing_inspect.is_literal_type(self.arg)
         if self.literal:
             self.arg = typing_inspect.get_args(self.arg)[0]
-
-
-Bool = dtypes_.Bool  #: ``"bool"`` numpy dtype
-DateTime = dtypes_.DateTime  #: ``"datetime64[ns]"`` numpy dtype
-Timedelta = dtypes_.Timedelta  #: ``"timedelta64[ns]"`` numpy dtype
-Category = dtypes_.Category  #: pandas ``"categorical"`` datatype
-Float = dtypes_.Float  #: ``"float"`` numpy dtype
-Float16 = dtypes_.Float16  #: ``"float16"`` numpy dtype
-Float32 = dtypes_.Float32  #: ``"float32"`` numpy dtype
-Float64 = dtypes_.Float64  #: ``"float64"`` numpy dtype
-Int = dtypes_.Int  #: ``"int"`` numpy dtype
-Int8 = dtypes_.Int8  #: ``"int8"`` numpy dtype
-Int16 = dtypes_.Int16  #: ``"int16"`` numpy dtype
-Int32 = dtypes_.Int32  #: ``"int32"`` numpy dtype
-Int64 = dtypes_.Int64  #: ``"int64"`` numpy dtype
-UInt8 = dtypes_.UInt8  #: ``"uint8"`` numpy dtype
-UInt16 = dtypes_.UInt16  #: ``"uint16"`` numpy dtype
-UInt32 = dtypes_.UInt32  #: ``"uint32"`` numpy dtype
-UInt64 = dtypes_.UInt64  #: ``"uint64"`` numpy dtype
-INT8 = pandas_engine.INT8  #: ``"Int8"`` pandas dtype:: pandas 0.24.0+
-INT16 = pandas_engine.INT16  #: ``"Int16"`` pandas dtype: pandas 0.24.0+
-INT32 = pandas_engine.INT32  #: ``"Int32"`` pandas dtype: pandas 0.24.0+
-INT64 = pandas_engine.INT64  #: ``"Int64"`` pandas dtype: pandas 0.24.0+
-UINT8 = pandas_engine.UINT8  #: ``"UInt8"`` pandas dtype:: pandas 0.24.0+
-UINT16 = pandas_engine.UINT16  #: ``"UInt16"`` pandas dtype: pandas 0.24.0+
-UINT32 = pandas_engine.UINT32  #: ``"UInt32"`` pandas dtype: pandas 0.24.0+
-UINT64 = pandas_engine.UINT64  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
-Object = numpy_engine.Object  #: ``"object"`` numpy dtype
-
-String = dtypes_.String  #: ``"str"`` numpy dtype
-
-#: ``"string"`` pandas dtypes: pandas 1.0.0+. For <1.0.0, this enum will
-#: fall back on the str-as-object-array representation.
-STRING = pandas_engine.STRING  #: ``"str"`` numpy dtype

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Generic, Type, TypeVar
 import pandas as pd
 import typing_inspect
 
-from .dtypes_ import *
-from .engines.pandas_engine import *
+from . import dtypes_
+from .engines import numpy_engine, pandas_engine
 
 try:  # python 3.8+
     from typing import Literal  # type: ignore
@@ -19,8 +19,8 @@ LEGACY_TYPING = sys.version_info[:2] < (3, 7)
 
 GenericDtype = TypeVar(  # type: ignore
     "GenericDtype",
-    DataType,
-    PandasExtensionType,
+    dtypes_.DataType,
+    pandas_engine.PandasExtensionType,
     bool,
     int,
     str,
@@ -122,35 +122,35 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
             self.arg = typing_inspect.get_args(self.arg)[0]
 
 
-Bool = Bool  #: ``"bool"`` numpy dtype
-DateTime = DateTime  #: ``"datetime64[ns]"`` numpy dtype
-Timedelta = Timedelta  #: ``"timedelta64[ns]"`` numpy dtype
-Category = Category  #: pandas ``"categorical"`` datatype
-Float = Float  #: ``"float"`` numpy dtype
-Float16 = Float16  #: ``"float16"`` numpy dtype
-Float32 = Float32  #: ``"float32"`` numpy dtype
-Float64 = Float64  #: ``"float64"`` numpy dtype
-Int = Int  #: ``"int"`` numpy dtype
-Int8 = Int8  #: ``"int8"`` numpy dtype
-Int16 = Int16  #: ``"int16"`` numpy dtype
-Int32 = Int32  #: ``"int32"`` numpy dtype
-Int64 = Int64  #: ``"int64"`` numpy dtype
-UInt8 = UInt8  #: ``"uint8"`` numpy dtype
-UInt16 = UInt16  #: ``"uint16"`` numpy dtype
-UInt32 = UInt32  #: ``"uint32"`` numpy dtype
-UInt64 = UInt64  #: ``"uint64"`` numpy dtype
-INT8 = INT8  #: ``"Int8"`` pandas dtype:: pandas 0.24.0+
-INT16 = INT16  #: ``"Int16"`` pandas dtype: pandas 0.24.0+
-INT32 = INT32  #: ``"Int32"`` pandas dtype: pandas 0.24.0+
-INT64 = INT64  #: ``"Int64"`` pandas dtype: pandas 0.24.0+
-UINT8 = UINT8  #: ``"UInt8"`` pandas dtype:: pandas 0.24.0+
-UINT16 = UINT16  #: ``"UInt16"`` pandas dtype: pandas 0.24.0+
-UINT32 = UINT32  #: ``"UInt32"`` pandas dtype: pandas 0.24.0+
-UINT64 = UINT64  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
-Object = Object  #: ``"object"`` numpy dtype
+Bool = dtypes_.Bool  #: ``"bool"`` numpy dtype
+DateTime = dtypes_.DateTime  #: ``"datetime64[ns]"`` numpy dtype
+Timedelta = dtypes_.Timedelta  #: ``"timedelta64[ns]"`` numpy dtype
+Category = dtypes_.Category  #: pandas ``"categorical"`` datatype
+Float = dtypes_.Float  #: ``"float"`` numpy dtype
+Float16 = dtypes_.Float16  #: ``"float16"`` numpy dtype
+Float32 = dtypes_.Float32  #: ``"float32"`` numpy dtype
+Float64 = dtypes_.Float64  #: ``"float64"`` numpy dtype
+Int = dtypes_.Int  #: ``"int"`` numpy dtype
+Int8 = dtypes_.Int8  #: ``"int8"`` numpy dtype
+Int16 = dtypes_.Int16  #: ``"int16"`` numpy dtype
+Int32 = dtypes_.Int32  #: ``"int32"`` numpy dtype
+Int64 = dtypes_.Int64  #: ``"int64"`` numpy dtype
+UInt8 = dtypes_.UInt8  #: ``"uint8"`` numpy dtype
+UInt16 = dtypes_.UInt16  #: ``"uint16"`` numpy dtype
+UInt32 = dtypes_.UInt32  #: ``"uint32"`` numpy dtype
+UInt64 = dtypes_.UInt64  #: ``"uint64"`` numpy dtype
+INT8 = pandas_engine.INT8  #: ``"Int8"`` pandas dtype:: pandas 0.24.0+
+INT16 = pandas_engine.INT16  #: ``"Int16"`` pandas dtype: pandas 0.24.0+
+INT32 = pandas_engine.INT32  #: ``"Int32"`` pandas dtype: pandas 0.24.0+
+INT64 = pandas_engine.INT64  #: ``"Int64"`` pandas dtype: pandas 0.24.0+
+UINT8 = pandas_engine.UINT8  #: ``"UInt8"`` pandas dtype:: pandas 0.24.0+
+UINT16 = pandas_engine.UINT16  #: ``"UInt16"`` pandas dtype: pandas 0.24.0+
+UINT32 = pandas_engine.UINT32  #: ``"UInt32"`` pandas dtype: pandas 0.24.0+
+UINT64 = pandas_engine.UINT64  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
+Object = numpy_engine.Object  #: ``"object"`` numpy dtype
 
-String = String  #: ``"str"`` numpy dtype
+String = dtypes_.String  #: ``"str"`` numpy dtype
 
 #: ``"string"`` pandas dtypes: pandas 1.0.0+. For <1.0.0, this enum will
 #: fall back on the str-as-object-array representation.
-STRING = STRING  #: ``"str"`` numpy dtype
+STRING = pandas_engine.STRING  #: ``"str"`` numpy dtype

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Generic, Type, TypeVar
 import pandas as pd
 import typing_inspect
 
-from .dtypes import PandasDtype, PandasExtensionType
+from .dtypes_ import *
+from .engines.pandas_engine import *
 
 try:  # python 3.8+
     from typing import Literal  # type: ignore
@@ -18,40 +19,12 @@ LEGACY_TYPING = sys.version_info[:2] < (3, 7)
 
 GenericDtype = TypeVar(  # type: ignore
     "GenericDtype",
-    PandasDtype,
+    DataType,
     PandasExtensionType,
     bool,
     int,
     str,
     float,
-    Literal[PandasDtype.Bool],
-    Literal[PandasDtype.DateTime],
-    Literal[PandasDtype.Category],
-    Literal[PandasDtype.Float],
-    Literal[PandasDtype.Float16],
-    Literal[PandasDtype.Float32],
-    Literal[PandasDtype.Float64],
-    Literal[PandasDtype.Int],
-    Literal[PandasDtype.Int8],
-    Literal[PandasDtype.Int16],
-    Literal[PandasDtype.Int32],
-    Literal[PandasDtype.Int64],
-    Literal[PandasDtype.UInt8],
-    Literal[PandasDtype.UInt16],
-    Literal[PandasDtype.UInt32],
-    Literal[PandasDtype.UInt64],
-    Literal[PandasDtype.INT8],
-    Literal[PandasDtype.INT16],
-    Literal[PandasDtype.INT32],
-    Literal[PandasDtype.INT64],
-    Literal[PandasDtype.UINT8],
-    Literal[PandasDtype.UINT16],
-    Literal[PandasDtype.UINT32],
-    Literal[PandasDtype.UINT64],
-    Literal[PandasDtype.Object],
-    Literal[PandasDtype.String],
-    Literal[PandasDtype.STRING],
-    Literal[PandasDtype.Timedelta],
     covariant=True,
 )
 Schema = TypeVar("Schema", bound="SchemaModel")  # type: ignore
@@ -149,45 +122,35 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
             self.arg = typing_inspect.get_args(self.arg)[0]
 
 
-Bool = Literal[PandasDtype.Bool]  #: ``"bool"`` numpy dtype
-DateTime = Literal[PandasDtype.DateTime]  #: ``"datetime64[ns]"`` numpy dtype
-Timedelta = Literal[
-    PandasDtype.Timedelta
-]  #: ``"timedelta64[ns]"`` numpy dtype
-Category = Literal[PandasDtype.Category]  #: pandas ``"categorical"`` datatype
-Float = Literal[PandasDtype.Float]  #: ``"float"`` numpy dtype
-Float16 = Literal[PandasDtype.Float16]  #: ``"float16"`` numpy dtype
-Float32 = Literal[PandasDtype.Float32]  #: ``"float32"`` numpy dtype
-Float64 = Literal[PandasDtype.Float64]  #: ``"float64"`` numpy dtype
-Int = Literal[PandasDtype.Int]  #: ``"int"`` numpy dtype
-Int8 = Literal[PandasDtype.Int8]  #: ``"int8"`` numpy dtype
-Int16 = Literal[PandasDtype.Int16]  #: ``"int16"`` numpy dtype
-Int32 = Literal[PandasDtype.Int32]  #: ``"int32"`` numpy dtype
-Int64 = Literal[PandasDtype.Int64]  #: ``"int64"`` numpy dtype
-UInt8 = Literal[PandasDtype.UInt8]  #: ``"uint8"`` numpy dtype
-UInt16 = Literal[PandasDtype.UInt16]  #: ``"uint16"`` numpy dtype
-UInt32 = Literal[PandasDtype.UInt32]  #: ``"uint32"`` numpy dtype
-UInt64 = Literal[PandasDtype.UInt64]  #: ``"uint64"`` numpy dtype
-INT8 = Literal[PandasDtype.INT8]  #: ``"Int8"`` pandas dtype:: pandas 0.24.0+
-INT16 = Literal[PandasDtype.INT16]  #: ``"Int16"`` pandas dtype: pandas 0.24.0+
-INT32 = Literal[PandasDtype.INT32]  #: ``"Int32"`` pandas dtype: pandas 0.24.0+
-INT64 = Literal[PandasDtype.INT64]  #: ``"Int64"`` pandas dtype: pandas 0.24.0+
-UINT8 = Literal[
-    PandasDtype.UINT8
-]  #: ``"UInt8"`` pandas dtype:: pandas 0.24.0+
-UINT16 = Literal[
-    PandasDtype.UINT16
-]  #: ``"UInt16"`` pandas dtype: pandas 0.24.0+
-UINT32 = Literal[
-    PandasDtype.UINT32
-]  #: ``"UInt32"`` pandas dtype: pandas 0.24.0+
-UINT64 = Literal[
-    PandasDtype.UINT64
-]  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
-Object = Literal[PandasDtype.Object]  #: ``"object"`` numpy dtype
+Bool = Bool  #: ``"bool"`` numpy dtype
+DateTime = DateTime  #: ``"datetime64[ns]"`` numpy dtype
+Timedelta = Timedelta  #: ``"timedelta64[ns]"`` numpy dtype
+Category = Category  #: pandas ``"categorical"`` datatype
+Float = Float  #: ``"float"`` numpy dtype
+Float16 = Float16  #: ``"float16"`` numpy dtype
+Float32 = Float32  #: ``"float32"`` numpy dtype
+Float64 = Float64  #: ``"float64"`` numpy dtype
+Int = Int  #: ``"int"`` numpy dtype
+Int8 = Int8  #: ``"int8"`` numpy dtype
+Int16 = Int16  #: ``"int16"`` numpy dtype
+Int32 = Int32  #: ``"int32"`` numpy dtype
+Int64 = Int64  #: ``"int64"`` numpy dtype
+UInt8 = UInt8  #: ``"uint8"`` numpy dtype
+UInt16 = UInt16  #: ``"uint16"`` numpy dtype
+UInt32 = UInt32  #: ``"uint32"`` numpy dtype
+UInt64 = UInt64  #: ``"uint64"`` numpy dtype
+INT8 = INT8  #: ``"Int8"`` pandas dtype:: pandas 0.24.0+
+INT16 = INT16  #: ``"Int16"`` pandas dtype: pandas 0.24.0+
+INT32 = INT32  #: ``"Int32"`` pandas dtype: pandas 0.24.0+
+INT64 = INT64  #: ``"Int64"`` pandas dtype: pandas 0.24.0+
+UINT8 = UINT8  #: ``"UInt8"`` pandas dtype:: pandas 0.24.0+
+UINT16 = UINT16  #: ``"UInt16"`` pandas dtype: pandas 0.24.0+
+UINT32 = UINT32  #: ``"UInt32"`` pandas dtype: pandas 0.24.0+
+UINT64 = UINT64  #: ``"UInt64"`` pandas dtype: pandas 0.24.0+
+Object = Object  #: ``"object"`` numpy dtype
 
-String = Literal[PandasDtype.String]  #: ``"str"`` numpy dtype
+String = String  #: ``"str"`` numpy dtype
 
 #: ``"string"`` pandas dtypes: pandas 1.0.0+. For <1.0.0, this enum will
 #: fall back on the str-as-object-array representation.
-STRING = Literal[PandasDtype.STRING]  #: ``"str"`` numpy dtype
+STRING = STRING  #: ``"str"`` numpy dtype

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ wrapt
 pyyaml >=5.1
 typing_inspect >= 0.6.0
 typing_extensions >= 3.7.4.3
+frictionless
 black >= 20.8b1
 isort >= 5.7.0
 codecov

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("pandera/version.py") as fp:
 _extras_require = {
     "strategies": ["hypothesis >= 5.41.1"],
     "hypotheses": ["scipy"],
-    "io": ["pyyaml >= 5.1", "black"],
+    "io": ["pyyaml >= 5.1", "black", "frictionless"],
 }
 extras_require = {
     **_extras_require,

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -21,7 +21,7 @@ from pandera import (
     check_types,
     errors,
 )
-from pandera.engines.pandas_engine import PandasEngine
+from pandera.engines.pandas_engine import Engine
 from pandera.typing import DataFrame, Index, Series
 
 
@@ -642,7 +642,7 @@ def test_check_types_coerce():
 
     df = transform_in(pd.DataFrame({"a": ["1"]}, index=["1"]))
     expected = InSchema.to_schema().columns["a"].dtype
-    assert PandasEngine.dtype(df["a"].dtype) == expected
+    assert Engine.dtype(df["a"].dtype) == expected
 
     @check_types()
     def transform_out() -> DataFrame[OutSchema]:
@@ -651,4 +651,4 @@ def test_check_types_coerce():
 
     out_df = transform_out()
     expected = OutSchema.to_schema().columns["b"].dtype
-    assert PandasEngine.dtype(out_df["b"].dtype) == expected
+    assert Engine.dtype(out_df["b"].dtype) == expected

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -13,7 +13,6 @@ from pandera import (
     Field,
     Float,
     Int,
-    PandasDtype,
     SchemaModel,
     String,
     check_input,
@@ -22,6 +21,7 @@ from pandera import (
     check_types,
     errors,
 )
+from pandera.engines.pandas_engine import PandasEngine
 from pandera.typing import DataFrame, Index, Series
 
 
@@ -641,8 +641,8 @@ def test_check_types_coerce():
         return df
 
     df = transform_in(pd.DataFrame({"a": ["1"]}, index=["1"]))
-    expected = InSchema.to_schema().columns["a"].pandas_dtype
-    assert PandasDtype(str(df["a"].dtype)) == expected == PandasDtype("int")
+    expected = InSchema.to_schema().columns["a"].dtype
+    assert PandasEngine.dtype(df["a"].dtype) == expected
 
     @check_types()
     def transform_out() -> DataFrame[OutSchema]:
@@ -650,7 +650,5 @@ def test_check_types_coerce():
         return pd.DataFrame({"b": ["1"]})
 
     out_df = transform_out()
-    expected = OutSchema.to_schema().columns["b"].pandas_dtype
-    assert (
-        PandasDtype(str(out_df["b"].dtype)) == expected == PandasDtype("int")
-    )
+    expected = OutSchema.to_schema().columns["b"].dtype
+    assert PandasEngine.dtype(out_df["b"].dtype) == expected

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -1,607 +1,390 @@
 """Tests a variety of python and pandas dtypes, and tests some specific
 coercion examples."""
+import dataclasses
+import inspect
+from decimal import Decimal
+from typing import Any, List
 
+import hypothesis
 import numpy as np
 import pandas as pd
 import pytest
+from _pytest.mark.structures import ParameterSet
+from _pytest.python import Metafunc
+from hypothesis import strategies as st
+from hypothesis.strategies._internal.strategies import one_of
 from packaging import version
 
 import pandera as pa
-from pandera import (
-    Bool,
-    Category,
-    Check,
-    Column,
-    DataFrameSchema,
-    DateTime,
-    Float,
-    Int,
-    Object,
-    PandasDtype,
-    SeriesSchema,
-    String,
-    Timedelta,
-)
-from pandera.dtypes import (
-    _DEFAULT_NUMPY_FLOAT_TYPE,
-    _DEFAULT_NUMPY_INT_TYPE,
-    _DEFAULT_PANDAS_FLOAT_TYPE,
-    _DEFAULT_PANDAS_INT_TYPE,
-)
-from pandera.errors import SchemaError
+from pandera.dtypes_ import DataType
+from pandera.engines.pandas_engine import *
 
 PANDAS_VERSION = version.parse(pd.__version__)
 
-TESTABLE_DTYPES = [
-    (Bool, "bool"),
-    (DateTime, "datetime64[ns]"),
-    (Category, "category"),
-    (Float, Float.str_alias),
-    (Int, Int.str_alias),
-    (Object, "object"),
-    (String, String.str_alias),
-    (Timedelta, "timedelta64[ns]"),
-    ("bool", "bool"),
-    ("datetime64[ns]", "datetime64[ns]"),
-    ("category", "category"),
-    ("float64", "float64"),
+
+# List dtype classes and associated pandas alias,
+# except for parameterizable dtypes that should also list examples of instances.
+int_dtypes = {
+    int: "int",
+    pa.Int: "int64",
+    pa.Int8: "int8",
+    pa.Int16: "int16",
+    pa.Int32: "int32",
+    pa.Int64: "int64",
+    np.int8: "int8",
+    np.int16: "int16",
+    np.int32: "int32",
+    np.int64: "int64",
+}
+
+
+nullable_int_dtypes = {
+    PandasInt8: "Int8",
+    PandasInt16: "Int16",
+    PandasInt32: "Int32",
+    PandasInt64: "Int64",
+}
+
+uint_dtypes = {
+    pa.UInt: "uint64",
+    pa.UInt8: "uint8",
+    pa.UInt16: "uint16",
+    pa.UInt32: "uint32",
+    pa.UInt64: "uint64",
+    np.uint8: "uint8",
+    np.uint16: "uint16",
+    np.uint32: "uint32",
+    np.uint64: "uint64",
+}
+
+nullable_uint_dtypes = {
+    PandasUInt8: "UInt8",
+    PandasUInt16: "UInt16",
+    PandasUInt32: "UInt32",
+    PandasUInt64: "UInt64",
+}
+
+float_dtypes = {
+    float: "float",
+    pa.Float: "float64",
+    pa.Float16: "float16",
+    pa.Float32: "float32",
+    pa.Float64: "float64",
+    pa.Float128: "float128",
+    np.float16: "float16",
+    np.float32: "float32",
+    np.float64: "float64",
+    np.float128: "float128",
+}
+
+complex_dtypes = {
+    complex: "complex",
+    pa.Complex: "complex128",
+    pa.Complex64: "complex64",
+    pa.Complex128: "complex128",
+}
+
+boolean_dtypes = {bool: "bool", pa.Bool: "bool", np.bool_: "bool"}
+nullable_boolean_dtypes = {pd.BooleanDtype: "boolean", pa.BOOL: "boolean"}
+
+string_dtypes = {
+    str: "str",
+    pa.String: "str",
+    np.str_: "str",
+}
+nullable_string_dtypes = {pd.StringDtype: "string"}
+
+object_dtypes = {object: "object", np.object_: "object"}
+
+category_dtypes = {
+    pa.Category: "category",
+    pa.Category(["A", "B"], ordered=True): pd.CategoricalDtype(
+        ["A", "B"], ordered=True
+    ),
+    pd.CategoricalDtype(["A", "B"], ordered=True): pd.CategoricalDtype(
+        ["A", "B"], ordered=True
+    ),
+}
+
+timestamp_dtypes = {
+    datetime.datetime: "datetime64[ns]",
+    np.datetime64: "datetime64[ns]",
+    pa.Timestamp: "datetime64[ns]",
+    pd.DatetimeTZDtype(tz="CET"): "datetime64[ns, CET]",
+    PandasDateTime: "datetime64[ns]",
+    PandasDateTime(unit="ns", tz="CET"): "datetime64[ns, CET]",
+}
+
+timedelta_dtypes = {
+    datetime.timedelta: "timedelta64",
+    datetime.timedelta: "timedelta64",
+    np.timedelta64: "timedelta64",
+    pd.Timedelta: "timedelta64",
+    Timedelta: "timedelta64",
+}
+
+period_dtypes = {pd.PeriodDtype(freq="D"): "period[D]"}
+# Series.astype does not accept a string alias for SparseDtype.
+sparse_dtypes = {
+    pd.SparseDtype: pd.SparseDtype(),
+    pd.SparseDtype(np.float64): pd.SparseDtype(np.float64),
+}
+interval_dtypes = {pd.IntervalDtype(subtype=np.int64): "interval[int64]"}
+
+dtype_fixtures = [
+    (int_dtypes, [-1]),
+    (nullable_int_dtypes, [-1, None]),
+    (uint_dtypes, [1]),
+    (nullable_uint_dtypes, [1, None]),
+    (float_dtypes, [1.0]),
+    (complex_dtypes, [complex(1)]),
+    (boolean_dtypes, [True, False]),
+    (nullable_boolean_dtypes, [True, None]),
+    (string_dtypes, ["A", "B"]),
+    (object_dtypes, ["A", "B"]),
+    (nullable_string_dtypes, [1, 2, None]),
+    (category_dtypes, [1, 2, None]),
+    (
+        timestamp_dtypes,
+        pd.to_datetime(["2019/01/01", "2018/05/21"]).to_series(),
+    ),
+    (
+        period_dtypes,
+        pd.to_datetime(["2019/01/01", "2018/05/21"])
+        .to_period("D")
+        .to_series(),
+    ),
+    (sparse_dtypes, pd.Series([1, None], dtype=pd.SparseDtype(float))),
+    (interval_dtypes, pd.interval_range(-10.0, 10.0).to_series()),
 ]
 
 
-def test_default_numeric_dtypes():
-    """Test that default numeric dtypes int and float are consistent."""
-    assert str(pd.Series([1]).dtype) == _DEFAULT_PANDAS_INT_TYPE
-    assert pa.Int.str_alias == _DEFAULT_PANDAS_INT_TYPE
-    assert str(pd.Series([1], dtype=int).dtype) == _DEFAULT_NUMPY_INT_TYPE
-    assert str(pd.Series([1], dtype="int").dtype) == _DEFAULT_NUMPY_INT_TYPE
-
-    assert str(pd.Series([1.0]).dtype) == _DEFAULT_PANDAS_FLOAT_TYPE
-    assert pa.Float.str_alias == _DEFAULT_PANDAS_FLOAT_TYPE
-    assert (
-        str(pd.Series([1.0], dtype=float).dtype) == _DEFAULT_NUMPY_FLOAT_TYPE
-    )
-    assert (
-        str(pd.Series([1.0], dtype="float").dtype) == _DEFAULT_NUMPY_FLOAT_TYPE
-    )
-
-
-def test_numeric_dtypes():
-    """Test every numeric type can be validated properly by schema.validate"""
-    for dtype in [pa.Float, pa.Float16, pa.Float32, pa.Float64]:
-        assert all(
-            isinstance(
-                schema.validate(
-                    pd.DataFrame(
-                        {"col": [-123.1, -7654.321, 1.0, 1.1, 1199.51, 5.1]},
-                        dtype=dtype.str_alias,
-                    )
-                ),
-                pd.DataFrame,
-            )
-            for schema in [
-                DataFrameSchema({"col": Column(dtype, nullable=False)}),
-                DataFrameSchema(
-                    {"col": Column(dtype.str_alias, nullable=False)}
-                ),
-            ]
+def pretty_param(*values: Any, **kw: Any) -> ParameterSet:
+    """Return a pytest parameter with a human-readable id."""
+    id_ = kw.pop("id", None)
+    if not id_:
+        id_ = "-".join(
+            f"{val.__module__}.{val.__name__}"
+            if inspect.isclass(val)
+            else repr(val)
+            for val in values
         )
-
-    for dtype in [pa.Int, pa.Int8, pa.Int16, pa.Int32, pa.Int64]:
-        assert all(
-            isinstance(
-                schema.validate(
-                    pd.DataFrame(
-                        {"col": [-712, -4, -321, 0, 1, 777, 5, 123, 9000]},
-                        dtype=dtype.str_alias,
-                    )
-                ),
-                pd.DataFrame,
-            )
-            for schema in [
-                DataFrameSchema({"col": Column(dtype, nullable=False)}),
-                DataFrameSchema(
-                    {"col": Column(dtype.str_alias, nullable=False)}
-                ),
-            ]
-        )
-
-    for dtype in [pa.UInt8, pa.UInt16, pa.UInt32, pa.UInt64]:
-        assert all(
-            isinstance(
-                schema.validate(
-                    pd.DataFrame(
-                        {"col": [1, 777, 5, 123, 9000]}, dtype=dtype.str_alias
-                    )
-                ),
-                pd.DataFrame,
-            )
-            for schema in [
-                DataFrameSchema({"col": Column(dtype, nullable=False)}),
-                DataFrameSchema(
-                    {"col": Column(dtype.str_alias, nullable=False)}
-                ),
-            ]
-        )
+    return pytest.param(*values, id=id_, **kw)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION.release < (1, 0, 0),  # type: ignore
-    reason="pandas >= 1.0.0 required",
-)
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        pa.INT8,
-        pa.INT16,
-        pa.INT32,
-        pa.INT64,
-        pa.UINT8,
-        pa.UINT16,
-        pa.UINT32,
-        pa.UINT64,
-    ],
-)
-@pytest.mark.parametrize("coerce", [True, False])
-def test_pandas_nullable_int_dtype(dtype, coerce):
-    """Test that pandas nullable int dtype can be specified in a schema."""
-    assert all(
-        isinstance(
-            schema.validate(
-                pd.DataFrame(
-                    # keep max range to 127 in order to support Int8
-                    {"col": range(128)},
-                    **({} if coerce else {"dtype": dtype.str_alias}),
-                )
-            ),
-            pd.DataFrame,
-        )
-        for schema in [
-            DataFrameSchema(
-                {"col": Column(dtype, nullable=False)}, coerce=coerce
-            ),
-            DataFrameSchema(
-                {"col": Column(dtype.str_alias, nullable=False)}, coerce=coerce
-            ),
-        ]
-    )
+def pytest_generate_tests(metafunc: Metafunc) -> None:
+    """Inject dtype, alias, data fixtures from `dtype_fixtures`.
 
-
-@pytest.mark.parametrize("str_alias", ["foo", "bar", "baz", "asdf", "qwerty"])
-def test_unrecognized_str_aliases(str_alias):
-    """Test that unrecognized string aliases are supported."""
-    with pytest.raises(TypeError):
-        PandasDtype.from_str_alias(str_alias)
-
-
-def test_category_dtype():
-    """Test the category type can be validated properly by schema.validate"""
-    schema = DataFrameSchema(
-        columns={
-            "col": Column(
-                pa.Category,
-                checks=[
-                    Check(lambda s: set(s) == {"A", "B", "C"}),
-                    Check(
-                        lambda s: s.cat.categories.tolist() == ["A", "B", "C"]
-                    ),
-                    Check(lambda s: s.isin(["A", "B", "C"])),
-                ],
-                nullable=False,
-            ),
-        },
-        coerce=False,
-    )
-    validated_df = schema.validate(
-        pd.DataFrame(
-            {"col": pd.Series(["A", "B", "A", "B", "C"], dtype="category")}
-        )
-    )
-    assert isinstance(validated_df, pd.DataFrame)
-
-
-def test_category_dtype_coerce():
-    """Test coercion of the category type is validated properly by
-    schema.validate and fails safely."""
-    columns = {
-        "col": Column(
-            pa.Category,
-            checks=Check(lambda s: set(s) == {"A", "B", "C"}),
-            nullable=False,
-        ),
-    }
-
-    with pytest.raises(SchemaError):
-        DataFrameSchema(columns=columns, coerce=False).validate(
-            pd.DataFrame(
-                {"col": pd.Series(["A", "B", "A", "B", "C"], dtype="object")}
-            )
-        )
-
-    validated_df = DataFrameSchema(columns=columns, coerce=True).validate(
-        pd.DataFrame(
-            {"col": pd.Series(["A", "B", "A", "B", "C"], dtype="object")}
-        )
-    )
-    assert isinstance(validated_df, pd.DataFrame)
-
-
-def helper_type_validation(dataframe_type, schema_type, debugging=False):
+    Filter pandera.dtypes.DataType classes if the test name contains "datatype".
     """
-    Helper function for using same or different dtypes for the dataframe and
-    the schema_type
-    """
-    df = pd.DataFrame({"column1": [dataframe_type(1)]})
-    if debugging:
-        print(dataframe_type, df.column1)
-    schema = pa.DataFrameSchema({"column1": pa.Column(schema_type)})
-    if debugging:
-        print(schema)
-    schema(df)
-
-
-@pytest.mark.parametrize(
-    "type1, type2",
-    [
-        # Pandas always converts complex numbers to np.complex128
-        (np.complex_, np.complex_),
-        (np.complex_, np.complex128),
-        (np.complex128, np.complex_),
-        (np.complex64, np.complex128),
-        (np.complex128, np.complex128),
-        # Pandas always converts float numbers to np.float64
-        (np.float_, np.float_),
-        (np.float_, np.float64),
-        (np.float16, np.float64),
-        (np.float32, np.float64),
-        (np.float64, np.float64),
-        # Pandas always converts int numbers to np.int64
-        (np.int_, np.int64),
-        (np.int8, np.int64),
-        (np.int16, np.int64),
-        (np.int32, np.int64),
-        (np.int64, np.int64),
-        # Pandas always converts int numbers to np.int64
-        (np.uint, np.int64),
-        (np.uint, np.int64),
-        (np.uint8, np.int64),
-        (np.uint16, np.int64),
-        (np.uint32, np.int64),
-        (np.uint64, np.int64),
-        (np.bool_, np.bool_),
-        (np.str_, np.str_)
-        # np.object, np.void and bytes are not tested
-    ],
-)
-def test_valid_numpy_type_conversions(type1, type2):
-    """Test correct conversions of numpy dtypes"""
-    try:
-        helper_type_validation(type1, type2)
-    except:  # pylint: disable=bare-except
-        # No exceptions since it should cover all exceptions for debug
-        # purpose
-        # Rerun test with debug inforation
-        print(f"Error on types: {type1}, {type2}")
-        helper_type_validation(type1, type2, True)
-
-
-@pytest.mark.parametrize(
-    "type1, type2",
-    [
-        (np.complex_, np.int_),
-        (np.int_, np.complex_),
-        (float, np.complex_),
-        (np.complex_, float),
-        (np.int_, np.float_),
-        (np.uint8, np.float_),
-        (np.complex_, str),
-    ],
-)
-def test_invalid_numpy_type_conversions(type1, type2):
-    """Test various numpy dtypes"""
-    with pytest.raises(SchemaError):
-        helper_type_validation(type1, type2)
-
-    PandasDtype.from_numpy_type(np.float_)
-    with pytest.raises(TypeError):
-        PandasDtype.from_numpy_type(pd.DatetimeIndex)
-
-
-def test_datetime():
-    """Test datetime types can be validated properly by schema.validate"""
-    schema = DataFrameSchema(
-        columns={
-            "col": Column(
-                pa.DateTime,
-                checks=Check(lambda s: s.min() > pd.Timestamp("2015")),
-            )
-        }
-    )
-
-    validated_df = schema.validate(
-        pd.DataFrame(
-            {"col": pd.to_datetime(["2019/01/01", "2018/05/21", "2016/03/10"])}
-        )
-    )
-
-    assert isinstance(validated_df, pd.DataFrame)
-
-    with pytest.raises(SchemaError):
-        schema.validate(pd.DataFrame({"col": pd.to_datetime(["2010/01/01"])}))
-
-
-@pytest.mark.skipif(
-    PANDAS_VERSION.release < (1, 0, 0),  # type: ignore
-    reason="pandas >= 1.0.0 required",
-)
-def test_pandas_extension_types():
-    """Test pandas extension data type happy path."""
-    # pylint: disable=no-member
-    test_params = [
-        (
-            pd.CategoricalDtype(),
-            pd.Series(["a", "a", "b", "b", "c", "c"], dtype="category"),
-            None,
-        ),
-        (
-            pd.DatetimeTZDtype(tz="UTC"),
-            pd.Series(
-                pd.date_range(start="20200101", end="20200301"),
-                dtype="datetime64[ns, utc]",
-            ),
-            None,
-        ),
-        (pd.Int64Dtype(), pd.Series(range(10), dtype="Int64"), None),
-        (
-            pd.StringDtype(),
-            pd.Series(["foo", "bar", "baz"], dtype="string"),
-            None,
-        ),
-        (
-            pd.PeriodDtype(freq="D"),
-            pd.Series(pd.period_range("1/1/2019", "1/1/2020", freq="D")),
-            None,
-        ),
-        (
-            pd.SparseDtype("float"),
-            pd.Series(range(100))
-            .where(lambda s: s < 5, other=np.nan)
-            .astype("Sparse[float]"),
-            {"nullable": True},
-        ),
-        (pd.BooleanDtype(), pd.Series([1, 0, 0, 1, 1], dtype="boolean"), None),
-        (
-            pd.IntervalDtype(subtype="int64"),
-            pd.Series(pd.IntervalIndex.from_breaks([0, 1, 2, 3, 4])),
-            None,
-        ),
+    fixtures = [
+        fixture
+        for fixture in ("dtype", "pd_dtype", "data")
+        if fixture in metafunc.fixturenames
     ]
-    for dtype, data, series_kwargs in test_params:
-        series_kwargs = {} if series_kwargs is None else series_kwargs
-        series_schema = SeriesSchema(pandas_dtype=dtype, **series_kwargs)
-        assert isinstance(series_schema.validate(data), pd.Series)
+    arg_names = ",".join(fixtures)
+
+    if arg_names:
+        arg_values = []
+        for dtypes, data in dtype_fixtures:
+            for dtype, pd_dtype in dtypes.items():
+                if "datatype" in metafunc.function.__name__ and not (
+                    isinstance(dtype, DataType)
+                    or (inspect.isclass(dtype) and issubclass(dtype, DataType))
+                ):
+                    # not a DataType class or instance
+                    continue
+
+                params = [dtype]
+                if "pd_dtype" in fixtures:
+                    params.append(pd_dtype)
+                if "data" in fixtures:
+                    params.append(data)
+                arg_values.append(pretty_param(*params))
+
+        metafunc.parametrize(arg_names, arg_values)
 
 
-def test_python_builtin_types():
-    """Test support python data types can be used for validation."""
-    schema = DataFrameSchema(
-        {
-            "int_col": Column(int),
-            "float_col": Column(float),
-            "str_col": Column(str),
-            "bool_col": Column(bool),
-            "object_col": Column(object),
-            "complex_col": Column(complex),
-        }
+def test_datatype_init(dtype: Any):
+    """Test that a default DataType can be constructed."""
+    if not inspect.isclass(dtype):
+        pytest.skip(
+            "test_datatype_init tests DataType classes, not instances."
+        )
+    assert isinstance(dtype(), DataType)
+
+
+def test_datatype_alias(dtype: Any, pd_dtype: Any):
+    """Test that a default DataType can be constructed."""
+    data_type = dtype() if inspect.isclass(dtype) else dtype
+    assert str(PandasEngine.dtype(dtype)) == str(pd_dtype)
+
+
+def test_frozen_datatype(dtype: Any):
+    """Test that DataType instances are immutable."""
+    data_type = dtype() if inspect.isclass(dtype) else dtype
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        data_type.foo = 1
+
+
+def test_invalid_pandas_extension_dtype():
+    with pytest.raises(TypeError):
+        PandasEngine.dtype(
+            pd.PeriodDtype
+        )  # PerioDtype has required parameters
+
+
+def test_check_equivalent(dtype: Any, pd_dtype: Any):
+    """Test that a pandas-compatible dtype can be validated by check()."""
+    actual_dtype = PandasEngine.dtype(pd_dtype)
+    expected_dtype = PandasEngine.dtype(dtype)
+    assert actual_dtype.check(expected_dtype)
+
+
+def test_check_not_equivalent(dtype: Any):
+    """Test that check() rejects non-equivalent dtypes."""
+    if str(PandasEngine.dtype(dtype)) == "object":
+        actual_dtype = PandasEngine.dtype(int)
+    else:
+        actual_dtype = PandasEngine.dtype(object)
+    expected_dtype = PandasEngine.dtype(dtype)
+    assert actual_dtype.check(expected_dtype) is False
+
+
+def test_coerce_no_cast(dtype: Any, pd_dtype: Any, data: List[Any]):
+    """Test that dtypes can be coerced without casting."""
+    expected_dtype = PandasEngine.dtype(dtype)
+    print(pd_dtype)
+    series = pd.Series(data, dtype=pd_dtype)
+    coerced_series = expected_dtype.coerce(series)
+    assert series.equals(coerced_series)
+    print(expected_dtype)
+    print(series)
+    print(coerced_series)
+    print(coerced_series.dtype)
+    print(PandasEngine.dtype(coerced_series.dtype))
+    assert expected_dtype.check(PandasEngine.dtype(coerced_series.dtype))
+
+    df = pd.DataFrame({"col": data}, dtype=pd_dtype)
+    coerced_df = expected_dtype.coerce(df)
+    assert df.equals(coerced_df)
+    assert expected_dtype.check(PandasEngine.dtype(coerced_df["col"].dtype))
+
+
+def _flatten_dtypes_dict(*dtype_kinds):
+    return [
+        (datatype, pd_dtype)
+        for dtype_kind in dtype_kinds
+        for datatype, pd_dtype in dtype_kind.items()
+    ]
+
+
+numeric_dtypes = _flatten_dtypes_dict(
+    int_dtypes,
+    uint_dtypes,
+    float_dtypes,
+    complex_dtypes,
+    boolean_dtypes,
+)
+
+nullable_numeric_dtypes = _flatten_dtypes_dict(
+    nullable_int_dtypes,
+    nullable_uint_dtypes,
+    nullable_boolean_dtypes,
+)
+
+nominal_dtypes = _flatten_dtypes_dict(
+    string_dtypes,
+    nullable_string_dtypes,
+    category_dtypes,
+)
+
+
+@pytest.mark.parametrize(
+    "dtypes, examples",
+    [
+        (numeric_dtypes, [1]),
+        (nullable_numeric_dtypes, [1, None]),
+        (nominal_dtypes, ["A", "B"]),
+    ],
+)
+@hypothesis.given(st.data())
+def test_coerce_cast(dtypes, examples, data):
+    """Test that dtypes can be coerced with casting."""
+    _, from_pd_dtype = data.draw(st.sampled_from(dtypes))
+    to_datatype, _ = data.draw(st.sampled_from(dtypes))
+
+    expected_dtype = PandasEngine.dtype(to_datatype)
+
+    series = pd.Series(examples, dtype=from_pd_dtype)
+    coerced_dtype = expected_dtype.coerce(series).dtype
+    assert expected_dtype.check(PandasEngine.dtype(coerced_dtype))
+
+    df = pd.DataFrame({"col": examples}, dtype=from_pd_dtype)
+    coerced_dtype = expected_dtype.coerce(df)["col"].dtype
+    assert expected_dtype.check(PandasEngine.dtype(coerced_dtype))
+
+
+def test_coerce_string():
+    """Test that strings can be coerced."""
+    data = pd.Series([1, None], dtype="Int32")
+    coerced = PandasEngine.dtype(str).coerce(data).to_list()
+    assert isinstance(coerced[0], str)
+    assert pd.isna(coerced[1])
+
+
+def test_default_numeric_dtypes():
+    """Test that default numeric dtypes int, float and complex are consistent."""
+    default_int_dtype = pd.Series([1], dtype=int).dtype
+    assert (
+        PandasEngine.dtype(default_int_dtype)
+        == PandasEngine.dtype(int)
+        == PandasEngine.dtype("int")
     )
-    df = pd.DataFrame(
-        {
-            "int_col": [1, 2, 3],
-            "float_col": [1.0, 2.0, 3.0],
-            "str_col": list("abc"),
-            "bool_col": [True, False, True],
-            "object_col": [[1], 1, {"foo": "bar"}],
-            "complex_col": [complex(1), complex(2), complex(3)],
-        }
+
+    default_float_dtype = pd.Series([1], dtype=float).dtype
+    assert (
+        PandasEngine.dtype(default_float_dtype)
+        == PandasEngine.dtype(float)
+        == PandasEngine.dtype("float")
     )
-    assert isinstance(schema(df), pd.DataFrame)
-    assert schema.dtype["int_col"] == PandasDtype.Int.str_alias
-    assert schema.dtype["float_col"] == PandasDtype.Float.str_alias
-    assert schema.dtype["str_col"] == PandasDtype.String.str_alias
-    assert schema.dtype["bool_col"] == PandasDtype.Bool.str_alias
-    assert schema.dtype["object_col"] == PandasDtype.Object.str_alias
-    assert schema.dtype["complex_col"] == PandasDtype.Complex.str_alias
 
-
-@pytest.mark.parametrize("python_type", [list, dict, set])
-def test_python_builtin_types_not_supported(python_type):
-    """Test unsupported python data types raise a type error."""
-    with pytest.raises(TypeError):
-        Column(python_type)
+    default_complex_dtype = pd.Series([1], dtype=complex).dtype
+    assert (
+        PandasEngine.dtype(default_complex_dtype)
+        == PandasEngine.dtype(complex)
+        == PandasEngine.dtype("complex")
+    )
 
 
 @pytest.mark.parametrize(
-    "pandas_api_type,pandas_dtype",
+    "examples",
     [
-        ["string", PandasDtype.String],
-        ["floating", PandasDtype.Float],
-        ["integer", PandasDtype.Int],
-        ["categorical", PandasDtype.Category],
-        ["boolean", PandasDtype.Bool],
-        ["datetime64", PandasDtype.DateTime],
-        ["datetime", PandasDtype.DateTime],
-        ["timedelta64", PandasDtype.Timedelta],
-        ["timedelta", PandasDtype.Timedelta],
-        ["mixed-integer", PandasDtype.Object],
+        pretty_param(param)
+        for param in [
+            ["A", "B"],  # string
+            [b"foo", b"bar"],  # bytes
+            [1, 2, 3],  # integer
+            ["a", datetime.date(2013, 1, 1)],  # mixed
+            ["a", 1],  # mixed-integer
+            [1, 2, 3.5, "foo"],  # mixed-integer-float
+            [1.0, 2.0, 3.5],  # floating
+            [Decimal(1), Decimal(2.0)],  # decimal
+            [pd.Timestamp("20130101")],  # datetime
+            [datetime.date(2013, 1, 1)],  # date
+            [datetime.timedelta(0, 1, 1)],  # timedelta
+            pd.Series(list("aabc")).astype("category"),  # categorical
+            [Decimal(1), Decimal(2.0)],  # decimal
+        ]
     ],
 )
-def test_pandas_api_types(pandas_api_type, pandas_dtype):
-    """Test pandas api type conversion."""
-    assert PandasDtype.from_pandas_api_type(pandas_api_type) is pandas_dtype
-
-
-@pytest.mark.parametrize(
-    "invalid_pandas_api_type",
-    [
-        "foo",
-        "bar",
-        "baz",
-        "this is not a type",
-    ],
-)
-def test_pandas_api_type_exception(invalid_pandas_api_type):
-    """Test unsupported values for pandas api type conversion."""
-    with pytest.raises(TypeError):
-        PandasDtype.from_pandas_api_type(invalid_pandas_api_type)
-
-
-@pytest.mark.parametrize(
-    "pandas_dtype", (pandas_dtype for pandas_dtype in PandasDtype)
-)
-def test_pandas_dtype_equality(pandas_dtype):
-    """Test __eq__ implementation."""
-    assert pandas_dtype is not None  # pylint:disable=singleton-comparison
-    assert pandas_dtype == pandas_dtype.value
-
-
-@pytest.mark.parametrize("pdtype", PandasDtype)
-def test_dtype_none_comparison(pdtype):
-    """Test that comparing PandasDtype to None is False."""
-    assert pdtype is not None
-
-
-@pytest.mark.parametrize(
-    "property_fn, pdtypes",
-    [
-        [
-            lambda x: x.is_int,
-            [
-                PandasDtype.Int,
-                PandasDtype.Int8,
-                PandasDtype.Int16,
-                PandasDtype.Int32,
-                PandasDtype.Int64,
-                PandasDtype.INT8,
-                PandasDtype.INT16,
-                PandasDtype.INT32,
-                PandasDtype.INT64,
-            ],
-        ],
-        [
-            lambda x: x.is_nullable_int,
-            [
-                PandasDtype.INT8,
-                PandasDtype.INT16,
-                PandasDtype.INT32,
-                PandasDtype.INT64,
-            ],
-        ],
-        [
-            lambda x: x.is_nonnullable_int,
-            [
-                PandasDtype.Int,
-                PandasDtype.Int8,
-                PandasDtype.Int16,
-                PandasDtype.Int32,
-                PandasDtype.Int64,
-            ],
-        ],
-        [
-            lambda x: x.is_uint,
-            [
-                PandasDtype.UInt8,
-                PandasDtype.UInt16,
-                PandasDtype.UInt32,
-                PandasDtype.UInt64,
-                PandasDtype.UINT8,
-                PandasDtype.UINT16,
-                PandasDtype.UINT32,
-                PandasDtype.UINT64,
-            ],
-        ],
-        [
-            lambda x: x.is_nullable_uint,
-            [
-                PandasDtype.UINT8,
-                PandasDtype.UINT16,
-                PandasDtype.UINT32,
-                PandasDtype.UINT64,
-            ],
-        ],
-        [
-            lambda x: x.is_nonnullable_uint,
-            [
-                PandasDtype.UInt8,
-                PandasDtype.UInt16,
-                PandasDtype.UInt32,
-                PandasDtype.UInt64,
-            ],
-        ],
-        [
-            lambda x: x.is_float,
-            [
-                PandasDtype.Float,
-                PandasDtype.Float16,
-                PandasDtype.Float32,
-                PandasDtype.Float64,
-            ],
-        ],
-        [
-            lambda x: x.is_complex,
-            [
-                PandasDtype.Complex,
-                PandasDtype.Complex64,
-                PandasDtype.Complex128,
-                PandasDtype.Complex256,
-            ],
-        ],
-        [lambda x: x.is_bool, [PandasDtype.Bool]],
-        [lambda x: x.is_string, [PandasDtype.String, PandasDtype.String]],
-        [lambda x: x.is_category, [PandasDtype.Category]],
-        [lambda x: x.is_datetime, [PandasDtype.DateTime]],
-        [lambda x: x.is_timedelta, [PandasDtype.Timedelta]],
-        [lambda x: x.is_object, [PandasDtype.Object]],
-        [
-            lambda x: x.is_continuous,
-            [
-                PandasDtype.Int,
-                PandasDtype.Int8,
-                PandasDtype.Int16,
-                PandasDtype.Int32,
-                PandasDtype.Int64,
-                PandasDtype.INT8,
-                PandasDtype.INT16,
-                PandasDtype.INT32,
-                PandasDtype.INT64,
-                PandasDtype.UInt8,
-                PandasDtype.UInt16,
-                PandasDtype.UInt32,
-                PandasDtype.UInt64,
-                PandasDtype.UINT8,
-                PandasDtype.UINT16,
-                PandasDtype.UINT32,
-                PandasDtype.UINT64,
-                PandasDtype.Float,
-                PandasDtype.Float16,
-                PandasDtype.Float32,
-                PandasDtype.Float64,
-                PandasDtype.Complex,
-                PandasDtype.Complex64,
-                PandasDtype.Complex128,
-                PandasDtype.Complex256,
-                PandasDtype.DateTime,
-                PandasDtype.Timedelta,
-            ],
-        ],
-    ],
-)
-def test_dtype_is_checks(property_fn, pdtypes):
-    """Test all the pandas dtype is_* properties."""
-    for pdtype in pdtypes:
-        assert property_fn(pdtype)
-
-
-def test_category_dtype_exception():
-    """Test that category dtype has no numpy dtype equivalent."""
-    with pytest.raises(TypeError):
-        # pylint: disable=pointless-statement
-        PandasDtype.Category.numpy_dtype
+def test_inferred_dtype(examples: pd.Series):
+    alias = pd.api.types.infer_dtype(examples)
+    if "mixed" in alias or alias in ("date", "string"):
+        # infer_dtype returns "string", "date"
+        # whereas a Series will default to a "np.object_" dtype
+        inferred_datatype = PandasEngine.dtype(object)
+    else:
+        inferred_datatype = PandasEngine.dtype(alias)
+    actual_dtype = PandasEngine.dtype(pd.Series(examples).dtype)
+    assert actual_dtype.check(inferred_datatype)

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -26,7 +26,7 @@ def equivalents() -> List[Any]:
 
 @pytest.fixture
 def engine() -> Type[Engine]:
-    class FakeEngine(metaclass=Engine, base_datatype=BaseDataType):
+    class FakeEngine(metaclass=Engine, base_pandera_dtypes=BaseDataType):
         pass
 
     yield FakeEngine
@@ -160,7 +160,7 @@ def test_register_dtype_overwrite(
     assert engine.dtype(42) == DtypeB()
 
 
-def test_register_base_datatype(engine: Type[Engine]):
+def test_register_base_pandera_dtypes(engine: Type[Engine]):
     """Test that base datatype cannot be registered."""
     with pytest.raises(
         ValueError,

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -1,6 +1,8 @@
-from typing import Any, Type, List, Union
-from pandera.engines.engine import Engine
+from typing import Any, List, Type, Union
+
 import pytest
+
+from pandera.engines.engine import Engine
 
 
 class BaseDataType:
@@ -132,7 +134,9 @@ def test_register_dtype_complete(engine: Type[Engine], equivalents: List[Any]):
         engine.dtype(str)
 
 
-def test_register_dtype_overwrite(engine: Type[Engine], equivalents: List[Any]):
+def test_register_dtype_overwrite(
+    engine: Type[Engine], equivalents: List[Any]
+):
     """Test that register_dtype overwrites existing registrations."""
 
     @engine.register_dtype(equivalents=["foo"])

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -1,0 +1,189 @@
+from typing import Any, Type, List, Union
+from pandera.engines.engine import Engine
+import pytest
+
+
+class BaseDataType:
+    def __eq__(self, obj: object) -> bool:
+        if isinstance(obj, type(self)):
+            return True
+        return False
+
+    def __hash__(self) -> int:
+        return hash(self.__class__.__name__)
+
+
+class SimpleDtype(BaseDataType):
+    pass
+
+
+@pytest.fixture
+def equivalents() -> List[Any]:
+    return [int, "int", 1]
+
+
+@pytest.fixture
+def engine() -> Type[Engine]:
+    class FakeEngine(metaclass=Engine, base_datatype=BaseDataType):
+        pass
+
+    yield FakeEngine
+
+    del FakeEngine
+
+
+def test_register_bare_dtype(engine: Type[Engine]):
+    """Test that a dtype without  equivalents nor 'from_parametrized_dtype'
+    classmethod can be registered.
+    """
+    with pytest.warns(UserWarning):
+        engine.register_dtype(SimpleDtype)
+
+
+def test_register_equivalents(engine: Type[Engine], equivalents: List[Any]):
+    """Test that a dtype with equivalents can be registered."""
+    engine.register_dtype(SimpleDtype, equivalents=equivalents)
+
+    for equivalent in equivalents:
+        assert engine.dtype(equivalent) == SimpleDtype()
+
+    with pytest.raises(
+        TypeError, match="Data type 'foo' not understood by FakeEngine"
+    ):
+        engine.dtype("foo")
+
+
+def test_register_from_parametrized_dtype(engine: Type[Engine]):
+    """Test that a dtype with from_parametrized_dtype can be registered."""
+
+    @engine.register_dtype
+    class Dtype(BaseDataType):
+        pass
+
+        @classmethod
+        def from_parametrized_dtype(cls, x: int):
+            return x
+
+    assert engine.dtype(42) == 42
+
+    with pytest.raises(
+        TypeError, match="Data type 'foo' not understood by FakeEngine"
+    ):
+        engine.dtype("foo")
+
+
+def test_register_from_parametrized_dtype_union(engine: Type[Engine]):
+    """Test that a dtype with from_parametrized_dtype and Union annotation
+    can be registered.
+    """
+
+    @engine.register_dtype
+    class Dtype(BaseDataType):
+        pass
+
+        @classmethod
+        def from_parametrized_dtype(cls, x: Union[int, str]):
+            return x
+
+    assert engine.dtype(42) == 42
+
+
+def test_register_invalid_from_parametrized_dtype(engine: Type[Engine]):
+    """Test that a dtype with invalid from_parametrized_dtype
+    cannot be registered.
+    """
+
+    with pytest.raises(
+        ValueError,
+        match="Dtype.from_parametrized_dtype must be a classmethod.",
+    ):
+
+        @engine.register_dtype
+        class Dtype(BaseDataType):
+            pass
+
+            def from_parametrized_dtype(cls, x: int):
+                return x
+
+
+def test_register_dtype_complete(engine: Type[Engine], equivalents: List[Any]):
+    """Test that a dtype with equivalents and from_parametrized_dtype
+    can be registered.
+    """
+
+    @engine.register_dtype(equivalents=equivalents)
+    class Dtype(BaseDataType):
+        pass
+
+        @classmethod
+        def from_parametrized_dtype(cls, x: Union[int, str]):
+            return x
+
+    assert engine.dtype(42) == 42
+    assert engine.dtype("foo") == "foo"
+
+    for equivalent in equivalents:
+        engine.dtype(equivalent) == Dtype()
+
+    with pytest.raises(
+        TypeError,
+        match="Data type '<class 'str'>' not understood by FakeEngine",
+    ):
+        engine.dtype(str)
+
+
+def test_register_dtype_overwrite(engine: Type[Engine], equivalents: List[Any]):
+    """Test that register_dtype overwrites existing registrations."""
+
+    @engine.register_dtype(equivalents=["foo"])
+    class DtypeA(BaseDataType):
+        @classmethod
+        def from_parametrized_dtype(cls, x: Union[int, str]):
+            return DtypeA()
+
+    assert engine.dtype("foo") == DtypeA()
+    assert engine.dtype("bar") == DtypeA()
+    assert engine.dtype(42) == DtypeA()
+
+    @engine.register_dtype(equivalents=["foo"])
+    class DtypeB(BaseDataType):
+        @classmethod
+        def from_parametrized_dtype(cls, x: int):
+            return DtypeB()
+
+    assert engine.dtype("foo") == DtypeB()
+    assert engine.dtype("bar") == DtypeA()
+    assert engine.dtype(42) == DtypeB()
+
+
+def test_register_base_datatype(engine: Type[Engine]):
+    """Test that base datatype cannot be registered."""
+    with pytest.raises(
+        ValueError,
+        match="BaseDataType subclasses cannot be registered with FakeEngine.",
+    ):
+
+        @engine.register_dtype(equivalents=[SimpleDtype])
+        class Dtype(BaseDataType):
+            pass
+
+
+def test_return_base_dtype(engine: Type[Engine]):
+    """Test that Engine.dtype returns back base datatypes."""
+    assert engine.dtype(SimpleDtype()) == SimpleDtype()
+    assert engine.dtype(SimpleDtype) == SimpleDtype()
+
+    class ParametrizedDtype(BaseDataType):
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+        def __eq__(self, obj: object) -> bool:
+            if not isinstance(obj, ParametrizedDtype):
+                return NotImplemented
+            return obj.x == self.x
+
+    assert engine.dtype(ParametrizedDtype(1)) == ParametrizedDtype(1)
+    with pytest.raises(
+        TypeError, match="DataType 'ParametrizedDtype' cannot be instantiated"
+    ):
+        engine.dtype(ParametrizedDtype)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -81,7 +81,7 @@ def test_invalid_annotations():
         d: Series[Decimal]  # type: ignore
 
     with pytest.raises(
-        TypeError, match="python type '<class 'decimal.Decimal'>"
+        TypeError, match="dtype '<class 'decimal.Decimal'>' not understood"
     ):
         InvalidDtype.to_schema()
 
@@ -480,7 +480,7 @@ def test_inherit_schemamodel_fields_alias():
     )
     expected_child_override_attr = expected_mid.rename_columns(
         {"_b": "b"}
-    ).update_column("b", pandas_dtype=int)
+    ).update_column("b", dtype=int)
     expected_child_override_alias = expected_mid.rename_columns(
         {"_b": "new_b"}
     )

--- a/tests/core/test_model_components.py
+++ b/tests/core/test_model_components.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 import pandera as pa
+from pandera.engines.pandas_engine import PandasEngine
 
 
 def test_field_to_column():
@@ -15,7 +16,7 @@ def test_field_to_column():
                 pa.DateTime, required=value
             )
             assert isinstance(col, pa.Column)
-            assert col.dtype == pa.DateTime.value
+            assert col.dtype == PandasEngine.dtype(pa.DateTime)
             assert col.properties[flag] == value
             assert col.required == value
 
@@ -26,7 +27,7 @@ def test_field_to_index():
         for value in [True, False]:
             index = pa.Field(**{flag: value}).to_index(pa.DateTime)
             assert isinstance(index, pa.Index)
-            assert index.dtype == pa.DateTime.value
+            assert index.dtype == PandasEngine.dtype(pa.DateTime)
             assert getattr(index, flag) == value
 
 

--- a/tests/core/test_model_components.py
+++ b/tests/core/test_model_components.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import pandera as pa
-from pandera.engines.pandas_engine import PandasEngine
+from pandera.engines.pandas_engine import Engine
 
 
 def test_field_to_column():
@@ -16,7 +16,7 @@ def test_field_to_column():
                 pa.DateTime, required=value
             )
             assert isinstance(col, pa.Column)
-            assert col.dtype == PandasEngine.dtype(pa.DateTime)
+            assert col.dtype == Engine.dtype(pa.DateTime)
             assert col.properties[flag] == value
             assert col.required == value
 
@@ -27,7 +27,7 @@ def test_field_to_index():
         for value in [True, False]:
             index = pa.Field(**{flag: value}).to_index(pa.DateTime)
             assert isinstance(index, pa.Index)
-            assert index.dtype == PandasEngine.dtype(pa.DateTime)
+            assert index.dtype == Engine.dtype(pa.DateTime)
             assert getattr(index, flag) == value
 
 

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -20,7 +20,7 @@ from pandera import (
     String,
     errors,
 )
-from pandera.engines.pandas_engine import PandasEngine
+from pandera.engines.pandas_engine import Engine
 
 
 def test_column():
@@ -79,7 +79,7 @@ def test_index_schema_coerce(dtype):
     """Test that index can be type-coerced."""
     schema = DataFrameSchema(index=Index(dtype, coerce=True))
     df = pd.DataFrame(index=pd.Index([1, 2, 3, 4], dtype="int64"))
-    validated_index_dtype = PandasEngine.dtype(schema(df).index.dtype)
+    validated_index_dtype = Engine.dtype(schema(df).index.dtype)
     assert schema.index.dtype.check(validated_index_dtype)
 
 
@@ -174,7 +174,7 @@ def test_multi_index_schema_coerce():
     validated_df = schema(df)
     for level_i in range(validated_df.index.nlevels):
         index_dtype = validated_df.index.get_level_values(level_i).dtype
-        assert indexes[level_i].dtype.check(PandasEngine.dtype(index_dtype))
+        assert indexes[level_i].dtype.check(Engine.dtype(index_dtype))
 
 
 def tests_multi_index_subindex_coerce():
@@ -463,7 +463,7 @@ def test_column_type_can_be_set():
 
     column_a.dtype = Float
 
-    assert column_a.dtype == PandasEngine.dtype(changed_type)
+    assert column_a.dtype == Engine.dtype(changed_type)
 
     for invalid_dtype in ("foobar", "bar"):
         with pytest.raises(TypeError):

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -20,8 +20,7 @@ from pandera import (
     String,
     errors,
 )
-
-from .test_dtypes import TESTABLE_DTYPES
+from pandera.engines.pandas_engine import PandasEngine
 
 
 def test_column():
@@ -44,25 +43,6 @@ def test_column():
 
     with pytest.raises(errors.SchemaError):
         Column(Int)(data)
-
-
-def test_coerce_nullable_object_column():
-    """Test that Object dtype coercing preserves object types."""
-    df_objects_with_na = pd.DataFrame(
-        {"col": [1, 2.0, [1, 2, 3], {"a": 1}, np.nan, None]}
-    )
-
-    column_schema = Column(Object, name="col", coerce=True, nullable=True)
-
-    validated_df = column_schema.validate(df_objects_with_na)
-    assert isinstance(validated_df, pd.DataFrame)
-    assert pd.isna(validated_df["col"].iloc[-1])
-    assert pd.isna(validated_df["col"].iloc[-2])
-    for i in range(4):
-        isinstance(
-            validated_df["col"].iloc[i],
-            type(df_objects_with_na["col"].iloc[i]),
-        )
 
 
 def test_column_in_dataframe_schema():
@@ -94,18 +74,13 @@ def test_index_schema():
         schema.validate(pd.DataFrame(index=range(1, 20)))
 
 
-@pytest.mark.parametrize("pdtype", [Float, Int, String, String])
-def test_index_schema_coerce(pdtype):
+@pytest.mark.parametrize("dtype", [Float, Int, String])
+def test_index_schema_coerce(dtype):
     """Test that index can be type-coerced."""
-    schema = DataFrameSchema(index=Index(pdtype, coerce=True))
+    schema = DataFrameSchema(index=Index(dtype, coerce=True))
     df = pd.DataFrame(index=pd.Index([1, 2, 3, 4], dtype="int64"))
-    validated_df = schema(df)
-    # pandas-native "string" dtype doesn't apply to indexes
-    assert (
-        validated_df.index.dtype == "object"
-        if pdtype is String
-        else pdtype.str_alias
-    )
+    validated_index_dtype = PandasEngine.dtype(schema(df).index.dtype)
+    assert schema.index.dtype.check(validated_index_dtype)
 
 
 def test_multi_index_columns():
@@ -198,10 +173,8 @@ def test_multi_index_schema_coerce():
     )
     validated_df = schema(df)
     for level_i in range(validated_df.index.nlevels):
-        assert (
-            validated_df.index.get_level_values(level_i).dtype
-            == indexes[level_i].dtype
-        )
+        index_dtype = validated_df.index.get_level_values(level_i).dtype
+        assert indexes[level_i].dtype.check(PandasEngine.dtype(index_dtype))
 
 
 def tests_multi_index_subindex_coerce():
@@ -234,12 +207,6 @@ def tests_multi_index_subindex_coerce():
         errors.SchemaErrors, match="A total of 2 schema errors were found"
     ):
         schema(data, lazy=True)
-
-
-@pytest.mark.parametrize("pandas_dtype, expected", TESTABLE_DTYPES)
-def test_column_dtype_property(pandas_dtype, expected):
-    """Tests that the dtypes provided by Column match pandas dtypes"""
-    assert Column(pandas_dtype).dtype == expected
 
 
 def test_schema_component_equality_operators():
@@ -494,18 +461,17 @@ def test_column_type_can_be_set():
     column_a = Column(Int, name="a")
     changed_type = Float
 
-    column_a.pandas_dtype = Float
+    column_a.dtype = Float
 
-    assert column_a.pandas_dtype == changed_type
-    assert column_a.dtype == changed_type.str_alias
+    assert column_a.dtype == PandasEngine.dtype(changed_type)
 
     for invalid_dtype in ("foobar", "bar"):
         with pytest.raises(TypeError):
-            column_a.pandas_dtype = invalid_dtype
+            column_a.dtype = invalid_dtype
 
     for invalid_dtype in (1, 2.2, ["foo", 1, 1.1], {"b": 1}):
         with pytest.raises(TypeError):
-            column_a.pandas_dtype = invalid_dtype
+            column_a.dtype = invalid_dtype
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -2,7 +2,6 @@
 
 import copy
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -15,7 +14,6 @@ from pandera import (
     Index,
     Int,
     MultiIndex,
-    Object,
     SeriesSchema,
     String,
     errors,

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -315,9 +315,9 @@ def test_series_schema():
         int_schema.validate(pd.Series([0, 30, 50, 100])), pd.Series
     )
 
-    def f(s):
-        print(s)
-        return s.isin(["foo", "bar", "baz"])
+    def f(series):
+        print(series)
+        return series.isin(["foo", "bar", "baz"])
 
     str_schema = SeriesSchema(
         str,

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-lines,redefined-outer-name
 
 import copy
+from datetime import datetime, timedelta
 from functools import partial
 from typing import Dict
 
@@ -10,28 +11,17 @@ import pandas as pd
 import pytest
 
 from pandera import (
-    STRING,
-    Bool,
     Category,
     Check,
     Column,
     DataFrameSchema,
-    DateTime,
-    Float,
     Index,
-    Int,
     MultiIndex,
-    Object,
-    PandasDtype,
     SeriesSchema,
-    String,
-    Timedelta,
     errors,
 )
-from pandera.dtypes import LEGACY_PANDAS
+from pandera.engines.pandas_engine import PandasEngine
 from pandera.schemas import SeriesSchemaBase
-
-from .test_dtypes import TESTABLE_DTYPES
 
 
 def test_dataframe_schema():
@@ -41,25 +31,25 @@ def test_dataframe_schema():
     """
     schema = DataFrameSchema(
         {
-            "a": Column(Int, Check(lambda x: x > 0, element_wise=True)),
+            "a": Column(int, Check(lambda x: x > 0, element_wise=True)),
             "b": Column(
-                Float, Check(lambda x: 0 <= x <= 10, element_wise=True)
+                float, Check(lambda x: 0 <= x <= 10, element_wise=True)
             ),
-            "c": Column(String, Check(lambda x: set(x) == {"x", "y", "z"})),
-            "d": Column(Bool, Check(lambda x: x.mean() > 0.5)),
+            "c": Column(str, Check(lambda x: set(x) == {"x", "y", "z"})),
+            "d": Column(bool, Check(lambda x: x.mean() > 0.5)),
             "e": Column(
                 Category, Check(lambda x: set(x) == {"c1", "c2", "c3"})
             ),
-            "f": Column(Object, Check(lambda x: x.isin([(1,), (2,), (3,)]))),
+            "f": Column(object, Check(lambda x: x.isin([(1,), (2,), (3,)]))),
             "g": Column(
-                DateTime,
+                datetime,
                 Check(
                     lambda x: x >= pd.Timestamp("2015-01-01"),
                     element_wise=True,
                 ),
             ),
             "i": Column(
-                Timedelta,
+                timedelta,
                 Check(
                     lambda x: x < pd.Timedelta(10, unit="D"), element_wise=True
                 ),
@@ -98,16 +88,17 @@ def test_dataframe_schema():
     # checks if 'a' is converted to float, while schema says int, will a schema
     # error be thrown
     with pytest.raises(errors.SchemaError):
+        df.assign(a=[1.7, 2.3, 3.1]).info()
         schema.validate(df.assign(a=[1.7, 2.3, 3.1]))
 
 
 def test_dataframe_schema_equality():
     """Test DataframeSchema equality."""
-    schema = DataFrameSchema({"a": Column(Int)})
+    schema = DataFrameSchema({"a": Column(int)})
     assert schema == copy.copy(schema)
     assert schema != "schema"
     assert DataFrameSchema(coerce=True) != DataFrameSchema(coerce=False)
-    assert schema != schema.update_column("a", pandas_dtype=Float)
+    assert schema != schema.update_column("a", dtype=float)
     assert schema != schema.update_column("a", checks=Check.eq(1))
 
 
@@ -117,7 +108,10 @@ def test_dataframe_schema_strict():
     not present in the dataframe.
     """
     schema = DataFrameSchema(
-        {"a": Column(Int, nullable=True), "b": Column(Int, nullable=True)},
+        {
+            "a": Column(int, nullable=True),
+            "b": Column(int, nullable=True),
+        },
         strict=True,
     )
     df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
@@ -132,7 +126,10 @@ def test_dataframe_schema_strict():
 
     with pytest.raises(errors.SchemaInitError):
         DataFrameSchema(
-            {"a": Column(Int, nullable=True), "b": Column(Int, nullable=True)},
+            {
+                "a": Column(int, nullable=True),
+                "b": Column(int, nullable=True),
+            },
             strict="foobar",
         )
 
@@ -145,7 +142,7 @@ def test_dataframe_schema_strict():
 def test_dataframe_schema_strict_regex():
     """Test that strict dataframe schema checks for regex matches."""
     schema = DataFrameSchema(
-        {"foo_*": Column(Int, regex=True)},
+        {"foo_*": Column(int, regex=True)},
         strict=True,
     )
     df = pd.DataFrame({"foo_%d" % i: range(10) for i in range(5)})
@@ -160,25 +157,26 @@ def test_dataframe_schema_strict_regex():
         )
 
 
-def test_dataframe_pandas_dtype_coerce():
+def test_dataframe_dtype_coerce():
     """
     Test that pandas dtype specified at the dataframe level overrides
     column data types.
     """
     schema = DataFrameSchema(
         columns={f"column_{i}": Column(float) for i in range(5)},
-        pandas_dtype=int,
+        dtype=int,
         coerce=True,
     )
 
-    df = pd.DataFrame({f"column_{i}": range(10) for i in range(5)}).astype(
-        float
+    df = pd.DataFrame(
+        {f"column_{i}": range(10) for i in range(5)}, dtype=float
     )
-    assert (schema(df).dtypes == Int.str_alias).all()
+    int_alias = str(PandasEngine.dtype(int))
+    assert (schema(df).dtypes == int_alias).all()
 
-    # test that pandas_dtype in columns are preserved
+    # test that dtype in schema.columns are preserved
     for col in schema.columns.values():
-        assert col.pandas_dtype is float
+        assert col.dtype == PandasEngine.dtype(float)
 
     # raises SchemeError if dataframe can't be coerced
     with pytest.raises(errors.SchemaErrors):
@@ -189,31 +187,31 @@ def test_dataframe_pandas_dtype_coerce():
         schema(pd.DataFrame({"foo": list("abcdef")}), lazy=True)
 
     # test that original dataframe dtypes are preserved
-    assert (df.dtypes == Float.str_alias).all()
+    float_alias = str(PandasEngine.dtype(float))
+    assert (df.dtypes == float_alias).all()
 
-    # test case where pandas_dtype is string
-    schema.pandas_dtype = str
-    assert (schema(df).dtypes == "object").all()
-
-    schema.pandas_dtype = PandasDtype.String
-    assert (schema(df).dtypes == "object").all()
-
-    # raises ValueError if _coerce_dtype is called when pandas_dtype is None
-    schema.pandas_dtype = None
+    # raises ValueError if _coerce_dtype is called when dtype is None
+    print("---")
+    schema.dtype = None
+    print("----=-")
+    print(schema.dtype)
     with pytest.raises(ValueError):
         schema._coerce_dtype(df)
 
     # test setting coerce as false at the dataframe level no longer coerces
     # columns to int
     schema.coerce = False
-    assert (schema(df).dtypes == "float64").all()
+    pd_dtypes = [
+        PandasEngine.dtype(pd_dtype) for pd_dtype in schema(df).dtypes
+    ]
+    assert all(pd_dtype == PandasEngine.dtype(float) for pd_dtype in pd_dtypes)
 
 
 def test_dataframe_coerce_regex():
     """Test dataframe pandas dtype coercion for regex columns"""
     schema = DataFrameSchema(
         columns={"column_": Column(float, regex=True, required=False)},
-        pandas_dtype=int,
+        dtype=int,
         coerce=True,
     )
 
@@ -247,15 +245,15 @@ def test_dataframe_reset_column_name():
     [
         (
             {
-                "a": Column(Int, required=False),
-                "b": Column(Int, required=False),
+                "a": Column(int, required=False),
+                "b": Column(int, required=False),
             },
             None,
         ),
         (
             None,
             MultiIndex(
-                indexes=[Index(Int, name="a"), Index(Int, name="b")],
+                indexes=[Index(int, name="a"), Index(int, name="b")],
             ),
         ),
     ],
@@ -313,15 +311,19 @@ def test_series_schema():
     SeriesSchema("int").validate(pd.Series([1, 2, 3]))
 
     int_schema = SeriesSchema(
-        Int, Check(lambda x: 0 <= x <= 100, element_wise=True)
+        int, Check(lambda x: 0 <= x <= 100, element_wise=True)
     )
     assert isinstance(
         int_schema.validate(pd.Series([0, 30, 50, 100])), pd.Series
     )
 
+    def f(s):
+        print(s)
+        return s.isin(["foo", "bar", "baz"])
+
     str_schema = SeriesSchema(
-        String,
-        Check(lambda s: s.isin(["foo", "bar", "baz"])),
+        str,
+        Check(f),
         nullable=True,
         coerce=True,
     )
@@ -342,21 +344,18 @@ def test_series_schema():
         with pytest.raises(TypeError):
             int_schema.validate(TypeError)
 
-    non_duplicate_schema = SeriesSchema(Int, allow_duplicates=False)
+    non_duplicate_schema = SeriesSchema(int, allow_duplicates=False)
     with pytest.raises(errors.SchemaError):
         non_duplicate_schema.validate(pd.Series([0, 1, 2, 3, 4, 1]))
 
     # when series name doesn't match schema
-    named_schema = SeriesSchema(Int, name="my_series")
+    named_schema = SeriesSchema(int, name="my_series")
     with pytest.raises(errors.SchemaError, match=r"^Expected .+ to have name"):
         named_schema.validate(pd.Series(range(5), name="your_series"))
 
     # when series floats are declared to be integer
-    with pytest.raises(
-        errors.SchemaError,
-        match=r"^after dropping null values, expected values in series",
-    ):
-        SeriesSchema(Int, nullable=True).validate(
+    with pytest.raises(errors.SchemaError):
+        SeriesSchema(int, nullable=True).validate(
             pd.Series([1.1, 2.3, 5.5, np.nan])
         )
 
@@ -365,7 +364,7 @@ def test_series_schema():
         errors.SchemaError,
         match=r"^non-nullable series .+ contains null values",
     ):
-        SeriesSchema(Float, nullable=False).validate(
+        SeriesSchema(float, nullable=False).validate(
             pd.Series([1.1, 2.3, 5.5, np.nan])
         )
 
@@ -374,7 +373,7 @@ def test_series_schema():
         errors.SchemaError,
         match="Error while coercing",
     ):
-        SeriesSchema(Float, coerce=True).validate(pd.Series(list("abcdefg")))
+        SeriesSchema(float, coerce=True).validate(pd.Series(list("abcdefg")))
 
 
 def test_series_schema_checks():
@@ -401,7 +400,7 @@ def test_series_schema_multiple_validators():
     """Tests how multiple Checks on a Series Schema are handled both
     successfully and when errors are expected."""
     schema = SeriesSchema(
-        Int,
+        int,
         [
             Check(lambda x: 0 <= x <= 50, element_wise=True),
             Check(lambda s: (s == 21).any()),
@@ -419,18 +418,18 @@ def test_series_schema_multiple_validators():
 def test_series_schema_with_index(coerce):
     """Test SeriesSchema with Index and MultiIndex components."""
     schema_with_index = SeriesSchema(
-        pandas_dtype=Int,
-        index=Index(Int, coerce=coerce),
+        dtype=int,
+        index=Index(int, coerce=coerce),
     )
     validated_series = schema_with_index(pd.Series([1, 2, 3], index=[1, 2, 3]))
     assert isinstance(validated_series, pd.Series)
 
     schema_with_multiindex = SeriesSchema(
-        pandas_dtype=Int,
+        dtype=int,
         index=MultiIndex(
             [
-                Index(Int, coerce=coerce),
-                Index(String, coerce=coerce),
+                Index(int, coerce=coerce),
+                Index(str, coerce=coerce),
             ]
         ),
     )
@@ -486,8 +485,8 @@ def test_dataframe_schema_check_function_types(check_function, should_fail):
     """Tests a DataFrameSchema against a variety of Check conditions."""
     schema = DataFrameSchema(
         {
-            "a": Column(Int, Check(check_function, element_wise=False)),
-            "b": Column(Float, Check(check_function, element_wise=False)),
+            "a": Column(int, Check(check_function, element_wise=False)),
+            "b": Column(float, Check(check_function, element_wise=False)),
         }
     )
     df = pd.DataFrame({"a": [1, 2, 3], "b": [1.1, 2.5, 9.9]})
@@ -496,19 +495,6 @@ def test_dataframe_schema_check_function_types(check_function, should_fail):
             schema.validate(df)
     else:
         schema.validate(df)
-
-
-def test_nullable_int_in_dataframe():
-    """Tests handling of nullability when datatype is integers."""
-    df = pd.DataFrame({"column1": [5, 1, np.nan]})
-    null_schema = DataFrameSchema(
-        {"column1": Column(Int, Check(lambda x: x > 0), nullable=True)}
-    )
-    assert isinstance(null_schema.validate(df), pd.DataFrame)
-
-    # test case where column is an object
-    df = df.astype({"column1": "object"})
-    assert isinstance(null_schema.validate(df), pd.DataFrame)
 
 
 def test_coerce_dtype_in_dataframe():
@@ -524,102 +510,36 @@ def test_coerce_dtype_in_dataframe():
     # specify `coerce` at the Column level
     schema1 = DataFrameSchema(
         {
-            "column1": Column(Int, Check(lambda x: x > 0), coerce=True),
-            "column2": Column(DateTime, coerce=True),
-            "column3": Column(String, coerce=True, nullable=True),
+            "column1": Column(int, Check(lambda x: x > 0), coerce=True),
+            "column2": Column(datetime, coerce=True),
         }
     )
     # specify `coerce` at the DataFrameSchema level
     schema2 = DataFrameSchema(
         {
-            "column1": Column(Int, Check(lambda x: x > 0)),
-            "column2": Column(DateTime),
-            "column3": Column(String, nullable=True),
+            "column1": Column(int, Check(lambda x: x > 0)),
+            "column2": Column(datetime),
         },
         coerce=True,
     )
 
     for schema in [schema1, schema2]:
         result = schema.validate(df)
-        assert result.column1.dtype == Int.str_alias
-        assert result.column2.dtype == DateTime.str_alias
-        for _, x in result.column3.iteritems():
-            assert pd.isna(x) or isinstance(x, str)
+        column1_datatype = PandasEngine.dtype(result.column1.dtype)
+        assert column1_datatype == PandasEngine.dtype(int)
+
+        column2_datatype = PandasEngine.dtype(result.column2.dtype)
+        assert column2_datatype == PandasEngine.dtype(datetime)
 
         # make sure that correct error is raised when null values are present
         # in a float column that's coerced to an int
-        schema = DataFrameSchema({"column4": Column(Int, coerce=True)})
+        schema = DataFrameSchema({"column4": Column(int, coerce=True)})
         with pytest.raises(
             errors.SchemaError,
             match=r"^Error while coercing .* to type u{0,1}int[0-9]{1,2}: "
             r"Cannot convert non-finite values \(NA or inf\) to integer",
         ):
             schema.validate(df)
-
-
-@pytest.mark.parametrize(
-    "data, dtype, nonnull_idx",
-    [
-        # some values are null
-        [["foobar", "foo", "bar", "baz", np.nan, np.nan], str, 4],
-        [["foobar", "foo", "bar", "baz", None, None], str, 4],
-        # some values are null, non-null values are not strings
-        [[1.0, 2.0, 3.0, 4.0, np.nan, np.nan], float, 4],
-        [[1, 2, 3, 4, None, None], "Int64", 4],
-        # all values are null
-        [[np.nan] * 6, object, 0],
-        [[None] * 6, object, 0],
-        [[np.nan] * 6, float, 0],
-        [[None] * 6, float, 0],
-    ],
-)
-@pytest.mark.parametrize("string_type", [String, str, "str", STRING, "string"])
-@pytest.mark.parametrize("nullable", [True, False])
-def test_coerce_dtype_nullable_str(
-    data, dtype, nonnull_idx, string_type, nullable
-):
-    """Tests how null values are handled with string dtypes."""
-    if LEGACY_PANDAS and (
-        dtype == "Int64" or string_type in {STRING, "string"}
-    ):
-        pytest.skip("Skipping data types that depend on pandas>1.0.0")
-    dataframe = pd.DataFrame({"col": pd.Series(data, dtype=dtype)})
-    schema = DataFrameSchema(
-        {"col": Column(string_type, coerce=True, nullable=nullable)}
-    )
-
-    if not nullable:
-        with pytest.raises(errors.SchemaError):
-            schema.validate(dataframe)
-        return
-
-    validated_df = schema.validate(dataframe)
-    assert isinstance(validated_df, pd.DataFrame)
-    for i, element in validated_df["col"].iteritems():
-        if i < nonnull_idx:
-            assert isinstance(element, str)
-        else:
-            assert pd.isna(element)
-
-
-@pytest.mark.parametrize(
-    "data, expected_type",
-    [
-        [{"a": 1, "b": 2, "c": 3}, dict],
-        [[1, 2, 3, 4], list],
-        [[1, {"a": 5}], list],
-        [{1, 2, 3}, set],
-    ],
-)
-@pytest.mark.parametrize("dtype", ["object", object, Object])
-def test_coerce_object_dtype(data, expected_type, dtype):
-    """Test coercing on object dtype."""
-    schema = DataFrameSchema({"col": Column(dtype)}, coerce=True)
-    df = pd.DataFrame({"col": [data] * 3})
-    validated_df = schema(df)
-    assert isinstance(validated_df, pd.DataFrame)
-    for _, x in validated_df["col"].iteritems():
-        assert isinstance(x, expected_type)
 
 
 def test_no_dtype_dataframe():
@@ -672,7 +592,7 @@ def test_required():
     isn't available.
     """
     schema = DataFrameSchema(
-        {"col1": Column(Int, required=False), "col2": Column(String)}
+        {"col1": Column(int, required=False), "col2": Column(str)}
     )
 
     df_ok_1 = pd.DataFrame({"col2": ["hello", "world"]})
@@ -725,7 +645,7 @@ def test_head_dataframe_schema():
     )
 
     schema = DataFrameSchema(
-        columns={"col1": Column(Int, Check(lambda s: s >= 0))}
+        columns={"col1": Column(int, Check(lambda s: s >= 0))}
     )
 
     # Validating with head of 100 should pass
@@ -741,7 +661,7 @@ def test_tail_dataframe_schema():
     )
 
     schema = DataFrameSchema(
-        columns={"col1": Column(Int, Check(lambda s: s < 0))}
+        columns={"col1": Column(int, Check(lambda s: s < 0))}
     )
 
     # Validating with tail of 1000 should pass
@@ -756,7 +676,7 @@ def test_sample_dataframe_schema():
 
     # assert all values -1
     schema = DataFrameSchema(
-        columns={"col1": Column(Int, Check(lambda s: s == -1))}
+        columns={"col1": Column(int, Check(lambda s: s == -1))}
     )
 
     for seed in [11, 123456, 9000, 654]:
@@ -770,11 +690,11 @@ def test_dataframe_schema_str_repr():
     printing/logging of a DataFrameSchema."""
     schema = DataFrameSchema(
         columns={
-            "col1": Column(Int),
-            "col2": Column(String),
-            "col3": Column(DateTime),
+            "col1": Column(int),
+            "col2": Column(str),
+            "col3": Column(datetime),
         },
-        index=Index(Int, name="my_index"),
+        index=Index(int, name="my_index"),
     )
 
     for x in [schema.__str__(), schema.__repr__()]:
@@ -788,26 +708,18 @@ def test_dataframe_schema_dtype_property():
     """Test that schema.dtype returns the matching Column types."""
     schema = DataFrameSchema(
         columns={
-            "col1": Column(Int),
-            "col2": Column(String),
-            "col3": Column(STRING),
-            "col4": Column(DateTime),
-            "col5": Column("uint16"),
+            "col1": Column(int),
+            "col2": Column(str),
+            "col3": Column(datetime),
+            "col4": Column("uint16"),
         }
     )
-    assert schema.dtype == {
-        "col1": "int64",
-        "col2": "object",
-        "col3": ("object" if LEGACY_PANDAS else "string"),
-        "col4": "datetime64[ns]",
-        "col5": "uint16",
+    assert schema.dtypes == {
+        "col1": PandasEngine.dtype("int64"),
+        "col2": PandasEngine.dtype("str"),
+        "col3": PandasEngine.dtype("datetime64[ns]"),
+        "col4": PandasEngine.dtype("uint16"),
     }
-
-
-@pytest.mark.parametrize("pandas_dtype, expected", TESTABLE_DTYPES)
-def test_series_schema_dtype_property(pandas_dtype, expected):
-    """Tests every type of allowed dtype."""
-    assert SeriesSchema(pandas_dtype).dtype == expected
 
 
 def test_schema_equality_operators():
@@ -815,33 +727,33 @@ def test_schema_equality_operators():
     SeriesSchemaBase."""
     df_schema = DataFrameSchema(
         {
-            "col1": Column(Int, Check(lambda s: s >= 0)),
-            "col2": Column(String, Check(lambda s: s >= 2)),
+            "col1": Column(int, Check(lambda s: s >= 0)),
+            "col2": Column(str, Check(lambda s: s >= 2)),
         },
         strict=True,
     )
     df_schema_columns_in_different_order = DataFrameSchema(
         {
-            "col2": Column(String, Check(lambda s: s >= 2)),
-            "col1": Column(Int, Check(lambda s: s >= 0)),
+            "col2": Column(str, Check(lambda s: s >= 2)),
+            "col1": Column(int, Check(lambda s: s >= 0)),
         },
         strict=True,
     )
     series_schema = SeriesSchema(
-        String,
+        str,
         checks=[Check(lambda s: s.str.startswith("foo"))],
         nullable=False,
         allow_duplicates=True,
         name="my_series",
     )
     series_schema_base = SeriesSchemaBase(
-        String,
+        str,
         checks=[Check(lambda s: s.str.startswith("foo"))],
         nullable=False,
         allow_duplicates=True,
         name="my_series",
     )
-    not_equal_schema = DataFrameSchema({"col1": Column(String)}, strict=False)
+    not_equal_schema = DataFrameSchema({"col1": Column(str)}, strict=False)
 
     assert df_schema == copy.deepcopy(df_schema)
     assert df_schema != not_equal_schema
@@ -857,7 +769,7 @@ def test_add_and_remove_columns():
     modify the original underlying DataFrameSchema."""
     schema1 = DataFrameSchema(
         {
-            "col1": Column(Int, Check(lambda s: s >= 0)),
+            "col1": Column(int, Check(lambda s: s >= 0)),
         },
         strict=True,
     )
@@ -867,8 +779,8 @@ def test_add_and_remove_columns():
     # test that add_columns doesn't modify schema1 after add_columns:
     schema2 = schema1.add_columns(
         {
-            "col2": Column(String, Check(lambda x: x <= 0)),
-            "col3": Column(Object, Check(lambda x: x == 0)),
+            "col2": Column(str, Check(lambda x: x <= 0)),
+            "col3": Column(object, Check(lambda x: x == 0)),
         }
     )
 
@@ -879,9 +791,9 @@ def test_add_and_remove_columns():
     # test that add_columns changed schema1 into schema2:
     expected_schema_2 = DataFrameSchema(
         {
-            "col1": Column(Int, Check(lambda s: s >= 0)),
-            "col2": Column(String, Check(lambda x: x <= 0)),
-            "col3": Column(Object, Check(lambda x: x == 0)),
+            "col1": Column(int, Check(lambda s: s >= 0)),
+            "col2": Column(str, Check(lambda x: x <= 0)),
+            "col3": Column(object, Check(lambda x: x == 0)),
         },
         strict=True,
     )
@@ -896,8 +808,8 @@ def test_add_and_remove_columns():
     # test that remove_columns has removed the changes as expected:
     expected_schema_3 = DataFrameSchema(
         {
-            "col1": Column(Int, Check(lambda s: s >= 0)),
-            "col3": Column(Object, Check(lambda x: x == 0)),
+            "col1": Column(int, Check(lambda s: s >= 0)),
+            "col3": Column(object, Check(lambda x: x == 0)),
         },
         strict=True,
     )
@@ -908,7 +820,7 @@ def test_add_and_remove_columns():
     schema4 = schema2.remove_columns(["col2", "col3"])
 
     expected_schema_4 = DataFrameSchema(
-        {"col1": Column(Int, Check(lambda s: s >= 0))}, strict=True
+        {"col1": Column(int, Check(lambda s: s >= 0))}, strict=True
     )
 
     assert schema4 == expected_schema_4 == schema1
@@ -922,8 +834,8 @@ def test_schema_get_dtype():
     """Test that schema dtype and get_dtype methods handle regex columns."""
     schema = DataFrameSchema(
         {
-            "col1": Column(Int),
-            "var*": Column(Float, regex=True),
+            "col1": Column(int),
+            "var*": Column(float, regex=True),
         }
     )
 
@@ -937,7 +849,7 @@ def test_schema_get_dtype():
     )
 
     with pytest.warns(UserWarning) as record:
-        assert schema.dtype == {"col1": Int.str_alias}
+        assert schema.dtypes == {"col1": PandasEngine.dtype(int)}
     assert len(record) == 1
     assert (
         record[0]
@@ -945,11 +857,11 @@ def test_schema_get_dtype():
         .startswith("Schema has columns specified as regex column names:")
     )
 
-    assert schema.get_dtype(data) == {
-        "col1": Int.str_alias,
-        "var1": Float.str_alias,
-        "var2": Float.str_alias,
-        "var3": Float.str_alias,
+    assert schema.get_dtypes(data) == {
+        "col1": PandasEngine.dtype(int),
+        "var1": PandasEngine.dtype(float),
+        "var2": PandasEngine.dtype(float),
+        "var3": PandasEngine.dtype(float),
     }
 
 
@@ -959,7 +871,7 @@ def _boolean_update_column_case(bool_kwarg):
         assert getattr(new_schema.columns["col"], bool_kwarg)
 
     return [
-        Column(Int, **{bool_kwarg: False}),
+        Column(int, **{bool_kwarg: False}),
         "col",
         {bool_kwarg: True},
         _assert_bool_case,
@@ -970,12 +882,12 @@ def _boolean_update_column_case(bool_kwarg):
     "column, column_to_update, update, assertion_fn",
     [
         [
-            Column(Int),
+            Column(int),
             "col",
-            {"pandas_dtype": String},
+            {"dtype": str},
             lambda old, new: [
-                old.columns["col"].pandas_dtype is Int,
-                new.columns["col"].pandas_dtype is String,
+                old.columns["col"].dtype is int,
+                new.columns["col"].dtype is str,
             ],
         ],
         *[
@@ -989,7 +901,7 @@ def _boolean_update_column_case(bool_kwarg):
             ]
         ],
         [
-            Column(Int, checks=Check.greater_than(0)),
+            Column(int, checks=Check.greater_than(0)),
             "col",
             {"checks": Check.less_than(10)},
             lambda old, new: [
@@ -998,8 +910,8 @@ def _boolean_update_column_case(bool_kwarg):
             ],
         ],
         # error cases
-        [Column(Int), "col", {"name": "renamed_col"}, ValueError],
-        [Column(Int), "foobar", {}, ValueError],
+        [Column(int), "col", {"name": "renamed_col"}, ValueError],
+        [Column(int), "foobar", {}, ValueError],
     ],
 )
 def test_dataframe_schema_update_column(
@@ -1021,7 +933,7 @@ def test_rename_columns():
 
     rename_dict = {"col1": "col1_new_name", "col2": "col2_new_name"}
     schema_original = DataFrameSchema(
-        columns={"col1": Column(Int), "col2": Column(Float)}
+        columns={"col1": Column(int), "col2": Column(float)}
     )
 
     schema_renamed = schema_original.rename_columns(rename_dict)
@@ -1049,9 +961,9 @@ def test_rename_columns():
             ["col1", "col2"],
             DataFrameSchema(
                 columns={
-                    "col1": Column(Int),
-                    "col2": Column(Int),
-                    "col3": Column(Int),
+                    "col1": Column(int),
+                    "col2": Column(int),
+                    "col3": Column(int),
                 }
             ),
         ),
@@ -1059,10 +971,10 @@ def test_rename_columns():
             [("col1", "col1b"), ("col2", "col2b")],
             DataFrameSchema(
                 columns={
-                    ("col1", "col1a"): Column(Int),
-                    ("col1", "col1b"): Column(Int),
-                    ("col2", "col2a"): Column(Int),
-                    ("col2", "col2b"): Column(Int),
+                    ("col1", "col1a"): Column(int),
+                    ("col1", "col1b"): Column(int),
+                    ("col2", "col2a"): Column(int),
+                    ("col2", "col2b"): Column(int),
                 }
             ),
         ),
@@ -1083,16 +995,16 @@ def test_lazy_dataframe_validation_error():
     """Test exceptions on lazy dataframe validation."""
     schema = DataFrameSchema(
         columns={
-            "int_col": Column(Int, Check.greater_than(5)),
-            "int_col2": Column(Int),
-            "float_col": Column(Float, Check.less_than(0)),
-            "str_col": Column(String, Check.isin(["foo", "bar"])),
-            "not_in_dataframe": Column(Int),
+            "int_col": Column(int, Check.greater_than(5)),
+            "int_col2": Column(int),
+            "float_col": Column(float, Check.less_than(0)),
+            "str_col": Column(str, Check.isin(["foo", "bar"])),
+            "not_in_dataframe": Column(int),
         },
         checks=Check(
             lambda df: df != 1, error="dataframe_not_equal_1", ignore_na=False
         ),
-        index=Index(String, name="str_index"),
+        index=Index(str, name="str_index"),
         strict=True,
     )
 
@@ -1117,7 +1029,7 @@ def test_lazy_dataframe_validation_error():
         },
         "Column": {
             "greater_than(5)": [1, 2],
-            "pandas_dtype('int64')": ["object"],
+            "dtype('int64')": ["object"],
             "less_than(0)": [1, 3],
         },
     }
@@ -1156,9 +1068,9 @@ def test_lazy_dataframe_validation_nullable():
     """
     schema = DataFrameSchema(
         columns={
-            "int_column": Column(Int, nullable=False),
-            "float_column": Column(Float, nullable=False),
-            "str_column": Column(String, nullable=False),
+            "int_column": Column(int, nullable=False),
+            "float_column": Column(float, nullable=False),
+            "str_column": Column(str, nullable=False),
         },
         strict=True,
     )
@@ -1233,7 +1145,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
             {
                 "data": pd.Series([0.1]),
                 "schema_errors": {
-                    "SeriesSchema": {"pandas_dtype('int64')": ["float64"]},
+                    "SeriesSchema": {"dtype('int64')": ["float64"]},
                 },
             },
         ],
@@ -1244,7 +1156,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
             {
                 "data": pd.Series([1, 2, 3], index=list("abc")),
                 "schema_errors": {
-                    "Index": {"pandas_dtype('int64')": ["object"]},
+                    "Index": {"dtype('int64')": ["object"]},
                 },
             },
         ],
@@ -1256,7 +1168,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
                 "data": pd.Series(["1", "foo", "bar"]),
                 "schema_errors": {
                     "SeriesSchema": {
-                        "pandas_dtype('float64')": ["object"],
+                        "dtype('float64')": ["object"],
                         "coerce_dtype('float64')": ["object"],
                     },
                 },
@@ -1289,7 +1201,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
                             # TypeError raised in python=3.5
                             'TypeError("unorderable types: str() > int()")',
                         ],
-                        "pandas_dtype('int64')": ["object"],
+                        "dtype('int64')": ["object"],
                     },
                 },
             },
@@ -1297,7 +1209,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
         # case: multiple series checks don't satisfy schema
         [
             Column(
-                Int,
+                int,
                 checks=[Check.greater_than(1), Check.less_than(3)],
                 name="column",
             ),
@@ -1310,7 +1222,7 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
             },
         ],
         [
-            Index(String, checks=Check.isin(["a", "b", "c"])),
+            Index(str, checks=Check.isin(["a", "b", "c"])),
             pd.DataFrame({"col": [1, 2, 3]}, index=["a", "b", "d"]),
             {
                 # expect that the data in the SchemaError is the pd.Index cast
@@ -1324,8 +1236,8 @@ def test_lazy_dataframe_scalar_false_check(schema_cls, data):
         [
             MultiIndex(
                 indexes=[
-                    Index(Int, checks=Check.greater_than(0), name="index0"),
-                    Index(Int, checks=Check.less_than(0), name="index1"),
+                    Index(int, checks=Check.greater_than(0), name="index0"),
+                    Index(int, checks=Check.less_than(0), name="index1"),
                 ]
             ),
             pd.DataFrame(
@@ -1401,10 +1313,6 @@ def test_schema_transformer_deprecated():
 )
 def test_schema_coerce_inplace_validation(inplace, from_dtype, to_dtype):
     """Test coercion logic for validation when inplace is True and False"""
-
-    to_dtype = PandasDtype.from_python_type(to_dtype).str_alias
-    from_dtype = PandasDtype.from_python_type(from_dtype).str_alias
-
     df = pd.DataFrame({"column": pd.Series([1, 2, 6], dtype=from_dtype)})
     schema = DataFrameSchema({"column": Column(to_dtype, coerce=True)})
     validated_df = schema.validate(df, inplace=inplace)
@@ -1423,10 +1331,10 @@ def schema_simple():
     """Simple schema fixture."""
     schema = DataFrameSchema(
         columns={
-            "col1": Column(pandas_dtype=Int),
-            "col2": Column(pandas_dtype=Float),
+            "col1": Column(dtype=int),
+            "col2": Column(dtype=float),
         },
-        index=Index(pandas_dtype=String, name="ind0"),
+        index=Index(dtype=str, name="ind0"),
     )
     return schema
 
@@ -1436,13 +1344,13 @@ def schema_multiindex():
     """Fixture for schema with MultiIndex."""
     schema = DataFrameSchema(
         columns={
-            "col1": Column(pandas_dtype=Int),
-            "col2": Column(pandas_dtype=Float),
+            "col1": Column(dtype=int),
+            "col2": Column(dtype=float),
         },
         index=MultiIndex(
             [
-                Index(pandas_dtype=String, name="ind0"),
-                Index(pandas_dtype=String, name="ind1"),
+                Index(dtype=str, name="ind0"),
+                Index(dtype=str, name="ind1"),
             ]
         ),
     )
@@ -1524,51 +1432,43 @@ def test_update_columns(schema_simple):
     """Catch-all test for update columns functionality"""
 
     # Basic function
-    test_schema = schema_simple.update_columns({"col2": {"pandas_dtype": Int}})
+    test_schema = schema_simple.update_columns({"col2": {"dtype": int}})
     assert (
         schema_simple.columns["col1"].properties
         == test_schema.columns["col1"].properties
     )
-    assert test_schema.columns["col2"].pandas_dtype == Int
+    assert test_schema.columns["col2"].dtype == PandasEngine.dtype(int)
 
     # Multiple columns, multiple properties
     test_schema = schema_simple.update_columns(
         {
-            "col1": {"pandas_dtype": Category, "coerce": True},
-            "col2": {"pandas_dtype": Int, "allow_duplicates": False},
+            "col1": {"dtype": Category, "coerce": True},
+            "col2": {"dtype": int, "allow_duplicates": False},
         }
     )
-    assert test_schema.columns["col1"].pandas_dtype == Category
+    assert test_schema.columns["col1"].dtype == PandasEngine.dtype(Category)
     assert test_schema.columns["col1"].coerce is True
-    assert test_schema.columns["col2"].pandas_dtype == Int
+    assert test_schema.columns["col2"].dtype == PandasEngine.dtype(int)
     assert test_schema.columns["col2"].allow_duplicates is False
 
     # Errors
     with pytest.raises(errors.SchemaInitError):
-        schema_simple.update_columns({"col3": {"pandas_dtype": Int}})
+        schema_simple.update_columns({"col3": {"dtype": int}})
     with pytest.raises(errors.SchemaInitError):
         schema_simple.update_columns({"col1": {"name": "foo"}})
     with pytest.raises(errors.SchemaInitError):
-        schema_simple.update_columns({"ind0": {"pandas_dtype": Int}})
+        schema_simple.update_columns({"ind0": {"dtype": int}})
 
 
-@pytest.mark.parametrize("pdtype", list(PandasDtype) + [None])  # type: ignore
-def test_series_schema_pdtype(pdtype):
-    """Series schema pdtype property should return PandasDtype."""
-    if pdtype is None:
-        series_schema = SeriesSchema(pdtype)
-        assert series_schema.pdtype is None
-        return
-    for pandas_dtype_input in [
-        pdtype,
-        pdtype.str_alias,
-        pdtype.value,
-    ]:
-        series_schema = SeriesSchema(pandas_dtype_input)
-        if pdtype is PandasDtype.STRING and LEGACY_PANDAS:
-            assert series_schema.pdtype == PandasDtype.String
-        else:
-            assert series_schema.pdtype == pdtype
+@pytest.mark.parametrize("dtype", [int, None])  # type: ignore
+def test_series_schema_dtype(dtype):
+    """Series schema dtype property should return
+    a PandasEngine-compatible dtype."""
+    if dtype is None:
+        series_schema = SeriesSchema(dtype)
+        assert series_schema.dtype is None
+    else:
+        assert SeriesSchema(dtype).dtype == PandasEngine.dtype(dtype)
 
 
 @pytest.mark.parametrize(
@@ -1613,7 +1513,7 @@ def test_dataframe_duplicated_columns(data, error, schema):
                 columns={"col": Column(int)},
                 checks=Check.gt(0),
                 index=Index(int),
-                pandas_dtype=int,
+                dtype=int,
                 coerce=True,
                 strict=True,
                 name="schema",
@@ -1623,7 +1523,7 @@ def test_dataframe_duplicated_columns(data, error, schema):
                 "columns",
                 "checks",
                 "index",
-                "pandas_dtype",
+                "dtype",
                 "coerce",
                 "strict",
                 "name",

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -8,7 +8,8 @@ import pandas as pd
 import pytest
 
 import pandera as pa
-from pandera.dtypes import LEGACY_PANDAS, PandasDtype
+from pandera.dtypes_ import DataType
+from pandera.engines.pandas_engine import PandasEngine
 from pandera.typing import LEGACY_TYPING, Series
 
 if not LEGACY_TYPING:
@@ -127,7 +128,7 @@ class SchemaUINT64(pa.SchemaModel):
 
 
 def _test_literal_pandas_dtype(
-    model: Type[pa.SchemaModel], pandas_dtype: PandasDtype
+    model: Type[pa.SchemaModel], pandas_dtype: DataType
 ):
     schema = model.to_schema()
     expected = pa.Column(pandas_dtype, name="col").dtype
@@ -159,13 +160,12 @@ def _test_literal_pandas_dtype(
     ],
 )
 def test_literal_legacy_pandas_dtype(
-    model: Type[pa.SchemaModel], pandas_dtype: PandasDtype
+    model: Type[pa.SchemaModel], pandas_dtype: DataType
 ):
     """Test literal annotations with the legacy pandas dtypes."""
     _test_literal_pandas_dtype(model, pandas_dtype)
 
 
-@pytest.mark.skipif(LEGACY_PANDAS, reason="pandas >= 1.0.0 required")
 @pytest.mark.parametrize(
     "model, pandas_dtype",
     [
@@ -180,7 +180,7 @@ def test_literal_legacy_pandas_dtype(
     ],
 )
 def test_literal_new_pandas_dtype(
-    model: Type[pa.SchemaModel], pandas_dtype: PandasDtype
+    model: Type[pa.SchemaModel], pandas_dtype: DataType
 ):
     """Test literal annotations with the new nullable pandas dtypes."""
     _test_literal_pandas_dtype(model, pandas_dtype)
@@ -377,58 +377,65 @@ if not LEGACY_TYPING:
             SchemaRedundantField.to_schema()
 
 
-if not LEGACY_PANDAS:
+class SchemaInt8Dtype(pa.SchemaModel):
+    col: Series[pd.Int8Dtype]
 
-    class SchemaInt8Dtype(pa.SchemaModel):
-        col: Series[pd.Int8Dtype]
 
-    class SchemaInt16Dtype(pa.SchemaModel):
-        col: Series[pd.Int16Dtype]
+class SchemaInt16Dtype(pa.SchemaModel):
+    col: Series[pd.Int16Dtype]
 
-    class SchemaInt32Dtype(pa.SchemaModel):
-        col: Series[pd.Int32Dtype]
 
-    class SchemaInt64Dtype(pa.SchemaModel):
-        col: Series[pd.Int64Dtype]
+class SchemaInt32Dtype(pa.SchemaModel):
+    col: Series[pd.Int32Dtype]
 
-    class SchemaUInt8Dtype(pa.SchemaModel):
-        col: Series[pd.UInt8Dtype]
 
-    class SchemaUInt16Dtype(pa.SchemaModel):
-        col: Series[pd.UInt16Dtype]
+class SchemaInt64Dtype(pa.SchemaModel):
+    col: Series[pd.Int64Dtype]
 
-    class SchemaUInt32Dtype(pa.SchemaModel):
-        col: Series[pd.UInt32Dtype]
 
-    class SchemaUInt64Dtype(pa.SchemaModel):
-        col: Series[pd.UInt64Dtype]
+class SchemaUInt8Dtype(pa.SchemaModel):
+    col: Series[pd.UInt8Dtype]
 
-    class SchemaStringDtype(pa.SchemaModel):
-        col: Series[pd.StringDtype]
 
-    class SchemaBooleanDtype(pa.SchemaModel):
-        col: Series[pd.BooleanDtype]
+class SchemaUInt16Dtype(pa.SchemaModel):
+    col: Series[pd.UInt16Dtype]
 
-    @pytest.mark.skipif(LEGACY_PANDAS, reason="pandas >= 1.0.0 required")
-    @pytest.mark.parametrize(
-        "model, dtype, has_mandatory_args",
-        [
-            (SchemaInt8Dtype, pd.Int8Dtype, False),
-            (SchemaInt16Dtype, pd.Int16Dtype, False),
-            (SchemaInt32Dtype, pd.Int32Dtype, False),
-            (SchemaInt64Dtype, pd.Int64Dtype, False),
-            (SchemaUInt8Dtype, pd.UInt8Dtype, False),
-            (SchemaUInt16Dtype, pd.UInt16Dtype, False),
-            (SchemaUInt32Dtype, pd.UInt32Dtype, False),
-            (SchemaUInt64Dtype, pd.UInt64Dtype, False),
-            (SchemaStringDtype, pd.StringDtype, False),
-            (SchemaBooleanDtype, pd.BooleanDtype, False),
-        ],
-    )
-    def test_new_pandas_extension_dtype_class(
-        model,
-        dtype: pd.core.dtypes.base.ExtensionDtype,
-        has_mandatory_args: bool,
-    ):
-        """Test type annotations with the new nullable pandas dtypes."""
-        _test_default_annotated_dtype(model, dtype, has_mandatory_args)
+
+class SchemaUInt32Dtype(pa.SchemaModel):
+    col: Series[pd.UInt32Dtype]
+
+
+class SchemaUInt64Dtype(pa.SchemaModel):
+    col: Series[pd.UInt64Dtype]
+
+
+class SchemaStringDtype(pa.SchemaModel):
+    col: Series[pd.StringDtype]
+
+
+class SchemaBooleanDtype(pa.SchemaModel):
+    col: Series[pd.BooleanDtype]
+
+
+@pytest.mark.parametrize(
+    "model, dtype, has_mandatory_args",
+    [
+        (SchemaInt8Dtype, pd.Int8Dtype, False),
+        (SchemaInt16Dtype, pd.Int16Dtype, False),
+        (SchemaInt32Dtype, pd.Int32Dtype, False),
+        (SchemaInt64Dtype, pd.Int64Dtype, False),
+        (SchemaUInt8Dtype, pd.UInt8Dtype, False),
+        (SchemaUInt16Dtype, pd.UInt16Dtype, False),
+        (SchemaUInt32Dtype, pd.UInt32Dtype, False),
+        (SchemaUInt64Dtype, pd.UInt64Dtype, False),
+        (SchemaStringDtype, pd.StringDtype, False),
+        (SchemaBooleanDtype, pd.BooleanDtype, False),
+    ],
+)
+def test_new_pandas_extension_dtype_class(
+    model,
+    dtype: pd.core.dtypes.base.ExtensionDtype,
+    has_mandatory_args: bool,
+):
+    """Test type annotations with the new nullable pandas dtypes."""
+    _test_default_annotated_dtype(model, dtype, has_mandatory_args)

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -9,7 +9,6 @@ import pytest
 
 import pandera as pa
 from pandera.dtypes_ import DataType
-from pandera.engines.pandas_engine import PandasEngine
 from pandera.typing import LEGACY_TYPING, Series
 
 if not LEGACY_TYPING:

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -614,3 +614,281 @@ def test_to_yaml_bugfix_419():
 
     with pytest.warns(UserWarning, match=".*registered checks.*"):
         CheckedSchemaModel.to_yaml()
+
+
+FRICTIONLESS_YAML = yaml.safe_load(
+    """
+fields:
+  - constraints:
+      maximum: 99
+      minimum: 10
+    name: integer_col
+    type: integer
+  - constraints:
+      maximum: 30
+    name: integer_col_2
+    type: integer
+  - constraints:
+      maxLength: 80
+      minLength: 3
+    name: string_col
+  - constraints:
+      pattern: \\d{3}[A-Z]
+    name: string_col_2
+  - constraints:
+      minLength: 3
+    name: string_col_3
+  - constraints:
+      maxLength: 3
+    name: string_col_4
+  - constraints:
+      enum:
+        - 1.0
+        - 2.0
+        - 3.0
+      required: true
+    name: float_col
+    type: number
+  - constraints:
+    name: float_col_2
+    type: number
+  - constraints:
+      minimum: "20201231"
+    name: date_col
+primaryKey: integer_col
+"""
+)
+
+FRICTIONLESS_JSON = {
+    "fields": [
+        {
+            "name": "integer_col",
+            "type": "integer",
+            "constraints": {"minimum": 10, "maximum": 99},
+        },
+        {
+            "name": "integer_col_2",
+            "type": "integer",
+            "constraints": {"maximum": 30},
+        },
+        {
+            "name": "string_col",
+            "constraints": {"maxLength": 80, "minLength": 3},
+        },
+        {
+            "name": "string_col_2",
+            "constraints": {"pattern": r"\d{3}[A-Z]"},
+        },
+        {
+            "name": "string_col_3",
+            "constraints": {"minLength": 3},
+        },
+        {
+            "name": "string_col_4",
+            "constraints": {"maxLength": 3},
+        },
+        {
+            "name": "float_col",
+            "type": "number",
+            "constraints": {"enum": [1.0, 2.0, 3.0], "required": True},
+        },
+        {
+            "name": "float_col_2",
+            "type": "number",
+        },
+        {
+            "name": "date_col",
+            "type": "date",
+            "constraints": {"minimum": "20201231"},
+        },
+    ],
+    "primaryKey": "integer_col",
+}
+
+# pandas dtype aliases to support testing across multiple pandas versions:
+STR_DTYPE = pa.dtypes.PandasDtype.from_str_alias("string").value
+STR_DTYPE_ALIAS = pa.dtypes.PandasDtype.from_str_alias("string").str_alias
+INT_DTYPE = pa.dtypes.PandasDtype.from_str_alias("int").value
+INT_DTYPE_ALIAS = pa.dtypes.PandasDtype.from_str_alias("int").str_alias
+
+YAML_FROM_FRICTIONLESS = f"""
+schema_type: dataframe
+version: {pa.__version__}
+columns:
+  integer_col:
+    pandas_dtype: {INT_DTYPE}
+    nullable: false
+    checks:
+      in_range:
+        min_value: 10
+        max_value: 99
+    allow_duplicates: false
+    coerce: true
+    required: true
+    regex: false
+  integer_col_2:
+    pandas_dtype: {INT_DTYPE}
+    nullable: true
+    checks:
+      less_than_or_equal_to: 30
+    allow_duplicates: true
+    coerce: true
+    required: true
+    regex: false
+  string_col:
+    pandas_dtype: {STR_DTYPE}
+    nullable: true
+    checks:
+      str_length:
+        min_value: 3
+        max_value: 80
+    allow_duplicates: true
+    coerce: true
+    required: true
+    regex: false
+  string_col_2:
+    pandas_dtype: {STR_DTYPE}
+    nullable: true
+    checks:
+      str_matches: ^\\d{{3}}[A-Z]$
+    allow_duplicates: true
+    coerce: true
+    required: true
+    regex: false
+  string_col_3:
+    pandas_dtype: {STR_DTYPE}
+    nullable: true
+    checks:
+      str_length: 3
+    allow_duplicates: true
+    coerce: true
+    required: true
+    regex: false
+  string_col_4:
+    pandas_dtype: {STR_DTYPE}
+    nullable: true
+    checks:
+      str_length: 3
+    allow_duplicates: true
+    coerce: true
+    required: true
+    regex: false
+  float_col:
+    pandas_dtype: category
+    nullable: false
+    checks:
+      isin:
+      - 1.0
+      - 2.0
+      - 3.0
+    allow_duplicates: true
+    coerce: true
+    required: true
+    regex: false
+  float_col_2:
+    pandas_dtype: float
+    nullable: true
+    checks: null
+    allow_duplicates: true
+    coerce: true
+    required: true
+    regex: false
+  date_col:
+    pandas_dtype: {STR_DTYPE}
+    nullable: true
+    checks:
+      greater_than_or_equal_to: '20201231'
+    allow_duplicates: true
+    coerce: true
+    required: true
+    regex: false
+checks: null
+index: null
+coerce: true
+strict: true
+"""
+
+VALID_FRICTIONLESS_DF = pd.DataFrame(
+    {
+        "integer_col": [10, 11, 12, 13, 14],
+        "integer_col_2": [1, 2, 3, 3, 1],
+        "string_col": ["aaa", None, "ccc", "ddd", "eee"],
+        "string_col_2": ["123A", "456B", None, "789C", "101D"],
+        "string_col_3": ["123ABC", "456B", None, "78a9C", "1A3F01D"],
+        "string_col_4": ["23A", "46B", None, "78C", "1D"],
+        "float_col": [1.0, 1.0, 1.0, 2.0, 3.0],
+        "float_col_2": [1, 1, None, 2, 3],
+        "date_col": [
+            "20210101",
+            "20210102",
+            "20210103",
+            "20210104",
+            "20210105",
+        ],
+    }
+)
+
+INVALID_FRICTIONLESS_DF = pd.DataFrame(
+    {
+        "integer_col": [1, 180, 12, 12, 18],
+        "integer_col_2": [10, 11, 12, 113, 14],
+        "string_col": ["a", "bbb", "ccc", "d" * 100, "eee"],
+        "string_col_2": ["123A", "456B", None, "789c", "101D"],
+        "string_col_3": ["1A", "456B", None, "789c", "101D"],
+        "string_col_4": ["123A", "4B", None, "c", "1D"],
+        "float_col": [1.0, 1.1, None, 3.0, 3.8],
+        "float_col_2": ["a", 1, None, 3.0, 3.8],
+        "unexpected_column": [1, 2, 3, 4, 5],
+    }
+)
+
+
+@pytest.mark.parametrize(
+    "frictionless_schema", [FRICTIONLESS_YAML, FRICTIONLESS_JSON]
+)
+def test_frictionless_schema_parses_correctly(frictionless_schema):
+    """Test parsing frictionless schema from yaml and json."""
+    schema = pa.io.from_frictionless_schema(frictionless_schema)
+
+    assert str(schema.to_yaml()).strip() == YAML_FROM_FRICTIONLESS.strip()
+
+    assert isinstance(
+        schema, pa.schemas.DataFrameSchema
+    ), "schema object not loaded successfully"
+
+    df = schema.validate(VALID_FRICTIONLESS_DF)
+    assert dict(df.dtypes) == {
+        "integer_col": INT_DTYPE_ALIAS,
+        "integer_col_2": INT_DTYPE_ALIAS,
+        "string_col": STR_DTYPE_ALIAS,
+        "string_col_2": STR_DTYPE_ALIAS,
+        "string_col_3": STR_DTYPE_ALIAS,
+        "string_col_4": STR_DTYPE_ALIAS,
+        "float_col": pd.CategoricalDtype(
+            categories=[1.0, 2.0, 3.0], ordered=False
+        ),
+        "float_col_2": "float64",
+        "date_col": STR_DTYPE_ALIAS,
+    }, "dtypes not parsed correctly from frictionless schema"
+
+    with pytest.raises(pa.errors.SchemaErrors) as err:
+        schema.validate(INVALID_FRICTIONLESS_DF, lazy=True)
+    # check we're capturing all errors according to the frictionless schema:
+    assert err.value.failure_cases[["check", "failure_case"]].fillna(
+        "NaN"
+    ).to_dict(orient="records") == [
+        {"check": "column_in_schema", "failure_case": "unexpected_column"},
+        {"check": "column_in_dataframe", "failure_case": "date_col"},
+        {"check": "coerce_dtype('float64')", "failure_case": "object"},
+        {"check": "no_duplicates", "failure_case": 12},
+        {"check": "less_than_or_equal_to(30)", "failure_case": 113},
+        {"check": "str_length(3, 80)", "failure_case": "a"},
+        {"check": "str_length(3, 80)", "failure_case": "d" * 100},
+        {
+            "check": "str_matches(re.compile('^\\\\d{3}[A-Z]$'))",
+            "failure_case": "789c",
+        },
+        {"check": "str_length(3, None)", "failure_case": "1A"},
+        {"check": "str_length(None, 3)", "failure_case": "123A"},
+        {"check": "not_nullable", "failure_case": "NaN"},
+    ], "validation failure cases not as expected"


### PR DESCRIPTION
This PR implements a dtype hierarchy that replaces `PandasDtype`, as discussed in #369.

## Goals of the refactor

* Decouple pandera and pandas dtypes: opening up to other dataframe-like data structures in the python ecosystem, such as Apache Spark, Apache Arrow and xarray.
* Built-in support for dynamic dtypes: e.g. categorical dtype implementations often have a ordered and categories arguments.
* Allow end-user to customize dtype coercion. For example, pass a date format, coerce ["oui", "non"] to boolean.

## Contract

From now on, I'm going to refer to numpy/pandas dtypes as `native dtypes` in contrast to pandera's `DataType`.

A `DataType` class implements the following contract:

1. Subclass `DataType`
2. `DataType.coerce` implements coercion logic that was previously located in `DataFrameSchema`.
3. `DataType.check` implements "equivalence" check between datatypes. The reason for not using `__eq__`  is that some dtypes are equivalents even if they are not represented by the same underlying pandas/numpy dtype. For example, Pandas represents numpy.str_` has a `numpy.object_`. Another example is to implement a `Number` datatype that is equivalent to `Float` and `Int`.
4. Implement `__hash__` and be immutable. Required for internal registry. In practice, datatypes are implemented via `dataclasses` which give us those properties for free.
5. `__str__` should return the native alias.

```python
class DataType:

    def coerce(self, obj: Any):
        """Coerce object to the dtype."""
        raise NotImplementedError()

    def check(self, datatype: "DataType") -> bool:
        """Validate that `datatype` is equivalent."""
        if not isinstance(datatype, DataType):
            return False
        return self == datatype

    def __hash__(self) -> int:
        """Must be implemented by subclasses."""

    def __str__(self) -> str:
        pass
```
A parallel class hierarchy implements a bridge interface to pandas and numpy dtypes: `PandasDataType`, `NumpyDataType` and their sub-classes. 

Pandera `DataType`s should not be instantiated directly. Instead, they are generated by a factory method `Engine.dtype()` (e.g `PandasEngine.dtype`) which can take any acceptable native dtype representations: string alias, builtin python types, pandas extension dtypes, numpy dtypes, etc. Basically anything that `pandera.Column` already accepts. `DataFrameSchema` holds an engine and delegates dtype translations to it.

Two engines are implemented:
* `PandasEngine`: full support for official pandas dtypes.
* `NumpyEngine`: only dtypes supported by pandas.

Numpy dtypes are supported by a `NumpyDataType` hierarchy so that we can validate pure numpy arrays in the future if we choose to do so. `NumpyEngine` has not been tested.

Moreover, only "abstract" DataType hierarchy should be exposed to end-users. Pandas/Numpy specifics should be kept to internals. Users should instead provide native dtypes to public api: e.g `pa.Column(pd.Int16Dtype)` or `pa.Column("Int16")`, 
not `pa.Column(pandera.engines.pandas_engine.PandasInt16)`! Exceptions are aliases such as `pa.INT, pa.STRING`, etc. provided for convenience and legacy reasons. 
^ Feel free to disagree :)

## Status of the implementation

New Pandera dtypes are kept in `dtypes_.py` at the moment in order to allow co-existence of refactored and non-refactored features. Pylint and Mypy will be very upset, waiting for feedbacks before sinking time into that fun part :clown_face:  Only tests related to refactored tests are expected to pass. 

 - [x] DataFrameSchema api
 - [x] SchemaModel api
 - [x] decorators
 - [ ] inference
 - [ ] schema_statistics
 - [ ] is_float(), is_continuous(), etc.
 - [ ] strategies
 - [ ] docstrings
 - [ ] documentation
 

## Breaking changes

* Dropped support for pandas 0.25
* No attempt to test on py3.6
* `DataFrameSchema.pdtype` renamed to `dtype`. Remove explicit reference to pandas. 
* `DataFrameSchema.dtype` renamed to `dtypes` and eturns a dict of `DataType`s instead of string aliases..
  - Better reflect pandas api: DataFrame has a `dtypes` property that return a dict of dtypes.
  - Now that dtypes are more powerful, it seems more intuitive to return them.
  - That change is further motivated by the fact that some parameterized datatypes cannot be distinguished by alias alone. For example, `str(pandas.CategoricalDtype(categories=["A", "B"])) == "category"`. 

## Ideas for future improvements

* Implement "meta" dtypes: `Nominal`, `Number`
* Implement `Date` and `Decimal` Datatype. Those are useful for compatibility with Parquet files via PyArrow.

Let's address questions and potential shortcomings before extending the refactor.