### PR TITLE
Feature/decorate coroutines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,6 @@ repos:
     hooks:
       - id: mypy
         entry: mypy pandera tests
-        files: (^pandera/|^tests)
-        exclude: (^docs/|^scripts)
+        files: (^pandera/|^tests|^scripts)
+        exclude: (^docs/)
         pass_filenames: false

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - pytest-asyncio
   - setuptools >= 52.0.0
   - nox = 2020.12.31  # TODO: update codebase to be 2021.6.6+ compatible
   - importlib_metadata # required if python < 3.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pylint >= 2.7.2
 pytest
 pytest-cov
 pytest-xdist
+pytest-asyncio
 setuptools >= 52.0.0
 nox == 2020.12.31
 importlib_metadata

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -72,9 +72,9 @@ def main(conda_file: Path, pip_file: Path, compare: bool = False) -> bool:
 
     Parameters
     ----------
-    conda_file : str
+    conda_file : Path
         Path to the conda file with dependencies (e.g. `environment.yml`).
-    pip_file : str
+    pip_file : Path
         Path to the pip file with dependencies (e.g. `requirements-dev.txt`).
     compare : bool, default False
         Whether to generate the pip file (``False``) or to compare if the

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -16,17 +16,22 @@ Usage:
     $ ./conda_to_pip --compare
 """
 import argparse
-import os
 import re
 import sys
+from pathlib import Path
+from typing import Dict, List, Optional
 
 import yaml
 
 EXCLUDE = {"python"}
-RENAME = {}
+RENAME: Dict[str, str] = {}
+
+REPO_PATH = Path(__file__).resolve().absolute().parents[1]
+CONDA_REQUIREMENTS_FILE = REPO_PATH / "environment.yml"
+PIP_REQUIREMENTS_FILE = REPO_PATH / "requirements-dev.txt"
 
 
-def conda_package_to_pip(package):
+def conda_package_to_pip(package: str) -> Optional[str]:
     """
     Convert a conda package to its pip equivalent.
 
@@ -44,7 +49,7 @@ def conda_package_to_pip(package):
 
         pkg, version = package.split(compare)
         if pkg in EXCLUDE:
-            return
+            return None
 
         if pkg in RENAME:
             return "".join((RENAME[pkg], compare, version))
@@ -52,7 +57,7 @@ def conda_package_to_pip(package):
         break
 
     if package in EXCLUDE:
-        return
+        return None
 
     if package in RENAME:
         return RENAME[package]
@@ -60,16 +65,16 @@ def conda_package_to_pip(package):
     return package
 
 
-def main(conda_fname, pip_fname, compare=False):
+def main(conda_file: Path, pip_file: Path, compare: bool = False) -> bool:
     """
     Generate the pip dependencies file from the conda file, or compare that
     they are synchronized (``compare=True``).
 
     Parameters
     ----------
-    conda_fname : str
+    conda_file : str
         Path to the conda file with dependencies (e.g. `environment.yml`).
-    pip_fname : str
+    pip_file : str
         Path to the pip file with dependencies (e.g. `requirements-dev.txt`).
     compare : bool, default False
         Whether to generate the pip file (``False``) or to compare if the
@@ -81,21 +86,21 @@ def main(conda_fname, pip_fname, compare=False):
     bool
         True if the comparison fails, False otherwise
     """
-    with open(conda_fname) as conda_fd:
+    with open(conda_file) as conda_fd:
         deps = yaml.safe_load(conda_fd)["dependencies"]
 
-    pip_deps = []
+    pip_deps: List[str] = []
     for dep in deps:
         if isinstance(dep, str):
             conda_dep = conda_package_to_pip(dep)
-            if conda_dep:
+            if conda_dep is not None:
                 pip_deps.append(conda_dep)
         elif isinstance(dep, dict) and len(dep) == 1 and "pip" in dep:
             pip_deps += dep["pip"]
         else:
             raise ValueError(f"Unexpected dependency {dep}")
 
-    fname = os.path.split(conda_fname)[1]
+    fname = conda_file.name
     header = (
         f"# This file is auto-generated from {fname}, do not modify.\n"
         "# See that file for comments about the need/usage of "
@@ -104,12 +109,9 @@ def main(conda_fname, pip_fname, compare=False):
     pip_content = header + "\n".join(pip_deps)
 
     if compare:
-        with open(pip_fname) as pip_fd:
-            return pip_content.strip() != pip_fd.read().strip()
-    else:
-        with open(pip_fname, "w") as pip_fd:
-            pip_fd.write(pip_content)
-        return False
+        return pip_file.read_text().strip() != pip_content.strip()
+    pip_file.write_text(pip_content)
+    return False
 
 
 if __name__ == "__main__":
@@ -128,16 +130,13 @@ if __name__ == "__main__":
     )
     args = argparser.parse_args()
 
