### PR TITLE
Decorator typing and enabling mypy on tests as well

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [BASIC]
 good-names=
+    F,
     logger,
     df,
     fn,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,6 @@
 import doctest
 import inspect
 import logging as pylogging
-import subprocess
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -17,6 +16,7 @@ import subprocess
 #
 import os
 import shutil
+import subprocess
 import sys
 
 from sphinx.util import logging

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -27,7 +27,7 @@ from .typing import AnnotationInfo
 Schemas = Union[schemas.DataFrameSchema, schemas.SeriesSchema]
 InputGetter = Union[str, int]
 OutputGetter = Union[str, int, Callable]
-F = TypeVar('F', bound=Callable)
+F = TypeVar("F", bound=Callable)
 
 
 def _get_fn_argnames(fn: Callable) -> List[str]:

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -11,8 +11,10 @@ from typing import (
     NoReturn,
     Optional,
     Tuple,
+    TypeVar,
     Union,
     cast,
+    overload,
 )
 
 import pandas as pd
@@ -25,6 +27,7 @@ from .typing import AnnotationInfo
 Schemas = Union[schemas.DataFrameSchema, schemas.SeriesSchema]
 InputGetter = Union[str, int]
 OutputGetter = Union[str, int, Callable]
+F = TypeVar('F', bound=Callable)
 
 
 def _get_fn_argnames(fn: Callable) -> List[str]:
@@ -81,7 +84,7 @@ def check_input(
     random_state: Optional[int] = None,
     lazy: bool = False,
     inplace: bool = False,
-) -> Callable:
+) -> Callable[[F], F]:
     # pylint: disable=duplicate-code
     """Validate function argument when function is called.
 
@@ -226,7 +229,7 @@ def check_output(
     random_state: Optional[int] = None,
     lazy: bool = False,
     inplace: bool = False,
-) -> Callable:
+) -> Callable[[F], F]:
     # pylint: disable=duplicate-code
     """Validate function output.
 
@@ -341,8 +344,8 @@ def check_io(
         Tuple[OutputGetter, Schemas],
         List[Tuple[OutputGetter, Schemas]],
     ] = None,
-    **inputs: Dict[InputGetter, Schemas],
-) -> Callable:
+    **inputs: Schemas,
+) -> Callable[[F], F]:
     """Check schema for multiple inputs and outputs.
 
     See :ref:`here<decorators>` for more usage details.
@@ -419,6 +422,34 @@ def check_io(
         return wrapped_fn(*args, **kwargs)
 
     return _wrapper
+
+
+@overload
+def check_types(
+    wrapped: F,
+    *,
+    head: Optional[int] = None,
+    tail: Optional[int] = None,
+    sample: Optional[int] = None,
+    random_state: Optional[int] = None,
+    lazy: bool = False,
+    inplace: bool = False,
+) -> F:
+    ...
+
+
+@overload
+def check_types(
+    wrapped: None = None,
+    *,
+    head: Optional[int] = None,
+    tail: Optional[int] = None,
+    sample: Optional[int] = None,
+    random_state: Optional[int] = None,
+    lazy: bool = False,
+    inplace: bool = False,
+) -> Callable[[F], F]:
+    ...
 
 
 def check_types(

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -323,8 +323,7 @@ def _format_checks(checks_dict):
             )
         else:
             args = ", ".join(
-                "{}={}".format(k, v.__repr__())
-                for k, v in check_kwargs.items()
+                f"{k}={v.__repr__()}" for k, v in check_kwargs.items()
             )
             checks.append(f"Check.{check_name}({args})")
     return f"[{', '.join(checks)}]"
@@ -395,7 +394,7 @@ def to_script(dataframe_schema, path_or_buf=None):
         else _format_index(statistics["index"])
     )
 
-    column_str = ", ".join("'{}': {}".format(k, v) for k, v in columns.items())
+    column_str = ", ".join(f"'{k}': {v}" for k, v in columns.items())
 
     script = SCRIPT_TEMPLATE.format(
         columns=column_str,

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -64,9 +64,9 @@ class FieldInfo:
         allow_duplicates: bool = True,
         coerce: bool = False,
         regex: bool = False,
-        alias: str = None,
-        check_name: bool = None,
-        dtype_kwargs: Dict[str, Any] = None,
+        alias: Any = None,
+        check_name: Optional[bool] = None,
+        dtype_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.checks = _to_checklist(checks)
         self.nullable = nullable
@@ -155,11 +155,11 @@ def Field(
     in_range: Dict[str, Any] = None,
     isin: Iterable = None,
     notin: Iterable = None,
-    str_contains: str = None,
-    str_endswith: str = None,
-    str_length: Dict[str, Any] = None,
-    str_matches: str = None,
-    str_startswith: str = None,
+    str_contains: Optional[str] = None,
+    str_endswith: Optional[str] = None,
+    str_length: Optional[Dict[str, Any]] = None,
+    str_matches: Optional[str] = None,
+    str_startswith: Optional[str] = None,
     nullable: bool = False,
     allow_duplicates: bool = True,
     coerce: bool = False,
@@ -167,9 +167,9 @@ def Field(
     ignore_na: bool = True,
     raise_warning: bool = False,
     n_failure_cases: int = 10,
-    alias: str = None,
-    check_name: bool = None,
-    dtype_kwargs: Dict[str, Any] = None,
+    alias: Any = None,
+    check_name: Optional[bool] = None,
+    dtype_kwargs: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> Any:
     """Used to provide extra information about a field of a SchemaModel.

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -671,9 +671,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         def _format_multiline(json_str, arg):
             return "\n".join(
-                "{}{}".format(indent, line)
-                if i != 0
-                else "{}{}={}".format(indent, arg, line)
+                f"{indent}{line}" if i != 0 else f"{indent}{arg}={line}"
                 for i, line in enumerate(json_str.split("\n"))
             )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ profile = black
 
 [mypy]
 ignore_missing_imports = True
