### PR TITLE
Docs/scaling - Bring Pandera to Spark and Dask

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,6 +67,7 @@ else:
 SKIP = sys.version_info < (3, 6)
 PY36 = sys.version_info < (3, 7)
 SKIP_PANDAS_LT_V1 = version.parse(pd.__version__).release < (1, 0) or PY36
+SKIP_SCALING = True
 """
 
 doctest_default_flags = (

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -311,6 +311,7 @@ Submit issues, feature requests or bugfixes on
    schema_inference
    schema_models
    lazy_validation
+   scaling
    data_synthesis_strategies
    extensions
    third_party_schema

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -311,10 +311,10 @@ Submit issues, feature requests or bugfixes on
    schema_inference
    schema_models
    lazy_validation
-   scaling
    data_synthesis_strategies
    extensions
    third_party_schema
+   scaling
 
 .. toctree::
    :maxdepth: 6

--- a/docs/source/scaling.rst
+++ b/docs/source/scaling.rst
@@ -1,0 +1,127 @@
+.. currentmodule:: pandera
+
+.. _scaling:
+
+Scaling Pandera to Big Data
+=================================
+
+Pandera only support Pandas DataFrames at the moment. However, the same Pandera code
+can be used on Spark or Dask with Fugue. Because Dask is built on top of Pandas DataFrames,
+it may be easier to
+
+Fugue
+-----
+
+Fugue is an abstraction layer that ports Python, Pandas, and SQL code to Spark and Dask. Here,
+
+To install:
+
+
+Example
+-------
+
+In this example, a pandas ``DataFrame`` in created with ``state``, ``city`` and ``price``
+columns.
+
+.. testcode:: scaling_pandera
+
+    import pandas as pd
+
+    data = pd.DataFrame({'state': ['FL','FL','FL','CA','CA','CA'],
+                        'city': ['Orlando', 'Miami', 'Tampa',
+                                'San Francisco', 'Los Angeles', 'San Diego'],
+                        'price': [8, 12, 10, 16, 20, 18]})
+    print(data)
+
+.. testoutput:: scaling_pandera
+
+    state           city  price
+    0    FL        Orlando      8
+    1    FL          Miami     12
+    2    FL          Tampa     10
+    3    CA  San Francisco     16
+    4    CA    Los Angeles     20
+    5    CA      San Diego     18
+
+Validation is then applied using pandera.
+
+.. testcode:: scaling_pandera
+
+    from pandera import Column, DataFrameSchema, Check
+
+    price_check = DataFrameSchema(
+        {"price": Column(int, Check.in_range(min_value=5,max_value=20))}
+    )
+
+    def price_validation(data:pd.DataFrame) -> pd.DataFrame:
+        price_check.validate(data)
+        return data
+
+    price_validation(data)
+
+Bringing this to Spark
+
+.. testcode:: scaling_pandera
+    from fugue import transform
+    from fugue_spark import SparkExecutionEngine
+
+    spark_df = transform(data, using=price_validation, schema="*", engine=SparkExecutionEngine)
+    spark_df.show()
+
+.. testoutput:: scaling_pandera
+    +-----+-------------+-----+
+    |state|         city|price|
+    +-----+-------------+-----+
+    |   FL|      Orlando|    8|
+    |   FL|        Miami|   12|
+    |   FL|        Tampa|   10|
+    |   CA|San Francisco|   16|
+    |   CA|  Los Angeles|   20|
+    |   CA|    San Diego|   18|
+    +-----+-------------+-----+
+
+
+Validation by Partition
+-----------------------
+
+There is an interesting use case that comes up
+
+.. testcode:: scaling_pandera
+
+    price_check_FL = DataFrameSchema({
+        "price": Column(int, Check.in_range(min_value=7,max_value=13)),
+    })
+
+    price_check_CA = DataFrameSchema({
+        "price": Column(Int, Check.in_range(min_value=15,max_value=21)),
+    })
+
+    price_checks = {'CA': price_check_CA, 'FL': price_check_FL}
+
+.. testcode:: scaling_pandera
+
+    from fugue import FugueWorkflow
+
+    def price_validation(df:pd.DataFrame) -> pd.DataFrame:
+        location = df['state'].iloc[0]
+        check = price_checks[location]
+        check.validate(df)
+        return df
+
+    with FugueWorkflow(SparkExecutionEngine) as dag:
+        df = dag.df(data)
+        df = df.partition(by=["state"]).transform(price_validation)
+        df.show()
+
+.. testoutput:: scaling_pandera
+
+    SparkDataFrame
+    state:str|city:str                                                                       |price:long
+    ---------+-------------------------------------------------------------------------------+----------
+    CA       |San Francisco                                                                  |16
+    CA       |Los Angeles                                                                    |20
+    CA       |San Diego                                                                      |18
+    FL       |Orlando                                                                        |8
+    FL       |Miami                                                                          |12
+    FL       |Tampa                                                                          |10
+    Total count: 6

--- a/docs/source/scaling.rst
+++ b/docs/source/scaling.rst
@@ -73,8 +73,7 @@ created that runs the validation. None of this will be new.
     )
 
     def price_validation(data:pd.DataFrame) -> pd.DataFrame:
-        price_check.validate(data)
-        return data
+        return price_check.validate(data)
 
 The ``transform`` function in ``Fugue`` is the easiest way to use ``Fugue`` with existing ``Python``
 functions as seen in the following code snippet. The first two arguments are the ``DataFrame`` and


### PR DESCRIPTION
Hi @cosmicBboy,

Here is a first pass of the `scaling.rst` we talked about. Here, we show how to scale `pandera` code to `Spark` and `Dask` using [Fugue](https://github.com/fugue-project/fugue). Thanks for agreeing to collaborate. Feedback is appreciated.

I don't know if you want to take it from here and find a place for this but @goodwanghan and I can also take care of making changes from your feedback. Just let us know.