### PR TITLE
Add frictionless documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -313,6 +313,7 @@ Submit issues, feature requests or bugfixes on
    lazy_validation
    data_synthesis_strategies
    extensions
+   third_party_schema
 
 .. toctree::
    :maxdepth: 6

--- a/docs/source/third_party_schema.rst
+++ b/docs/source/third_party_schema.rst
@@ -1,0 +1,29 @@
+.. pandera documentation for integrating with third party schema
+
+.. currentmodule:: pandera
+
+.. _third_party_schema:
+
+Reading Third-Party Schema (new)
+================================
+
+*new in 0.7.0*
+
+Pandera now accepts schema from other data validation frameworks. This requires
+a pandera installation with the ``io`` extension; please see the
+:ref:`installation<installation>` instructions for more details.
+
+Frictionless Data Schema
+------------------------
+
+.. note:: Please see the
+    `Frictionless schema <https://specs.frictionlessdata.io/table-schema/>`_
+    documentation for more information on this standard.
+
+.. autofunction:: pandera.io.from_frictionless_schema
+
+under the hood, this uses the :class:`~pandera.io.FrictionlessFieldParser` class
+to parse each frictionless field (column):
+
+.. autoclass:: pandera.io.FrictionlessFieldParser
+    :members:

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -637,8 +637,7 @@ def from_frictionless_schema(
     >>> schema.columns["column_1"].allow_duplicates
     False
     >>> schema.columns["column_2"].checks
-    [<Check str_length: str_length(None, 10)>,
-     <Check str_matches: str_matches(re.compile('^\\S+$'))>]
+    [<Check str_length: str_length(None, 10)>, <Check str_matches: str_matches(re.compile('^\\\\S+$'))>]
     """
     if not isinstance(schema, FrictionlessSchema):
         schema = FrictionlessSchema(schema)

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -427,14 +427,15 @@ def to_script(dataframe_schema, path_or_buf=None):
 
 class FrictionlessFieldParser:
     """Parses frictionless data schema field specifications so we can convert
-    them to an equivalent :class:`pandera.schema_components.Column` schema.
+    them to an equivalent Pandera :class:`~pandera.schema_components.Column`
+    schema.
 
     For this implementation, we are using field names, constraints and types
     but leaving other frictionless parameters out (e.g. foreign keys, type
     formats, titles, descriptions).
 
     :param field: a field object from a frictionless schema.
-    :primary_keys: the primary keys from a frictionless schema. These are used
+    :param primary_keys: the primary keys from a frictionless schema. These are used
         to ensure primary key fields are treated properly - no duplicates,
         no missing values etc.
     """
@@ -486,7 +487,7 @@ class FrictionlessFieldParser:
         `here <https://specs.frictionlessdata.io/table-schema/#constraints>`_
         and maps them into the equivalent pandera checks.
 
-        :returns: a dictionary of pandera :class:`pandera.checks.Check`
+        :returns: a dictionary of pandera :class:`~pandera.checks.Check`
             objects which capture the standard constraint logic of a
             frictionless schema field.
         """
@@ -530,31 +531,47 @@ class FrictionlessFieldParser:
 
     @property
     def nullable(self) -> bool:
-        """Determine whether this field can contain missing values."""
+        """Determine whether this field can contain missing values.
+
+        If a field is a primary key, this will return ``False``."""
         if self.is_a_primary_key:
             return False
         return not self.constraints.get("required", False)
 
     @property
     def allow_duplicates(self) -> bool:
-        """Determine whether this field can contain duplicate values."""
+        """Determine whether this field can contain duplicate values.
+
+        If a field is a primary key, this will return ``False``."""
         if self.is_a_primary_key:
             return False
         return not self.constraints.get("unique", False)
 
     @property
     def coerce(self) -> bool:
-        """Determine whether values within this field should be coerced."""
+        """Determine whether values within this field should be coerced.
+
+        This currently returns ``True`` for all fields within a frictionless
+        schema.
+        """
         return True
 
     @property
     def required(self) -> bool:
-        """Determine whether this field must exist within the data."""
+        """Determine whether this field must exist within the data.
+
+        This currently returns ``True`` for all fields within a frictionless
+        schema.
+        """
         return True
 
     @property
     def regex(self) -> bool:
-        """Determine whether this field name should be used for regex matches."""
+        """Determine whether this field name should be used for regex matches.
+
+        This currently returns ``False`` for all fields within a frictionless
+        schema.
+        """
         return False
 
     def to_pandera_column(self) -> Dict:
@@ -574,9 +591,9 @@ class FrictionlessFieldParser:
 def from_frictionless_schema(
     schema: Union[str, Path, Dict, FrictionlessSchema]
 ) -> DataFrameSchema:
-    """Create a :class:`~pandera.schemas.DataFrameSchema` from a frictionless
-    json/yaml schema file on disk, or a frictionless schema already loaded
-    into memory.
+    """Create a :class:`~pandera.schemas.DataFrameSchema` from either a
+    frictionless json/yaml schema file saved on disk, or from a frictionless
+    schema already loaded into memory.
 
     Each field from the frictionless schema will be converted to a pandera
     column specification using :class:`~pandera.io.FrictionlessFieldParser`
@@ -590,18 +607,28 @@ def from_frictionless_schema(
 
     :example:
 
+    Here, we're defining a very basic frictionless schema in memory before
+    parsing it and then querying the resulting
+    :class:`~pandera.schemas.DataFrameSchema` object as per any other Pandera
+    schema:
+
     >>> from pandera.io import from_frictionless_schema
     >>>
     >>> FRICTIONLESS_SCHEMA = {
-    ...     "fields": [
-    ...         {
-    ...             "name": "column_1",
-    ...             "type": "integer",
-    ...             "constraints": {"minimum": 10, "maximum": 99}
-    ...         }
-    ...     ],
-    ...     "primaryKey": "column_1"
-    ... }
+         "fields": [
+             {
+                 "name": "column_1",
+                 "type": "integer",
+                 "constraints": {"minimum": 10, "maximum": 99}
+             },
+             {
+                 "name": "column_2",
+                 "type": "string",
+                 "constraints": {"maxLength": 10, "pattern": "\\S+"}
+             },
+         ],
+         "primaryKey": "column_1"
+     }
     >>> schema = from_frictionless_schema(FRICTIONLESS_SCHEMA)
     >>> schema.columns["column_1"].checks
     [<Check in_range: in_range(10, 99)>]
@@ -609,6 +636,9 @@ def from_frictionless_schema(
     True
     >>> schema.columns["column_1"].allow_duplicates
     False
+    >>> schema.columns["column_2"].checks
+    [<Check str_length: str_length(None, 10)>,
+     <Check str_matches: str_matches(re.compile('^\\S+$'))>]
     """
     if not isinstance(schema, FrictionlessSchema):
         schema = FrictionlessSchema(schema)

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -591,6 +591,7 @@ class FrictionlessFieldParser:
 def from_frictionless_schema(
     schema: Union[str, Path, Dict, FrictionlessSchema]
 ) -> DataFrameSchema:
+    # pylint: disable=line-too-long
     """Create a :class:`~pandera.schemas.DataFrameSchema` from either a
     frictionless json/yaml schema file saved on disk, or from a frictionless
     schema already loaded into memory.

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -615,20 +615,20 @@ def from_frictionless_schema(
     >>> from pandera.io import from_frictionless_schema
     >>>
     >>> FRICTIONLESS_SCHEMA = {
-    ...         "fields": [
-    ...             {
-    ...                 "name": "column_1",
-    ...                 "type": "integer",
-    ...                 "constraints": {"minimum": 10, "maximum": 99}
-    ...             },
-    ...             {
-    ...                 "name": "column_2",
-    ...                 "type": "string",
-    ...                 "constraints": {"maxLength": 10, "pattern": "\\S+"}
-    ...             },
-    ...         ],
-    ...         "primaryKey": "column_1"
-    ...     }
+    ...     "fields": [
+    ...         {
+    ...             "name": "column_1",
+    ...             "type": "integer",
+    ...             "constraints": {"minimum": 10, "maximum": 99}
+    ...         },
+    ...         {
+    ...             "name": "column_2",
+    ...             "type": "string",
+    ...             "constraints": {"maxLength": 10, "pattern": "\\S+"}
+    ...         },
+    ...     ],
+    ...     "primaryKey": "column_1"
+    ... }
     >>> schema = from_frictionless_schema(FRICTIONLESS_SCHEMA)
     >>> schema.columns["column_1"].checks
     [<Check in_range: in_range(10, 99)>]

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -615,20 +615,20 @@ def from_frictionless_schema(
     >>> from pandera.io import from_frictionless_schema
     >>>
     >>> FRICTIONLESS_SCHEMA = {
-         "fields": [
-             {
-                 "name": "column_1",
-                 "type": "integer",
-                 "constraints": {"minimum": 10, "maximum": 99}
-             },
-             {
-                 "name": "column_2",
-                 "type": "string",
-                 "constraints": {"maxLength": 10, "pattern": "\\S+"}
-             },
-         ],
-         "primaryKey": "column_1"
-     }
+    ...         "fields": [
+    ...             {
+    ...                 "name": "column_1",
+    ...                 "type": "integer",
+    ...                 "constraints": {"minimum": 10, "maximum": 99}
+    ...             },
+    ...             {
+    ...                 "name": "column_2",
+    ...                 "type": "string",
+    ...                 "constraints": {"maxLength": 10, "pattern": "\\S+"}
+    ...             },
+    ...         ],
+    ...         "primaryKey": "column_1"
+    ...     }
     >>> schema = from_frictionless_schema(FRICTIONLESS_SCHEMA)
     >>> schema.columns["column_1"].checks
     [<Check in_range: in_range(10, 99)>]


### PR DESCRIPTION
Fixes #492 

I wrote the original code, so I guess it makes sense for me to have a stab at this one!

I've expanded the docstrings within `pandera.io` and then included a minimal new page within the documentation to render these more clearly - this feels like a more sensible option than writing documentation from scratch, given that we're only partially covering the frictionless feature set and this might change in future, so any changes will just need to be reflected in the accompanying docstrings to get pulled through to the documentation in future builds