+warn_return_any = False
+warn_unused_configs = True
+show_error_codes = True

--- a/tests/core/checks_fixtures.py
+++ b/tests/core/checks_fixtures.py
@@ -1,5 +1,6 @@
 """Pytest fixtures for testing custom checks."""
 import unittest.mock as mock
+from typing import Generator
 
 import pandas as pd
 import pytest
@@ -11,7 +12,7 @@ __all__ = "custom_check_teardown", "extra_registered_checks"
 
 
 @pytest.fixture(scope="function")
-def custom_check_teardown():
+def custom_check_teardown() -> Generator[None, None, None]:
     """Remove all custom checks after execution of each pytest function."""
     yield
     for check_name in list(pa.Check.REGISTERED_CUSTOM_CHECKS):
@@ -19,7 +20,7 @@ def custom_check_teardown():
 
 
 @pytest.fixture(scope="function")
-def extra_registered_checks():
+def extra_registered_checks() -> Generator[None, None, None]:
     """temporarily registers custom checks onto the Check class"""
     # pylint: disable=unused-variable
     with mock.patch(

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -349,7 +349,7 @@ def test_check_io() -> None:
     # invalid out schema types
     for out_schema in [1, 5.0, "foo", {"foo": "bar"}, ["foo"]]:
 
-        @check_io(out=out_schema)  # type: ignore[arg-type]  # mypy identifies the wrong usage correctly
+        @check_io(out=out_schema)  # type: ignore[arg-type]  # mypy correctly finds the wrong usage
         def invalid_out_schema_type(df):
             return df
 
@@ -467,6 +467,7 @@ def test_check_types_unchanged() -> None:
         notused: int,  # pylint: disable=unused-argument
     ) -> DataFrame[OnlyZeroesSchema]:
         return df
