### PR TITLE
add support for Any annotation in schema model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         args: ["--line-length=79"]
 
   - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.7.2
+    rev: v2.10.2
     hooks:
       - id: pylint
         args: ["--disable=import-error"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,7 +56,7 @@ def _build_setup_requirements() -> Dict[str, List[Requirement]]:
 
 def _build_dev_requirements() -> List[Requirement]:
     """Load requirements from file."""
-    with open(REQUIREMENT_PATH, "rt") as req_file:
+    with open(REQUIREMENT_PATH, "rt", encoding="utf-8") as req_file:
         return list(parse_requirements(req_file.read()))
 
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -298,6 +298,8 @@ class SchemaModel:
             else:
                 dtype = annotation.arg
 
+            dtype = None if dtype is Any else dtype
+
             if annotation.origin is Series:
                 col_constructor = (
                     field.to_column if field else schema_components.Column

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -357,6 +357,7 @@ def test_check_io() -> None:
     for out_schema in [1, 5.0, "foo", {"foo": "bar"}, ["foo"]]:
 
         # mypy finds correctly the wrong usage
+        # pylint: disable=cell-var-from-loop
         @check_io(out=out_schema)  # type: ignore[arg-type]
         def invalid_out_schema_type(df):
             return df
@@ -688,7 +689,8 @@ def test_check_types_with_literal_type(arg_examples):
         @check_types
         def transform_with_literal(
             df: DataFrame[InSchema],
-            arg: arg_type,  # pylint: disable=unused-argument
+            # pylint: disable=unused-argument,cell-var-from-loop
+            arg: arg_type,
         ) -> DataFrame[OutSchema]:
             return df.assign(b=100)
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2,7 +2,7 @@
 # pylint:disable=missing-class-docstring,missing-function-docstring,too-few-public-methods
 import re
 from decimal import Decimal  # pylint:disable=C0415
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import pandas as pd
 import pytest
@@ -18,10 +18,11 @@ def test_to_schema() -> None:
     class Schema(pa.SchemaModel):
         a: Series[int]
         b: Series[str]
+        c: Series[Any]
         idx: Index[str]
 
     expected = pa.DataFrameSchema(
-        columns={"a": pa.Column(int), "b": pa.Column(str)},
+        columns={"a": pa.Column(int), "b": pa.Column(str), "c": pa.Column()},
         index=pa.Index(str),
     )
 


### PR DESCRIPTION
the motivation behind this feature is to support column annotations
that can have any type, to support use cases like the one described
in https://github.com/pandera-dev/pandera/discussions/592, where
custom checks can be applied to any column except for ones that
are explicitly defined in the schema model class attributes