### PR TITLE
Comply with PEP561 and Series typing fix

### DIFF
--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -72,6 +72,9 @@ class Series(pd.Series, Generic[GenericDtype]):  # type: ignore
     *new in 0.5.0*
     """
 
+    def __get__(self, instance: object, owner: Type) -> str:
+        raise AttributeError("Series should resolve to Field-s")
+
 
 if TYPE_CHECKING:  # pragma: no cover
     # pylint:disable=too-few-public-methods,invalid-name

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     license="MIT",
     data_files=[("", ["LICENSE.txt"])],
     packages=["pandera"],
+    package_data={"pandera": ["py.typed"]},
     install_requires=[
         "packaging >= 20.0",
         "numpy >= 1.9.0",


### PR DESCRIPTION
## Problem 1 - Users can't benefit from pandera type annotations
Pandera uses mypy extensively (which is fantastic) but users who pip install pandera cannot use these annotations to type check their usages of pandera. 
## Solution
To allow users to benefit from type annotations in a library, one needs to add a file called `py.typed` as specified by https://www.python.org/dev/peps/pep-0561/.

## Problem 2 - wrong inferred typed for `SchemaModel.column`
SchemaModel.column resolves to `Series` instead of `str`.
## Solution
All `Series` are eventually resolved as `FieldInfo`-s which leverage a get descriptor to turn the output of `SchemaModel.column` into a `str`. However, `mypy` rightly thinks that class attributes (e.g. `.column`) are `Series` objects (because we annotated them as such). `Series` don't have the same typed descriptor as `FieldInfo` to let `mypy` know that accessing a Series returns a `str`. Therefore I added a descriptor solely for typing purposes.
## Philosophical note
On a more philosophical note, the problem is that we are annotating a `FieldInfo` object as something else, namely as `Series`.