+
     df = pd.DataFrame({"a": [0]})
     pd.testing.assert_frame_equal(transform(df, 2), df)
 

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -25,7 +25,7 @@ from pandera import (
 from pandera.typing import DataFrame, Index, Series
 
 
-def test_check_function_decorators():
+def test_check_function_decorators() -> None:
     """
     Tests 5 different methods that are common across the @check_input and
     @check_output decorators.
@@ -147,7 +147,7 @@ def test_check_function_decorators():
     assert isinstance(df, pd.DataFrame)
 
 
-def test_check_function_decorator_errors():
+def test_check_function_decorator_errors() -> None:
     """Test that the check_input and check_output decorators error properly."""
     # case 1: checks that the input and output decorators error when different
     # types are passed in and out
@@ -186,7 +186,7 @@ def test_check_function_decorator_errors():
         test_incorrect_check_input_index(pd.DataFrame({"column1": [1, 2, 3]}))
 
 
-def test_check_input_method_decorators():
+def test_check_input_method_decorators() -> None:
     """Test the check_input and check_output decorator behaviours when the
     dataframe is changed within the function being checked"""
     in_schema = DataFrameSchema({"column1": Column(String)})
@@ -262,7 +262,7 @@ def test_check_input_method_decorators():
     )
 
 
-def test_check_io():
+def test_check_io() -> None:
     # pylint: disable=too-many-locals
     """Test that check_io correctly validates/invalidates data."""
 
@@ -332,7 +332,7 @@ def test_check_io():
         (validate_lazy, [df1], [invalid_df], df1),
         (validate_inplace, [df1], [invalid_df], df1),
     ]:
-        result = fn(*valid)
+        result = fn(*valid)  # type: ignore[operator]
         if isinstance(result, pd.Series):
             assert (result == out).all()
         if isinstance(result, pd.DataFrame):
@@ -344,12 +344,12 @@ def test_check_io():
             errors.SchemaErrors if fn is validate_lazy else errors.SchemaError
         )
         with pytest.raises(expected_error):
-            fn(*invalid)
+            fn(*invalid)  # type: ignore[operator]
 
     # invalid out schema types
     for out_schema in [1, 5.0, "foo", {"foo": "bar"}, ["foo"]]:
 
-        @check_io(out=out_schema)
+        @check_io(out=out_schema)  # type: ignore[arg-type]  # mypy identifies the wrong usage correctly
         def invalid_out_schema_type(df):
             return df
 
@@ -360,7 +360,7 @@ def test_check_io():
 @pytest.mark.parametrize(
     "obj_getter", [1.5, 0.1, ["foo"], {1, 2, 3}, {"foo": "bar"}]
 )
-def test_check_input_output_unrecognized_obj_getter(obj_getter):
+def test_check_input_output_unrecognized_obj_getter(obj_getter) -> None:
     """
     Test that check_input and check_output raise correct errors on unrecognized
     dataframe object getters
@@ -399,7 +399,7 @@ def test_check_input_output_unrecognized_obj_getter(obj_getter):
         ),
     ],
 )
-def test_check_io_unrecognized_obj_getter(out, error, msg):
+def test_check_io_unrecognized_obj_getter(out, error, msg) -> None:
     """
     Test that check_io raise correct errors on unrecognized decorator arguments
     """
@@ -419,7 +419,7 @@ class OnlyZeroesSchema(SchemaModel):  # pylint:disable=too-few-public-methods
     a: Series[int] = Field(eq=0)
 
 
-def test_check_types_arguments():
+def test_check_types_arguments() -> None:
     """Test that check_types forwards key-words arguments to validate."""
     df = pd.DataFrame({"a": [0, 0]})
 
@@ -457,7 +457,7 @@ def test_check_types_arguments():
         transform_lazy(df)
 
 
-def test_check_types_unchanged():
+def test_check_types_unchanged() -> None:
     """Test the check_types behaviour when the dataframe is unchanged within the
     function being checked."""
 
@@ -467,7 +467,6 @@ def test_check_types_unchanged():
         notused: int,  # pylint: disable=unused-argument
     ) -> DataFrame[OnlyZeroesSchema]:
         return df
-
     df = pd.DataFrame({"a": [0]})
     pd.testing.assert_frame_equal(transform(df, 2), df)
 
@@ -502,7 +501,7 @@ class OutSchema(SchemaModel):  # pylint: disable=too-few-public-methods
         coerce = True
 
 
-def test_check_types_multiple_inputs():
+def test_check_types_multiple_inputs() -> None:
     """Test that check_types behaviour when multiple inputs are annotated."""
 
     @check_types
@@ -519,7 +518,7 @@ def test_check_types_multiple_inputs():
         transform(correct, wrong)
 
 
-def test_check_types_error_input():
+def test_check_types_error_input() -> None:
     """Test that check_types raises an error when the input is not correct."""
 
     @check_types
@@ -539,7 +538,7 @@ def test_check_types_error_input():
         assert exc.data.equals(df)
 
 
-def test_check_types_error_output():
+def test_check_types_error_output() -> None:
     """Test that check_types raises an error when the output is not correct."""
 
     df = pd.DataFrame({"a": [1]}, index=["1"])
@@ -579,7 +578,7 @@ def test_check_types_error_output():
         assert exc.data.equals(df)
 
 