-    repo_path = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
     res = main(
-        os.path.join(repo_path, "environment.yml"),
-        os.path.join(repo_path, "requirements-dev.txt"),
-        compare=args.compare,
+        CONDA_REQUIREMENTS_FILE, PIP_REQUIREMENTS_FILE, compare=args.compare
     )
     if res:
         msg = (
-            f"`requirements-dev.txt` has to be generated with `{sys.argv[0]}` after "
-            "`environment.yml` is modified.\n" % sys.argv[0]
+            f"`{PIP_REQUIREMENTS_FILE}` has to be generated with `{sys.argv[0]}` after "
+            f"`{CONDA_REQUIREMENTS_FILE}` is modified.\n"
         )
         if args.azure:
             msg = f"##vso[task.logissue type=error;sourcepath=requirements-dev.txt]{msg}"

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -806,11 +806,15 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
         class Config:
             strict = True
 
+    @check_output(Schema.to_schema())
+    @check_input(Schema.to_schema())
     @check_types
     async def coroutine(df1: DataFrame[Schema]) -> DataFrame[Schema]:
         return df1
 
     class SomeClass:
+        @check_output(Schema.to_schema())
+        @check_input(Schema.to_schema())
         @check_types
         async def regular_coroutine(  # pylint: disable=no-self-use
             self,
@@ -819,16 +823,20 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
             return df1
 
         @classmethod
+        @check_output(Schema.to_schema())
+        @check_input(Schema.to_schema(), "df1")
         @check_types
         async def class_coroutine(
             cls, df1: DataFrame[Schema]
         ) -> DataFrame[Schema]:
             return df1
 
-        @classmethod
+        @staticmethod
+        @check_output(Schema.to_schema())
+        @check_input(Schema.to_schema())
         @check_types
         async def static_coroutine(
-            cls, df1: DataFrame[Schema]
+            df1: DataFrame[Schema],
         ) -> DataFrame[Schema]:
             return df1
 

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -845,7 +845,8 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
             return df1
 
     async def check_coros() -> None:
-        df: DataFrame[Schema] = DataFrame({Schema.col1: [1]})
+        good_df: DataFrame[Schema] = DataFrame({Schema.col1: [1]})
+        bad_df: DataFrame[Schema] = DataFrame({"bad_schema": [1]})
         instance = SomeClass()
         for coro in [
             coroutine,
@@ -854,7 +855,10 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
             instance.static_coroutine,
             SomeClass.static_coroutine,
         ]:
-            res = await coro(df)
-            pd.testing.assert_frame_equal(df, res)
+            res = await coro(good_df)
+            pd.testing.assert_frame_equal(good_df, res)
+
+            with pytest.raises(errors.SchemaError):
+                await coro(bad_df)
 
     event_loop.run_until_complete(check_coros())

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -806,16 +806,18 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
         class Config:
             strict = True
 
+    @check_types
     @check_output(Schema.to_schema())
     @check_input(Schema.to_schema())
-    @check_types
+    @check_io(df1=Schema.to_schema(), out=Schema.to_schema())
     async def coroutine(df1: DataFrame[Schema]) -> DataFrame[Schema]:
         return df1
 
     class SomeClass:
-        @check_output(Schema.to_schema())
-        @check_input(Schema.to_schema())
         @check_types
+        @check_output(Schema.to_schema())
+        @check_input(Schema.to_schema(), "df1")
+        @check_io(df1=Schema.to_schema(), out=Schema.to_schema())
         async def regular_coroutine(  # pylint: disable=no-self-use
             self,
             df1: DataFrame[Schema],
@@ -823,18 +825,20 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
             return df1
 
         @classmethod
+        @check_types
         @check_output(Schema.to_schema())
         @check_input(Schema.to_schema(), "df1")
-        @check_types
+        @check_io(df1=Schema.to_schema(), out=Schema.to_schema())
         async def class_coroutine(
             cls, df1: DataFrame[Schema]
         ) -> DataFrame[Schema]:
             return df1
 
         @staticmethod
+        @check_types
         @check_output(Schema.to_schema())
         @check_input(Schema.to_schema())
-        @check_types
+        @check_io(df1=Schema.to_schema(), out=Schema.to_schema())
         async def static_coroutine(
             df1: DataFrame[Schema],
         ) -> DataFrame[Schema]:

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -827,8 +827,9 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
         @classmethod
         @check_types
         @check_output(Schema.to_schema())
-        @check_input(Schema.to_schema(), "df1")
-        @check_io(df1=Schema.to_schema(), out=Schema.to_schema())
+        # Uncomment when https://github.com/GrahamDumpleton/wrapt/issues/182 is fixed
+        # @check_input(Schema.to_schema(), "df1")
+        # @check_io(df1=Schema.to_schema(), out=Schema.to_schema())
         async def class_coroutine(
             cls, df1: DataFrame[Schema]
         ) -> DataFrame[Schema]:


### PR DESCRIPTION
- Fixes #544 
- Fixed double string formatting bug in `scripts/generate_pip_deps_from_conda.py`

#### Attention
 `check_input(schema, 'arg_name')` does not work with Python 3.9 because of an issue in wrapt https://github.com/GrahamDumpleton/wrapt/issues/182