### PR TITLE
Feature/533: report all failure cases when coercing dtypes fails

### DIFF
--- a/pandera/check_utils.py
+++ b/pandera/check_utils.py
@@ -1,0 +1,62 @@
+"""Utility functions for validation."""
+
+from typing import Optional, Tuple, Union
+
+import pandas as pd
+
+
+def prepare_series_check_output(
+    check_obj: Union[pd.Series, pd.DataFrame],
+    check_output: pd.Series,
+    ignore_na: bool = True,
+    n_failure_cases: Optional[int] = None,
+) -> Tuple[pd.Series, pd.Series]:
+    """Prepare the check output and failure cases for a Series check output.
+
+    check_obj can be a dataframe, since a check function can potentially return
+    a Series resulting from applying some check function that outputs a Series.
+    """
+    if ignore_na:
+        isna = (
+            check_obj.isna().any(axis="columns")
+            if isinstance(check_obj, pd.DataFrame)
+            else check_obj.isna()
+        )
+        check_output = check_output | isna
+    failure_cases = check_obj[~check_output]
+    if not failure_cases.empty and n_failure_cases is not None:
+        failure_cases = failure_cases.groupby(check_output).head(
+            n_failure_cases
+        )
+    return check_output, failure_cases
+
+
+def prepare_dataframe_check_output(
+    check_obj: pd.DataFrame,
+    check_output: pd.DataFrame,
+    df_orig: Optional[pd.DataFrame] = None,
+    ignore_na: bool = True,
+    n_failure_cases: Optional[int] = None,
+) -> Tuple[pd.Series, pd.Series]:
+    """Unstack a dataframe of boolean values.
+
+    Check results consisting of a boolean dataframe should be reported at the
+    most granular level.
+    """
+    if df_orig is not None:
+        assert df_orig.shape == check_output.shape
+
+    if df_orig is None:
+        df_orig = check_obj
+    check_output = check_output.unstack()
+    if ignore_na:
+        check_output = check_output | df_orig.unstack().isna()
+    failure_cases = (
+        check_obj.unstack()[~check_output]
+        .rename("failure_case")
+        .rename_axis(["column", "index"])
+        .reset_index()
+    )
+    if not failure_cases.empty and n_failure_cases is not None:
+        failure_cases = failure_cases.drop_duplicates().head(n_failure_cases)
+    return check_output, failure_cases

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -21,7 +21,7 @@ from typing import (
 
 import pandas as pd
 
-from . import check_utils, constants, errors
+from . import constants, errors
 from . import strategies as st
 
 CheckResult = namedtuple(
@@ -368,6 +368,9 @@ class _CheckBase(metaclass=_CheckMeta):
 
             ``failure_cases``: subset of the check_object that failed.
         """
+        # pylint: disable=import-outside-toplevel
+        from pandera import check_utils
+
         # prepare check object
         if isinstance(df_or_series, pd.Series) or (
             column is not None and isinstance(df_or_series, pd.DataFrame)

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -21,7 +21,7 @@ from typing import (
 
 import pandas as pd
 
-from . import constants, errors
+from . import check_utils, constants, errors
 from . import strategies as st
 
 CheckResult = namedtuple(
@@ -368,9 +368,6 @@ class _CheckBase(metaclass=_CheckMeta):
 
             ``failure_cases``: subset of the check_object that failed.
         """
-        # pylint: disable=import-outside-toplevel
-        from pandera import check_utils
-
         # prepare check object
         if isinstance(df_or_series, pd.Series) or (
             column is not None and isinstance(df_or_series, pd.DataFrame)

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -27,7 +27,8 @@ _DataType = TypeVar("_DataType", bound=DataType)
 _Engine = TypeVar("_Engine", bound="Engine")
 _EngineType = Type[_Engine]
 
-if TYPE_CHECKING:
+
+if TYPE_CHECKING:  # pragma: no cover
 
     class Dispatch:
         """Only used for type annotation."""

--- a/pandera/engines/type_aliases.py
+++ b/pandera/engines/type_aliases.py
@@ -1,0 +1,10 @@
+"""Custom type aliases."""
+
+from typing import Union
+
+import numpy as np
+import pandas as pd
+
+PandasObject = Union[pd.Series, pd.Index, pd.DataFrame]
+PandasExtensionType = pd.core.dtypes.base.ExtensionDtype
+PandasDataType = Union[pd.core.dtypes.base.ExtensionDtype, np.dtype, type]

--- a/pandera/engines/utils.py
+++ b/pandera/engines/utils.py
@@ -1,0 +1,101 @@
+"""Engine module utilities."""
+
+import itertools
+from typing import Any, Union
+
+import numpy as np
+import pandas as pd
+
+from .. import check_utils
+from .type_aliases import PandasObject
+
+
+def numpy_pandas_coercible(series: pd.Series, type_: Any) -> pd.Series:
+    """Checks whether a series is coercible with respect to a type.
+
+    Bisects the series until all the failure cases are found.
+    """
+
+    def _bisect(series):
+        assert (
+            series.shape[0] >= 2
+        ), "cannot bisect a pandas Series of length < 2"
+        bisect_index = series.shape[0] // 2
+        return [series.iloc[:bisect_index], series.iloc[bisect_index:]]
+
+    def _coercible(series):
+        try:
+            series.astype(type_)
+            return True
+        except (ValueError, TypeError):
+            return False
+
+    search_list = _bisect(series)
+    failure_index = []
+    while search_list:
+        candidates = []
+        for _series in search_list:
+            if _series.shape[0] == 1 and not _coercible(_series):
+                # if series is reduced to a single value and isn't coercible,
+                # keep track of its index value.
+                failure_index.append(_series.index[0])
+            elif not _coercible(_series):
+                # if the series length > 1, add it to the candidates list
+                # to be further bisected
+                candidates.append(_series)
+
+        # the new search list is a flat list of bisected series views.
+        search_list = list(
+            itertools.chain.from_iterable([_bisect(c) for c in candidates])
+        )
+    return pd.Series(~series.index.isin(failure_index), index=series.index)
+
+
+def numpy_pandas_coerce_failure_cases(
+    data_container: Union[PandasObject, np.ndarray], type_: Any
+) -> PandasObject:
+    """
+    Get the failure cases resulting from trying to coerce a pandas/numpy object
+    into particular data type.
+    """
+    # pylint: disable=import-outside-toplevel
+    from pandera import error_formatters
+
+    if isinstance(data_container, np.ndarray):
+        if len(data_container.shape) == 1:
+            data_container = pd.Series(data_container)
+        elif len(data_container.shape) == 2:
+            data_container = pd.DataFrame(data_container)
+        else:
+            raise ValueError(
+                "only numpy arrays of 1 or 2 dimensions are supported"
+            )
+
+    if isinstance(data_container, pd.Index):
+        data_container = data_container.to_series()
+
+    if isinstance(data_container, pd.DataFrame):
+        check_output = data_container.apply(
+            numpy_pandas_coercible,
+            args=(type_,),
+        )
+        _, failure_cases = check_utils.prepare_dataframe_check_output(
+            data_container,
+            check_output,
+            ignore_na=False,
+        )
+    elif isinstance(data_container, pd.Series):
+        check_output = numpy_pandas_coercible(data_container, type_)
+        _, failure_cases = check_utils.prepare_series_check_output(
+            data_container,
+            check_output,
+            ignore_na=False,
+        )
+    else:
+        raise TypeError(
+            f"type of data_container {type(data_container)} not understood. "
+            "Must be a pandas Series, Index, or DataFrame."
+        )
+    return error_formatters.reshape_failure_cases(
+        failure_cases, ignore_na=False
+    )

--- a/pandera/engines/utils.py
+++ b/pandera/engines/utils.py
@@ -58,7 +58,7 @@ def numpy_pandas_coerce_failure_cases(
     Get the failure cases resulting from trying to coerce a pandas/numpy object
     into particular data type.
     """
-    # pylint: disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel,cyclic-import
     from pandera import error_formatters
 
     if isinstance(data_container, np.ndarray):

--- a/pandera/error_formatters.py
+++ b/pandera/error_formatters.py
@@ -18,7 +18,10 @@ def format_generic_error_message(
     :param check: check that generated error.
     :param check_index: The validator that failed.
     """
-    return f"{parent_schema} failed series or dataframe validator {check_index}:\n{check}"
+    return (
+        f"{parent_schema} failed series or dataframe validator "
+        f"{check_index}:\n{check}"
+    )
 
 
 def format_vectorized_error_message(
@@ -117,7 +120,8 @@ def reshape_failure_cases(
         )
     else:
         raise TypeError(
-            f"type of failure_cases argument not understood: {type(failure_cases)}"
+            "type of failure_cases argument not understood: "
+            f"{type(failure_cases)}"
         )
 
     return (

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -17,6 +17,14 @@ ErrorData = namedtuple(
 )
 
 
+class ParserError(Exception):
+    """Raised when data cannot be parsed from the raw into its clean form."""
+
+    def __init__(self, message, failure_cases):
+        super().__init__(message)
+        self.failure_cases = failure_cases
+
+
 class SchemaInitError(Exception):
     """Raised when schema initialization fails."""
 

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -308,7 +308,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         try:
             return self.dtype.coerce(obj)
-        except Exception as exc:
+        except errors.ParserError as exc:
             raise errors.SchemaError(
                 self,
                 obj,
@@ -316,7 +316,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                     f"Error while coercing '{self.name}' to type "
                     f"{self.dtype}: {exc}"
                 ),
-                failure_cases=scalar_failure_case(str(obj.dtypes.to_dict())),
+                failure_cases=exc.failure_cases,
                 check=f"coerce_dtype('{self.dtype}')",
             ) from exc
 
@@ -1614,7 +1614,7 @@ class SeriesSchemaBase:
 
         try:
             return self.dtype.coerce(obj)
-        except (ValueError, TypeError) as exc:
+        except errors.ParserError as exc:
             msg = (
                 f"Error while coercing '{self.name}' to type "
                 f"{self.dtype}: {exc}"
@@ -1623,7 +1623,7 @@ class SeriesSchemaBase:
                 self,
                 obj,
                 msg,
-                failure_cases=scalar_failure_case(str(obj.dtype)),
+                failure_cases=exc.failure_cases,
                 check=f"coerce_dtype('{self.dtype}')",
             ) from exc
 

--- a/tests/core/test_engine_utils.py
+++ b/tests/core/test_engine_utils.py
@@ -1,0 +1,72 @@
+"""Unit tests for engine module utility functions."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pandera.engines import utils
+
+
+@pytest.mark.parametrize(
+    "data_container, data_type, expected_failure_cases",
+    [
+        [pd.Series(list("ab1cd3")), int, [False, False, True] * 2],
+        [pd.Series(list("12345")), int, [True] * 5],
+        [pd.Series([1, 2, "foo", "bar"]), float, [True, True, False, False]],
+    ],
+)
+def test_numpy_pandas_coercible(
+    data_container, data_type, expected_failure_cases
+):
+    """Test that the correct boolean Series outputs are returned."""
+    assert (
+        expected_failure_cases
+        == utils.numpy_pandas_coercible(data_container, data_type).tolist()
+    )
+
+
+@pytest.mark.parametrize(
+    "data_container",
+    [
+        pd.Series([1, 2, 3, 4]),
+        np.array([1, 2, 3, 4]),
+        pd.DataFrame({0: [1, 2, 3, 4]}),
+        np.array([[1], [2], [3], [4]]),
+    ],
+)
+def test_numpy_pandas_coerce_failure_cases(data_container):
+    """
+    Test that different data container types can be checked for coerce failure
+    cases.
+    """
+    failure_cases = utils.numpy_pandas_coerce_failure_cases(
+        data_container, int
+    )
+    assert isinstance(failure_cases, pd.DataFrame)
+    assert failure_cases.empty
+
+
+@pytest.mark.parametrize(
+    "invalid_data_container, exception_type",
+    [
+        [1, TypeError],
+        [5.1, TypeError],
+        ["foobar", TypeError],
+        [[1, 2, 3], TypeError],
+        [{0: 1}, TypeError],
+        # pylint: disable=too-many-function-args
+        [np.array([1]).reshape(1, 1, 1), ValueError],
+    ],
+)
+def test_numpy_pandas_coerce_failure_cases_exceptions(
+    invalid_data_container, exception_type
+):
+    """
+    Test exceptions of trying to get failure cases for invalid input types.
+    """
+    error_msg = {
+        TypeError: "type of data_container .+ not understood",
+        ValueError: "only numpy arrays of 1 or 2 dimensions are supported",
+    }[exception_type]
+    with pytest.raises(exception_type, match=error_msg):
+        utils.numpy_pandas_coerce_failure_cases(invalid_data_container, int)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -891,7 +891,7 @@ def test_frictionless_schema_parses_correctly(frictionless_schema):
     ).to_dict(orient="records") == [
         {"check": "column_in_schema", "failure_case": "unexpected_column"},
         {"check": "column_in_dataframe", "failure_case": "date_col"},
-        {"check": "coerce_dtype('float64')", "failure_case": "object"},
+        {"check": "coerce_dtype('float64')", "failure_case": "a"},
         {"check": "no_duplicates", "failure_case": 12},
         {"check": "in_range(10, 99)", "failure_case": 1},
         {"check": "in_range(10, 99)", "failure_case": 180},


### PR DESCRIPTION
Fixes #533 

This PR adds support for reporting all failure cases when failing to coerce a column/dataframe to the specified type.