### PR TITLE
unify dataframe definitions to fix auto-complete

### DIFF
--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -78,26 +78,20 @@ class Series(pd.Series, Generic[GenericDtype]):  # type: ignore
         raise AttributeError("Series should resolve to Field-s")
 
 
-if TYPE_CHECKING:  # pragma: no cover
-    # pylint:disable=too-few-public-methods,invalid-name
+# pylint:disable=invalid-name
+if TYPE_CHECKING:
     T = TypeVar("T")
-
-    class DataFrame(pd.DataFrame, Generic[T]):
-        """
-        Representation of pandas.DataFrame, only used for type annotation.
-
-        *new in 0.5.0*
-        """
-
-
 else:
-    # pylint:disable=too-few-public-methods
-    class DataFrame(pd.DataFrame, Generic[Schema]):
-        """
-        Representation of pandas.DataFrame, only used for type annotation.
+    T = Schema
 
-        *new in 0.5.0*
-        """
+
+# pylint:disable=too-few-public-methods
+class DataFrame(pd.DataFrame, Generic[T]):
+    """
+    Representation of pandas.DataFrame, only used for type annotation.
+
+    *new in 0.5.0*
+    """
 
 
 class AnnotationInfo:  # pylint:disable=too-few-public-methods


### PR DESCRIPTION
having two different dataframes defined under an `if` for some reason causing PyCharm to not offer auto-complete of
DataFrame methods/attributes. I'm not entirely sure why but some trial and error showed that this refactor seems to produce the correct behaviour. Note that I was *sometimes* able to get auto-complete working without this change, but it seemed to reliably work with the change added.

*Before*

<img width="569" alt="Screen Shot 2021-07-23 at 10 53 30" src="https://user-images.githubusercontent.com/212268/126727424-0f5b46d4-b155-4488-a68f-e78219ba7dcb.png">

*After*

<img width="591" alt="Screen Shot 2021-07-23 at 10 54 02" src="https://user-images.githubusercontent.com/212268/126727432-d82df7bb-ed60-4646-85e3-62cd6a6016fb.png">