-def test_check_types_optional_out():
+def test_check_types_optional_out() -> None:
     """Test the check_types behaviour when the output schema is optional."""
 
     @check_types
@@ -601,7 +600,7 @@ def test_check_types_optional_out():
     assert optional_out(df) is None
 
 
-def test_check_types_optional_in():
+def test_check_types_optional_in() -> None:
     """Test the check_types behaviour when the input schema is optional."""
 
     @check_types
@@ -613,7 +612,7 @@ def test_check_types_optional_in():
     assert optional_in(None) is None
 
 
-def test_check_types_optional_in_out():
+def test_check_types_optional_in_out() -> None:
     """Test the check_types behaviour when both input and outputs schemas are optional."""
 
     @check_types
@@ -633,7 +632,7 @@ def test_check_types_optional_in_out():
     assert transform(None) is None
 
 
-def test_check_types_coerce():
+def test_check_types_coerce() -> None:
     """Test that check_types return the result of validate."""
 
     @check_types()

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -564,8 +564,8 @@ def test_dataframe_check() -> None:
 
 
 def test_registered_dataframe_checks(
-    extra_registered_checks: None,
-) -> None:  # pylint: disable=unused-argument
+    extra_registered_checks: None,  # pylint: disable=unused-argument
+) -> None:
     """Check that custom check inheritance works"""
     # pylint: disable=unused-variable
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -12,7 +12,7 @@ import pandera.extensions as pax
 from pandera.typing import DataFrame, Index, Series, String
 
 
-def test_to_schema():
+def test_to_schema() -> None:
     """Test that SchemaModel.to_schema() can produce the correct schema."""
 
     class Schema(pa.SchemaModel):
@@ -31,7 +31,7 @@ def test_to_schema():
         Schema()
 
 
-def test_empty_schema():
+def test_empty_schema() -> None:
     """Test that SchemaModel supports empty schemas."""
 
     empty_schema = pa.DataFrameSchema()
@@ -56,7 +56,7 @@ def test_empty_schema():
     assert schema == EmptyParentSchema.to_schema()
 
 
-def test_invalid_annotations():
+def test_invalid_annotations() -> None:
     """Test that SchemaModel.to_schema() fails if annotations or types are not
     recognized.
     """
@@ -86,7 +86,7 @@ def test_invalid_annotations():
         InvalidDtype.to_schema()
 
 
-def test_optional_column():
+def test_optional_column() -> None:
     """Test that optional columns are not required."""
 
     class Schema(pa.SchemaModel):
@@ -100,7 +100,7 @@ def test_optional_column():
     assert not schema.columns["c"].required
 
 
-def test_optional_index():
+def test_optional_index() -> None:
     """Test that optional indices are not required."""
 
     class Schema(pa.SchemaModel):
@@ -116,7 +116,7 @@ def test_optional_index():
             model.to_schema()
 
 
-def test_schemamodel_with_fields():
+def test_schemamodel_with_fields() -> None:
     """Test that Fields are translated in the schema."""
 
     class Schema(pa.SchemaModel):
@@ -138,9 +138,9 @@ def test_schemamodel_with_fields():
     assert actual == expected
 
 
-def test_invalid_field():
+def test_invalid_field() -> None:
     class Schema(pa.SchemaModel):
