### PR TITLE
add support for pyarrow backed string data type

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -188,9 +188,6 @@ jobs:
             mamba install -c conda-forge pandas==${{ matrix.pandas-version }}
           fi
 
-      - name: Clean unused packages
-        run: mamba clean -p
-
       - name: Conda info
         run: |
           conda info

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -142,6 +142,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9"]
+        pandas-version: ["1.2.5", "latest"]
         # exclude these configurations until issue tracked here is fixed:
         # https://github.com/pandera-dev/pandera/issues/555
         exclude:
@@ -190,28 +191,28 @@ jobs:
           nox
           -db conda -r -v
           --non-interactive
-          --session "tests-${{ matrix.python-version }}(extra='core')"
+          --session "tests-${{ matrix.python-version }}(extra='core', pandas='{{ matrix.pandas-version }}')"
 
       - name: Unit Tests - Hypotheses
         run: >
           nox
           -db conda -r -v
           --non-interactive
-          --session "tests-${{ matrix.python-version }}(extra='hypotheses')"
+          --session "tests-${{ matrix.python-version }}(extra='hypotheses', pandas='{{ matrix.pandas-version }}')"
 
       - name: Unit Tests - IO
         run: >
           nox
           -db conda -r -v
           --non-interactive
-          --session "tests-${{ matrix.python-version }}(extra='io')"
+          --session "tests-${{ matrix.python-version }}(extra='io', pandas='{{ matrix.pandas-version }}')"
 
       - name: Unit Tests - Strategies
         run: >
           nox
           -db conda -r -v
           --non-interactive
-          --session "tests-${{ matrix.python-version }}(extra='strategies')"
+          --session "tests-${{ matrix.python-version }}(extra='strategies', pandas='{{ matrix.pandas-version }}')"
 
       - name: Upload coverage to Codecov
         uses: "codecov/codecov-action@v1"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -177,8 +177,12 @@ jobs:
           channel-priority: true
           activate-environment: pandera-dev
           auto-update-conda: false
+          environment-file: environment.yml
           use-only-tar-bz2: true
           auto-activate-base: false
