### PR TITLE
Add 'ordered.setter' decorator

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -190,6 +190,11 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         """Whether or not to validate the columns order."""
         return self._ordered
 
+    @ordered.setter
+    def ordered(self, value: bool) -> None:
+        """Set ordered attribute"""
+        self._ordered = value
+
     # the _is_inferred getter and setter methods are not public
     @property
     def _is_inferred(self):


### PR DESCRIPTION
Hi!

I'm coming from the SciPy 2021 sprint and this is my first contribution to Pandera.
 
Summary of changes:
 - Adds `ordered.setter` decorator to class DataFrameSchema. Note: I did not put a period at the end of the docstring to mirror the `coerce.setter` method above.
  - Closes #563

The changes are quite small, but I made sure to run all the tests as [instructed here](https://github.com/pandera-dev/pandera/blob/master/.github/CONTRIBUTING.md#run-the-full-test-suite-locally). Please let me know if there are any changes I have to make.

Best,
V