-        a: Series[int] = 0
+        a: Series[int] = 0  # type: ignore[assignment]  # mypy identifies the wrong usage correctly
 
     with pytest.raises(
         pa.errors.SchemaInitError, match="'a' can only be assigned a 'Field'"
@@ -148,7 +148,7 @@ def test_invalid_field():
         Schema.to_schema()
 
 
-def test_multiindex():
+def test_multiindex() -> None:
     """Test that multiple Index annotations create a MultiIndex."""
 
     class Schema(pa.SchemaModel):
@@ -166,7 +166,7 @@ def test_multiindex():
     assert expected == Schema.to_schema()
 
 
-def test_column_check_name():
+def test_column_check_name() -> None:
     """Test that column name is mandatory."""
 
     class Schema(pa.SchemaModel):
@@ -176,7 +176,7 @@ def test_column_check_name():
         Schema.to_schema()
 
 
-def test_single_index_check_name():
+def test_single_index_check_name() -> None:
     """Test single index name."""
     df = pd.DataFrame(index=pd.Index(["cat", "dog"], name="animal"))
 
@@ -203,7 +203,7 @@ def test_single_index_check_name():
         SchemaNamedIndex.validate(df)
 
 
-def test_multiindex_check_name():
+def test_multiindex_check_name() -> None:
     """Test a MultiIndex name."""
 
     df = pd.DataFrame(
@@ -234,7 +234,7 @@ def test_multiindex_check_name():
     assert isinstance(NotCheckNameSchema.validate(df), pd.DataFrame)
 
 
-def test_check_validate_method():
+def test_check_validate_method() -> None:
     """Test validate method on valid data."""
 
     class Schema(pa.SchemaModel):
@@ -250,7 +250,7 @@ def test_check_validate_method():
     assert isinstance(Schema.validate(df, lazy=True), pd.DataFrame)
 
 
-def test_check_validate_method_field():
+def test_check_validate_method_field() -> None:
     """Test validate method on valid data."""
 
     class Schema(pa.SchemaModel):
@@ -273,7 +273,7 @@ def test_check_validate_method_field():
     assert isinstance(Schema.validate(df, lazy=True), pd.DataFrame)
 
 
-def test_check_validate_method_aliased_field():
+def test_check_validate_method_aliased_field() -> None:
     """Test validate method on valid data."""
 
     class Schema(pa.SchemaModel):
@@ -290,7 +290,7 @@ def test_check_validate_method_aliased_field():
     assert isinstance(Schema.validate(df, lazy=True), pd.DataFrame)
 
 
-def test_check_single_column():
+def test_check_single_column() -> None:
     """Test the behaviour of a check on a single column."""
 
     class Schema(pa.SchemaModel):
@@ -309,7 +309,7 @@ def test_check_single_column():
         schema.validate(df, lazy=True)
 
 
-def test_check_single_index():
+def test_check_single_index() -> None:
     """Test the behaviour of a check on a single index."""
 
     class Schema(pa.SchemaModel):
@@ -327,7 +327,7 @@ def test_check_single_index():
         Schema.validate(df, lazy=True)
 
 
-def test_field_and_check():
+def test_field_and_check() -> None:
     """Test the combination of a field and a check on the same column."""
 
     class Schema(pa.SchemaModel):
@@ -342,7 +342,7 @@ def test_field_and_check():
     assert len(schema.columns["a"].checks) == 2
 
 
-def test_check_non_existing():
+def test_check_non_existing() -> None:
     """Test a check on a non-existing column."""
 
     class Schema(pa.SchemaModel):
@@ -360,7 +360,7 @@ def test_check_non_existing():
         Schema.to_schema()
 
 
-def test_multiple_checks():
+def test_multiple_checks() -> None:
     """Test multiple checks on the same column."""
 
     class Schema(pa.SchemaModel):
@@ -390,7 +390,7 @@ def test_multiple_checks():
         schema.validate(df, lazy=True)
 
 
-def test_check_multiple_columns():
+def test_check_multiple_columns() -> None:
     """Test a single check decorator targeting multiple columns."""
 
     class Schema(pa.SchemaModel):
@@ -409,7 +409,7 @@ def test_check_multiple_columns():
         Schema.validate(df, lazy=True)
 
 
-def test_check_regex():
+def test_check_regex() -> None:
     """Test the regex argument of the check decorator."""
 
     class Schema(pa.SchemaModel):
@@ -429,7 +429,7 @@ def test_check_regex():
         Schema.validate(df, lazy=True)
 
 
-def test_inherit_schemamodel_fields():
+def test_inherit_schemamodel_fields() -> None:
     """Test that columns and indices are inherited."""
 
     class Base(pa.SchemaModel):
@@ -451,7 +451,7 @@ def test_inherit_schemamodel_fields():
     assert expected == Child.to_schema()
 
 
-def test_inherit_schemamodel_fields_alias():
+def test_inherit_schemamodel_fields_alias() -> None:
     """Test that columns and index aliases are inherited."""
 
     class Base(pa.SchemaModel):
@@ -497,7 +497,7 @@ def test_inherit_schemamodel_fields_alias():
     assert expected_mid == ChildEmpty.to_schema()
 
 
-def test_inherit_field_checks():
+def test_inherit_field_checks() -> None:
     """Test that checks are inherited and overridden."""
 
     class Base(pa.SchemaModel):
@@ -530,7 +530,7 @@ def test_inherit_field_checks():
         schema.validate(df, lazy=True)
 
 
-def test_dataframe_check():
+def test_dataframe_check() -> None:
     """Test dataframe checks."""
 
     class Base(pa.SchemaModel):
@@ -564,8 +564,8 @@ def test_dataframe_check():
 
 
 def test_registered_dataframe_checks(
-    extra_registered_checks,
-):  # pylint: disable=unused-argument
+    extra_registered_checks: None,
+) -> None:  # pylint: disable=unused-argument
     """Check that custom check inheritance works"""
     # pylint: disable=unused-variable
 
@@ -628,7 +628,7 @@ def test_registered_dataframe_checks(
 
         class ErrorSchema(pa.SchemaModel):
             class Config:
-                unknown_check = {}
+                unknown_check = {}  # type: ignore[var-annotated]
 
         # Check lookup happens at validation/to_schema conversion time
         # This means that you can register checks after defining a Config,
@@ -637,7 +637,7 @@ def test_registered_dataframe_checks(
         ErrorSchema.to_schema()
 
 
-def test_config():
+def test_config() -> None:
     """Test that Config can be inherited and translate into DataFrameSchema options."""
 
     class Base(pa.SchemaModel):
@@ -688,7 +688,7 @@ class Output(Input):
     c: Series[int]
 
 
-def test_check_types():
+def test_check_types() -> None:
     @pa.check_types
     def transform(df: DataFrame[Input]) -> DataFrame[Output]:
         return df.assign(c=lambda x: x.a + x.b)
@@ -709,7 +709,7 @@ def test_check_types():
             transform(invalid_data)
 
 
-def test_alias():
+def test_alias() -> None:
     """Test that columns and indices can be aliased."""
 
     class Schema(pa.SchemaModel):
@@ -740,7 +740,7 @@ def test_alias():
     assert actual == ["index0", "index1"]
 
 
-def test_inherit_alias():
+def test_inherit_alias() -> None:
     """Test that aliases are inherited and can be overwritten."""
 
     # Three cases to consider per annotation:
@@ -816,7 +816,7 @@ def test_field_name_access():
     assert Base.i2 == "i2"
 
 
-def test_field_name_access_inherit():
+def test_field_name_access_inherit() -> None:
     """Test that column and index names can be accessed through the class"""
 
     class Base(pa.SchemaModel):
@@ -885,7 +885,7 @@ def test_field_name_access_inherit():
     assert Child.i3 == "_i3"
 
 
-def test_column_access_regex():
+def test_column_access_regex() -> None:
     class Schema(pa.SchemaModel):
         col_regex: Series[str] = pa.Field(alias="column_([0-9])+", regex=True)
 

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -310,7 +310,7 @@ def test_str_pattern_checks(str_strat, pattern_fn, chained, data, pattern):
             st.integers(min_value=0, max_value=100),
             st.integers(min_value=0, max_value=100),
         )
-        .map(sorted)
+        .map(sorted)  # type: ignore[arg-type]
         .filter(lambda x: x[0] < x[1])  # type: ignore
     ),
 )