+
+      - name: Install nox
+        run: mamba install -c conda-forge nox
 
       - name: Conda info
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Update pandas version in environment file
         run: |
           if [[ "${{ matrix.pandas-version }}" != latest' ]] \
-            sed -i '' 's/pandas/pandas = {{ matrix.pandas-version }}/g' environment.yml \
+            sed -i '' 's/pandas/pandas = ${{ matrix.pandas-version }}/g' environment.yml \
           fi
 
       - name: Cache conda

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -158,13 +158,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Update pandas version in environment file
-        run: |
-          if [[ "${{ matrix.pandas-version }}" != 'latest' ]]
-          then
-            sed -i 's/pandas/pandas = ${{ matrix.pandas-version }}/g' environment.yml
-          fi
-
       - name: Cache conda
         uses: actions/cache@v2
         with:
@@ -187,6 +180,16 @@ jobs:
           environment-file: environment.yml
           use-only-tar-bz2: true
           auto-activate-base: false
+
+      - name: Install pandas
+        run: |
+          if [[ "${{ matrix.pandas-version }}" != 'latest' ]]
+          then
+            mamba install -c conda-forge pandas==${{ matrix.pandas-version }}
+          fi
+
+      - name: Clean unused packages
+        run: mamba clean -p
 
       - name: Conda info
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -160,8 +160,9 @@ jobs:
 
       - name: Update pandas version in environment file
         run: |
-          if [[ "${{ matrix.pandas-version }}" != latest' ]] \
-            sed -i '' 's/pandas/pandas = ${{ matrix.pandas-version }}/g' environment.yml \
+          if [[ "${{ matrix.pandas-version }}" != latest' ]]
+          then
+            sed -i '' 's/pandas/pandas = ${{ matrix.pandas-version }}/g' environment.yml
           fi
 
       - name: Cache conda

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           if [[ "${{ matrix.pandas-version }}" != 'latest' ]]
           then
-            sed -i '' 's/pandas/pandas = ${{ matrix.pandas-version }}/g' environment.yml
+            sed -i 's/pandas/pandas = ${{ matrix.pandas-version }}/g' environment.yml
           fi
 
       - name: Cache conda

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -142,6 +142,13 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9"]
+        # exclude these configurations until issue tracked here is fixed:
+        # https://github.com/pandera-dev/pandera/issues/555
+        exclude:
+          - os: windows-latest
+            python-version: "3.7"
+          - os: windows-latest
+            python-version: "3.9"
 
     defaults:
       run:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -160,8 +160,8 @@ jobs:
 
       - name: Update pandas version in environment file
         run: |
-          if [ "${{ matrix.pandas-version }}" != latest' ]
-            sed -i '' 's/pandas/pandas = {{ matrix.pandas-version }}/g' environment.yml
+          if [[ "${{ matrix.pandas-version }}" != latest' ]] \
+            sed -i '' 's/pandas/pandas = {{ matrix.pandas-version }}/g' environment.yml \
           fi
 
       - name: Cache conda

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -135,7 +135,7 @@ jobs:
 
   tests:
     name: >
-      CI Tests (${{ matrix.python-version }}, ${{ matrix.os }})
+      CI Tests (${{ matrix.python-version }}, ${{ matrix.os }}), pandas-${{ matrix.pandas-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -191,28 +191,28 @@ jobs:
           nox
           -db conda -r -v
           --non-interactive
-          --session "tests-${{ matrix.python-version }}(extra='core', pandas='{{ matrix.pandas-version }}')"
+          --session "tests-${{ matrix.python-version }}(extra='core', pandas='${{ matrix.pandas-version }}')"
 
       - name: Unit Tests - Hypotheses
         run: >
           nox
           -db conda -r -v
           --non-interactive
-          --session "tests-${{ matrix.python-version }}(extra='hypotheses', pandas='{{ matrix.pandas-version }}')"
+          --session "tests-${{ matrix.python-version }}(extra='hypotheses', pandas='${{ matrix.pandas-version }}')"
 
       - name: Unit Tests - IO
         run: >
           nox
           -db conda -r -v
           --non-interactive
-          --session "tests-${{ matrix.python-version }}(extra='io', pandas='{{ matrix.pandas-version }}')"
+          --session "tests-${{ matrix.python-version }}(extra='io', pandas='${{ matrix.pandas-version }}')"
 
       - name: Unit Tests - Strategies
         run: >
           nox
           -db conda -r -v
           --non-interactive
-          --session "tests-${{ matrix.python-version }}(extra='strategies', pandas='{{ matrix.pandas-version }}')"
+          --session "tests-${{ matrix.python-version }}(extra='strategies', pandas='${{ matrix.pandas-version }}')"
 
       - name: Upload coverage to Codecov
         uses: "codecov/codecov-action@v1"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -158,6 +158,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Update pandas version in environment file
+        run: |
+          if [ "${{ matrix.pandas-version }}" != latest' ]
+            sed -i '' 's/pandas/pandas = {{ matrix.pandas-version }}/g' environment.yml
+          fi
+
       - name: Cache conda
         uses: actions/cache@v2
         with:
@@ -177,11 +183,9 @@ jobs:
           channel-priority: true
           activate-environment: pandera-dev
           auto-update-conda: false
+          environment-file: environment.yml
           use-only-tar-bz2: true
           auto-activate-base: false
-
-      - name: Install nox
-        run: mamba install -c conda-forge nox
 
       - name: Conda info
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -177,7 +177,6 @@ jobs:
           channel-priority: true
           activate-environment: pandera-dev
           auto-update-conda: false
-          environment-file: environment.yml
           use-only-tar-bz2: true
           auto-activate-base: false
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -135,7 +135,7 @@ jobs:
 
   tests:
     name: >
-      CI Tests (${{ matrix.python-version }}, ${{ matrix.os }}), pandas-${{ matrix.pandas-version }})
+      CI Tests (${{ matrix.python-version }}, ${{ matrix.os }}, pandas-${{ matrix.pandas-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Update pandas version in environment file
         run: |
-          if [[ "${{ matrix.pandas-version }}" != latest' ]]
+          if [[ "${{ matrix.pandas-version }}" != 'latest' ]]
           then
             sed -i '' 's/pandas/pandas = ${{ matrix.pandas-version }}/g' environment.yml
           fi

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - typing_inspect >= 0.6.0
   - typing_extensions >= 3.7.4.3
   - frictionless
+  - pyarrow
 
   # testing and dependencies
   - black >= 20.8b1

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ REQUIRES: Dict[str, Dict[str, str]] = _build_requires()
 CONDA_ARGS = [
     "--channel=conda-forge",
     "--update-specs",
-    "--satisfied-skip-solve",
+    "-S",
 ]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,7 @@ nox.options.sessions = (
 
 DEFAULT_PYTHON = "3.8"
 PYTHON_VERSIONS = ["3.7", "3.8", "3.9"]
+PANDAS_VERSIONS = ["1.2.5", "latest"]
 
 PACKAGE = "pandera"
 
@@ -171,14 +172,18 @@ def install_extras(
     session: Session,
     extra: str = "core",
     force_pip: bool = False,
+    pandas: str = "latest",
 ) -> None:
     """Install dependencies."""
     specs, pip_specs = [], []
+    pandas_version = "" if pandas == "latest" else f"=={pandas}"
     for spec in REQUIRES[extra].values():
         if spec.split("==")[0] in ALWAYS_USE_PIP:
             pip_specs.append(spec)
         else:
-            specs.append(spec if spec != "pandas" else "pandas")
+            specs.append(
+                spec if spec != "pandas" else f"pandas{pandas_version}"
+            )
     if extra == "core":
         specs.append(REQUIRES["all"]["hypothesis"])
 
@@ -293,10 +298,11 @@ EXTRA_NAMES = [
 
 
 @nox.session(python=PYTHON_VERSIONS)
+@nox.parametrize("pandas", PANDAS_VERSIONS)
 @nox.parametrize("extra", EXTRA_NAMES)
-def tests(session: Session, extra: str) -> None:
+def tests(session: Session, pandas: str, extra: str) -> None:
     """Run the test suite."""
-    install_extras(session, extra)
+    install_extras(session, extra, pandas=pandas)
 
     if session.posargs:
         args = session.posargs

--- a/noxfile.py
+++ b/noxfile.py
@@ -199,8 +199,8 @@ def install_extras(
             print("using pip installer")
             session.install(*specs)
 
-    session.install(*pip_specs)
-    # always use pip for these packages
+        # always use pip for these packages
+        session.install(*pip_specs)
     session.install("-e", ".", "--no-deps")  # install pandera
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -315,6 +315,8 @@ def tests(session: Session, extra: str) -> None:
             "--cov-report=term-missing",
             "--cov-report=xml",
             "--cov-append",
+            "--verbose",
+            "--verbosity=10",
         ]
         if not CI_RUN:
             args.append("--cov-report=html")

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,6 +113,7 @@ REQUIRES: Dict[str, Dict[str, str]] = _build_requires()
 CONDA_ARGS = [
     "--channel=conda-forge",
     "--update-specs",
+    "--satisfied-skip-solve",
 ]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -315,8 +315,6 @@ def tests(session: Session, extra: str) -> None:
             "--cov-report=term-missing",
             "--cov-report=xml",
             "--cov-append",
-            "--verbose",
-            "--verbosity=10",
         ]
         if not CI_RUN:
             args.append("--cov-report=html")

--- a/noxfile.py
+++ b/noxfile.py
@@ -187,20 +187,20 @@ def install_extras(
     if extra == "core":
         specs.append(REQUIRES["all"]["hypothesis"])
 
-    # CI already installs all dependencies, so only run this for local runs
-    if not CI_RUN:
-        if (
-            isinstance(session.virtualenv, nox.virtualenv.CondaEnv)
-            and not force_pip
-        ):
-            print("using conda installer")
-            conda_install(session, *specs)
-        else:
-            print("using pip installer")
-            session.install(*specs)
+    # CI installs conda dependencies, so only run this for local runs
+    if (
+        isinstance(session.virtualenv, nox.virtualenv.CondaEnv)
+        and not force_pip
+        and not CI_RUN
+    ):
+        print("using conda installer")
+        conda_install(session, *specs)
+    else:
+        print("using pip installer")
+        session.install(*specs)
 
-        # always use pip for these packages
-        session.install(*pip_specs)
+    # always use pip for these packages
+    session.install(*pip_specs)
     session.install("-e", ".", "--no-deps")  # install pandera
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,19 +110,22 @@ def _build_requires() -> Dict[str, Dict[str, str]]:
 
 REQUIRES: Dict[str, Dict[str, str]] = _build_requires()
 
-CONDA_ARGS = [
-    "--channel=conda-forge",
-    "--update-specs",
-    "-S",
-]
-
 
 def conda_install(session: Session, *args):
     """Use mamba to install conda dependencies."""
+
+    conda_args = ["--channel=conda-forge"]
+
+    if CI_RUN:
+        conda_args.append("--satisfied-skip-solve")
+    else:
+        conda_args.append("--update-specs")
+
     run_args = [
         "install",
         "--yes",
-        *CONDA_ARGS,
+        "--channel=conda-forge",
+        *conda_args,
         "--prefix",
         session.virtualenv.location,  # type: ignore
         *args,

--- a/noxfile.py
+++ b/noxfile.py
@@ -304,11 +304,15 @@ def tests(session: Session, extra: str) -> None:
         path = f"tests/{extra}/" if extra != "all" else "tests"
         args = []
         if extra == "strategies":
+            # strategies tests runs very slowly in python 3.7:
+            # https://github.com/pandera-dev/pandera/issues/556
+            # as a stop-gap, use the "dev" profile for 3.7
+            profile = "ci" if CI_RUN and session.python != "3.7" else "dev"
             # enable threading via pytest-xdist
             args = [
                 "-n=auto",
                 "-q",
-                f"--hypothesis-profile={'ci' if CI_RUN else 'dev'}",
+                f"--hypothesis-profile={profile}",
             ]
         args += [
             f"--cov={PACKAGE}",

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -34,6 +34,7 @@ from pandera.engines.pandas_engine import (
     INT16,
     INT32,
     INT64,
+    PANDAS_1_3_0_PLUS,
     STRING,
     UINT8,
     UINT16,
@@ -41,6 +42,7 @@ from pandera.engines.pandas_engine import (
     UINT64,
 )
 from pandera.engines.pandas_engine import _PandasDtype as PandasDtype
+from pandera.engines.pandas_engine import pandas_version
 
 from . import constants, errors, pandas_accessor
 from .checks import Check
@@ -55,14 +57,3 @@ from .version import __version__
 
 if platform.system() != "Windows":
     from pandera.dtypes import Complex256, Float128
-
-
-def pandas_version():
-    # pylint:disable=missing-function-docstring,import-outside-toplevel
-    import pandas as pd
-    from packaging import version
-
-    return version.parse(pd.__version__)
-
-
-PANDAS_1_3_0_PLUS = pandas_version().release >= (1, 3, 0)

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -17,10 +17,20 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+from packaging import version
 
 from .. import dtypes
 from ..dtypes import immutable
 from . import engine, numpy_engine
+
+
+def pandas_version():
+    """Return the pandas version."""
+
+    return version.parse(pd.__version__)
+
+
+PANDAS_1_3_0_PLUS = pandas_version().release >= (1, 3, 0)
 
 try:
     from typing import Literal  # type: ignore
@@ -374,25 +384,43 @@ class Category(DataType, dtypes.Category):
         )
 
 
-@Engine.register_dtype(equivalents=["string", pd.StringDtype])
-@immutable(init=True)
-class STRING(DataType, dtypes.String):
-    """Semantic representation of a :class:`pandas.StringDtype`."""
+if PANDAS_1_3_0_PLUS:
 
-    type: pd.PeriodDtype = dataclasses.field(default=None, init=False)
-    storage: Optional[Literal["python", "pyarrow"]] = "python"
+    @Engine.register_dtype(equivalents=["string", pd.StringDtype])
+    @immutable(init=True)
+    class STRING(DataType, dtypes.String):
+        """Semantic representation of a :class:`pandas.StringDtype`."""
 
-    def __post_init__(self):
-        object.__setattr__(self, "type", pd.StringDtype(self.storage))
+        type: pd.StringDtype = dataclasses.field(default=None, init=False)
+        storage: Optional[Literal["python", "pyarrow"]] = "python"
 
-    @classmethod
-    def from_parametrized_dtype(cls, pd_dtype: pd.StringDtype):
-        """Convert a :class:`pandas.StringDtype` to
-        a Pandera :class:`pandera.engines.pandas_engine.STRING`."""
-        return cls(pd_dtype.storage)
+        def __post_init__(self):
+            if PANDAS_1_3_0_PLUS:
+                type_ = pd.StringDtype(self.storage)
+            else:
+                type_ = pd.StringDtype()
+            object.__setattr__(self, "type", type_)
 
-    def __str__(self) -> str:
-        return repr(self.type)
+        @classmethod
+        def from_parametrized_dtype(cls, pd_dtype: pd.StringDtype):
+            """Convert a :class:`pandas.StringDtype` to
+            a Pandera :class:`pandera.engines.pandas_engine.STRING`."""
+            return cls(pd_dtype.storage)
+
+        def __str__(self) -> str:
+            return repr(self.type)
+
+
+else:
+
+    @Engine.register_dtype(
+        equivalents=["string", pd.StringDtype, pd.StringDtype()]
+    )  # type: ignore
+    @immutable
+    class STRING(DataType, dtypes.String):  # type: ignore
+        """Semantic representation of a :class:`pandas.StringDtype`."""
+
+        type = pd.StringDtype()
 
 
 @Engine.register_dtype(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ pyyaml >=5.1
 typing_inspect >= 0.6.0
 typing_extensions >= 3.7.4.3
 frictionless
+pyarrow
 black >= 20.8b1
 isort >= 5.7.0
 codecov

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
         "typing_extensions >= 3.7.4.3 ; python_version<'3.8'",
         "typing_inspect >= 0.6.0",
         "wrapt",
+        "frictionless",
+        "pyarrow",
     ],
     extras_require=extras_require,
     python_requires=">=3.7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,6 @@ collect_ignore = []
 if not HAS_HYPOTHESIS:
     collect_ignore.append("test_strategies.py")
 else:
-    settings.register_profile("ci", max_examples=100, deadline=5000)
+    settings.register_profile("ci", max_examples=100, deadline=20000)
     settings.register_profile("dev", max_examples=10, deadline=2000)
     settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,6 @@ collect_ignore = []
 if not HAS_HYPOTHESIS:
     collect_ignore.append("test_strategies.py")
 else:
-    settings.register_profile("ci", max_examples=100, deadline=10000)
-    settings.register_profile("dev", max_examples=10, deadline=2000)
+    settings.register_profile("ci", max_examples=100, deadline=None)
+    settings.register_profile("dev", max_examples=10, deadline=None)
     settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,6 @@ collect_ignore = []
 if not HAS_HYPOTHESIS:
     collect_ignore.append("test_strategies.py")
 else:
-    settings.register_profile("ci", max_examples=100, deadline=20000)
+    settings.register_profile("ci", max_examples=100, deadline=10000)
     settings.register_profile("dev", max_examples=10, deadline=2000)
     settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -106,6 +106,7 @@ string_dtypes = {
     str: "str",
     pa.String: "str",
     np.str_: "str",
+    pd.StringDtype(storage="pyarrow"): "string[pyarrow]",
 }
 nullable_string_dtypes = {pd.StringDtype: "string"}
 

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -106,9 +106,13 @@ string_dtypes = {
     str: "str",
     pa.String: "str",
     np.str_: "str",
-    pd.StringDtype(storage="pyarrow"): "string[pyarrow]",
 }
+
 nullable_string_dtypes = {pd.StringDtype: "string"}
+if pa.PANDAS_1_3_0_PLUS:
+    nullable_string_dtypes.update(
+        {pd.StringDtype(storage="pyarrow"): "string[pyarrow]"}
+    )
 
 object_dtypes = {object: "object", np.object_: "object"}
 

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -328,6 +328,7 @@ def test_str_pattern_checks(str_strat, pattern_fn, chained, data, pattern):
         .filter(lambda x: x[0] < x[1])  # type: ignore
     ),
 )
+@hypothesis.settings(suppress_health_check=[hypothesis.HealthCheck.too_slow])
 def test_str_length_checks(chained, data, value_range):
     """Test built-in check strategies for string length."""
     min_value, max_value = value_range

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -70,6 +70,10 @@ def test_unsupported_pandas_dtype_strategy(data_type):
 
 @pytest.mark.parametrize("data_type", SUPPORTED_DTYPES)
 @hypothesis.given(st.data())
+@hypothesis.settings(
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+    max_examples=20,
+)
 def test_pandas_dtype_strategy(data_type, data):
     """Test that series can be constructed from pandas dtype."""
 
@@ -649,6 +653,7 @@ def test_field_element_strategy(data_type, data):
 @hypothesis.given(st.data())
 @hypothesis.settings(
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
+    deadline=None,
 )
 def test_check_nullable_field_strategy(
     data_type, field_strategy, nullable, data

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -653,7 +653,6 @@ def test_field_element_strategy(data_type, data):
 @hypothesis.given(st.data())
 @hypothesis.settings(
     suppress_health_check=[hypothesis.HealthCheck.too_slow],
-    deadline=None,
 )
 def test_check_nullable_field_strategy(
     data_type, field_strategy, nullable, data


### PR DESCRIPTION
This PR adds support for the [pyarrow backed string data type new in pandas 1.3.0](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.3.0.html#pyarrow-backed-string-data-type). 

It requires pandera >= 0.7.0 (new dtype engines).

Note: I moved `PANDAS_1_3_0_PLUS` from `pandera.__init__` to `pandera.engines.pandas_engine` so that it's usable within pandera.