### PR TITLE
bugfix: lazy validation correctly reports all errors

### DIFF
--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -124,9 +124,9 @@ catch these errors and inspect the failure cases in a more granular form:
         schema.validate(df, lazy=True)
     except pa.errors.SchemaErrors as err:
         print("Schema errors and failure cases:")
-        print(err.failure_cases.head())
+        print(err.failure_cases)
         print("\nDataFrame object that failed validation:")
-        print(err.data.head())
+        print(err.data)
 
 .. testoutput:: lazy_validation
     :skipif: SKIP_PANDAS_LT_V1
@@ -137,14 +137,18 @@ catch these errors and inspect the failure cases in a more granular form:
     1  DataFrameSchema          None      column_in_dataframe         None
     2           Column    int_column    pandas_dtype('int64')         None
     3           Column  float_column  pandas_dtype('float64')         None
-    4           Column    str_column              equal_to(a)            0
+    4           Column  float_column          greater_than(0)            0
+    5           Column    str_column              equal_to(a)            0
+    6           Column    str_column              equal_to(a)            0
 
          failure_case index
     0  unknown_column  None
     1     date_column  None
     2          object  None
     3           int64  None
-    4               b     1
+    4               0     0
+    5               b     1
+    6               d     2
 
     DataFrame object that failed validation:
       int_column  float_column str_column unknown_column

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -171,5 +171,6 @@ class SchemaErrors(Exception):
             pd.concat(check_failure_cases)
             .reset_index(drop=True)
             .sort_values("schema_context", ascending=False)
+            .drop_duplicates()
         )
         return error_counts, failure_cases

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -26,8 +26,6 @@ def _is_valid_multiindex_tuple_str(x: Tuple[Any]) -> bool:
 class Column(SeriesSchemaBase):
     """Validate types and properties of DataFrame columns."""
 
-    has_subcomponents = False
-
     def __init__(
         self,
         pandas_dtype: PandasDtypeInputTypes = None,
@@ -315,8 +313,6 @@ class Column(SeriesSchemaBase):
 class Index(SeriesSchemaBase):
     """Validate types and properties of a DataFrame Index."""
 
-    has_subcomponents = False
-
     @property
     def names(self):
         """Get index names in the Index schema component."""
@@ -437,8 +433,6 @@ class MultiIndex(DataFrameSchema):
     This class inherits from :class:`~pandera.schemas.DataFrameSchema` to
     leverage its validation logic.
     """
-
-    has_subcomponents = True
 
     def __init__(
         self,

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -332,6 +332,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                 return coerce_fn(obj)
             except errors.SchemaError as exc:
                 error_handler.collect_error("dtype_coercion_error", exc)
+                return obj
 
         for colname, col_schema in self.columns.items():
             if col_schema.regex:
@@ -583,7 +584,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             try:
                 result = schema_component(
                     df_to_validate,
-                    lazy=lazy if schema_component.has_subcomponents else None,
+                    lazy=lazy,
                     # don't make a copy of the data
                     inplace=True,
                 )


### PR DESCRIPTION
- always use lazy validation on dataframe schema sub components
- remove has_subcomponent schema component class attribute, not
  sure why this was introduced in the first place?
- drop duplicate schema errors in `SchemaErrors` exception