### PR DESCRIPTION
### The problem
1. Decorators were mostly resolving to `Callable`, this limits static type checking (e.g., with mypy) on the underlying function (for arguments that are not DataFrame-s for example). Moreover, this means that autocompletion in IDEs such as PyCharm does not work.
2. Unfortunately, in Pandas a "column name" can be any object, even though sane people mostly use strings and seldom integers. Even in the test suite there was an integer used as a "column name".

### The fix
Improving the type annotations.

### Testing - mypy output of `reveal_type`
##### Before
```
tests\core\test_decorators.py:470: note: Revealed type is "def (*Any, **Any) -> Any"
```
##### After
```
tests\core\test_decorators.py:470: note: Revealed type is "def (df: pandera.typing.DataFrame[tests.core.test_decorators.OnlyZeroesSchema], notused: builtins.int) -> 
pandera.typing.DataFrame[tests.core.test_decorators.OnlyZeroesSchema]"
````

### Testing - enabling type checking on the test suite
Test functions were not statically type-checked because they had no annotations. For example, the below is not type-checked,
```python
def test_check_types_unchanged() :
   ...
```
while
```python
def test_check_types_unchanged() -> None:
   ...
```
would be typed-checked because it is annotated.

### Further testing
To go the extra mile we may want to do this for testing our typing: https://sobolevn.me/2019/08/testing-mypy-types
