### PR TITLE
Add support for timezone-aware datetime strategies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         args: ["--line-length=79"]
 
   - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.7.2
+    rev: v2.10.2
     hooks:
       - id: pylint
         args: ["--disable=import-error"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,6 +67,7 @@ else:
 SKIP = sys.version_info < (3, 6)
 PY36 = sys.version_info < (3, 7)
 SKIP_PANDAS_LT_V1 = version.parse(pd.__version__).release < (1, 0) or PY36
+SKIP_SCALING = True
 """
 
 doctest_default_flags = (

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -314,6 +314,7 @@ Submit issues, feature requests or bugfixes on
    data_synthesis_strategies
    extensions
    third_party_schema
+   scaling
 
 .. toctree::
    :maxdepth: 6

--- a/docs/source/scaling.rst
+++ b/docs/source/scaling.rst
@@ -1,0 +1,180 @@
+.. currentmodule:: pandera
+
+.. _scaling:
+
+Scaling Pandera to Big Data
+=================================
+
+Validation on big data comes in two forms. The first is performing one set of
+validations on data that doesn't fit in memory. The second happens when a large dataset
+is comprised of multiple groups that require different validations. In pandas semantics,
+this would be the equivalent of a ``groupby-validate`` operation. This section will cover
+using ``pandera`` for both of these scenarios.
+
+``Pandera`` only supports pandas ``DataFrames`` at the moment. However, the same ``pandera``
+code can be used on top of ``Spark`` or ``Dask`` engines with
+`Fugue <https://github.com/fugue-project/fugue/>`_ . These computation engines allow validation
+to be performed in a distributed setting. ``Fugue`` is an open source abstraction layer that
+ports ``Python``, ``pandas``, and ``SQL`` code to ``Spark`` and ``Dask``.
+
+Fugue
+-----
+
+``Fugue`` serves as an interface to distributed computing. Because of its non-invasive design,
+existing ``Python`` code can be scaled to a distributed setting without significant changes.
+
+To run the example, ``Fugue`` needs to installed separately. Using pip:
+
+.. code:: bash
+
+    pip install fugue[spark]
+
+This will also install ``PySpark`` because of the ``spark`` extra. ``Dask`` is available
+with the ``dask`` extra.
+
+
+Example
+-------
+
+In this example, a pandas ``DataFrame`` is created with ``state``, ``city`` and ``price``
+columns. ``Pandera`` will be used to validate that the ``price`` column values are within
+a certain range.
+
+.. testcode:: scaling_pandera
+
+    import pandas as pd
+
+    data = pd.DataFrame({'state': ['FL','FL','FL','CA','CA','CA'],
+                        'city': ['Orlando', 'Miami', 'Tampa',
+                                'San Francisco', 'Los Angeles', 'San Diego'],
+                        'price': [8, 12, 10, 16, 20, 18]})
+    print(data)
+
+.. testoutput:: scaling_pandera
+
+      state           city  price
+    0    FL        Orlando      8
+    1    FL          Miami     12
+    2    FL          Tampa     10
+    3    CA  San Francisco     16
+    4    CA    Los Angeles     20
+    5    CA      San Diego     18
+
+
+Validation is then applied using pandera. A ``price_validation`` function is
+created that runs the validation. None of this will be new.
+
+.. testcode:: scaling_pandera
+
+    from pandera import Column, DataFrameSchema, Check
+
+    price_check = DataFrameSchema(
+        {"price": Column(int, Check.in_range(min_value=5,max_value=20))}
+    )
+
+    def price_validation(data:pd.DataFrame) -> pd.DataFrame:
+        return price_check.validate(data)
+
+The ``transform`` function in ``Fugue`` is the easiest way to use ``Fugue`` with existing ``Python``
+functions as seen in the following code snippet. The first two arguments are the ``DataFrame`` and
+function to apply. The keyword argument ``schema`` is required because schema is strictly enforced
+in distributed settings. Here, the ``schema`` is simply `*` because no new columns are added.
+
+The last part of the ``transform`` function is the ``engine``. Here, the ``SparkExecutionEngine`` is used
+to run the code on top of ``Spark``. ``Fugue`` also has a ``DaskExecutionEngine``, and passing nothing uses
+the default pandas-based ``ExecutionEngine``. Because the ``SparkExecutionEngine`` is used, the result
+becomes a ``Spark DataFrame``.
+
+.. testcode:: scaling_pandera
+    :skipif: SKIP_SCALING
+
+    from fugue import transform
+    from fugue_spark import SparkExecutionEngine
+
+    spark_df = transform(data, price_validation, schema="*", engine=SparkExecutionEngine)
+    spark_df.show()
+
+.. testoutput:: scaling_pandera
+    :skipif: SKIP_SCALING
+
+    +-----+-------------+-----+
+    |state|         city|price|
+    +-----+-------------+-----+
+    |   FL|      Orlando|    8|
+    |   FL|        Miami|   12|
+    |   FL|        Tampa|   10|
+    |   CA|San Francisco|   16|
+    |   CA|  Los Angeles|   20|
+    |   CA|    San Diego|   18|
+    +-----+-------------+-----+
+
+
+Validation by Partition
+-----------------------
+
+There is an interesting use case that arises with bigger datasets. Frequently, there are logical
+groupings of data that require different validations. In the earlier sample data, the
+price range for the records with ``state`` FL is lower than the range for the ``state`` CA.
+Two :class:`~pandera.schemas.DataFrameSchema` will be created to reflect this. Notice their ranges
+for the :class:`~pandera.checks.Check` differ.
+
+.. testcode:: scaling_pandera
+
+    price_check_FL = DataFrameSchema({
+        "price": Column(int, Check.in_range(min_value=7,max_value=13)),
+    })
+
+    price_check_CA = DataFrameSchema({
+        "price": Column(int, Check.in_range(min_value=15,max_value=21)),
+    })
+
+    price_checks = {'CA': price_check_CA, 'FL': price_check_FL}
+
+A slight modification is needed to our ``price_validation`` function. ``Fugue`` will partition
+the whole dataset into multiple pandas ``DataFrames``. Think of this as a ``groupby``. By the
+time ``price_validation`` is used, it only contains the data for one ``state``. The appropriate
+``DataFrameSchema`` is pulled and then applied.
+
+To partition our data by ``state``, all we need to do is pass it into the ``transform`` function
+through the ``partition`` argument. This splits up the data across different workers before they
+each run the ``price_validation`` function. Again, this is like a groupby-validation.
+
+.. testcode:: scaling_pandera
+    :skipif: SKIP_SCALING
+
+    def price_validation(df:pd.DataFrame) -> pd.DataFrame:
+        location = df['state'].iloc[0]
+        check = price_checks[location]
+        check.validate(df)
+        return df
+
+    spark_df = transform(data,
+              price_validation,
+              schema="*",
+              partition=dict(by="state"),
+              engine=SparkExecutionEngine)
+
+    spark_df.show()
+
+.. testoutput:: scaling_pandera
+    :skipif: SKIP_SCALING
+
+    SparkDataFrame
+    state:str|city:str                                                 |price:long
+    ---------+---------------------------------------------------------+----------
+    CA       |San Francisco                                            |16
+    CA       |Los Angeles                                              |20
+    CA       |San Diego                                                |18
+    FL       |Orlando                                                  |8
+    FL       |Miami                                                    |12
+    FL       |Tampa                                                    |10
+    Total count: 6
+
+.. note::
+
+    Because operations in a distributed setting are applied per partition, statistical
+    validators will be applied on each partition rather than the global dataset. If no
+    partitioning scheme is specified, ``Spark`` and ``Dask`` use default partitions. Be
+    careful about using operations like mean, min, and max without partitioning beforehand.
+
+    All row-wise validations scale well with this set-up.

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,7 +56,7 @@ def _build_setup_requirements() -> Dict[str, List[Requirement]]:
 
 def _build_dev_requirements() -> List[Requirement]:
     """Load requirements from file."""
-    with open(REQUIREMENT_PATH, "rt") as req_file:
+    with open(REQUIREMENT_PATH, "rt", encoding="utf-8") as req_file:
         return list(parse_requirements(req_file.read()))
 
 

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -157,7 +157,13 @@ class Engine(  # pylint:disable=too-few-public-methods
             alias = "bool"
         elif alias.startswith("string"):
             alias = "str"
-        return np.dtype(alias)
+
+        try:
+            return np.dtype(alias)
+        except TypeError as err:
+            raise TypeError(
+                f"Data type '{pandera_dtype}' cannot be cast to a numpy dtype."
+            ) from err
 
 
 ###############################################################################

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -298,6 +298,8 @@ class SchemaModel:
             else:
                 dtype = annotation.arg
 
+            dtype = None if dtype is Any else dtype
+
             if annotation.origin is Series:
                 col_constructor = (
                     field.to_column if field else schema_components.Column

--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -245,6 +245,10 @@ def _datetime_strategy(
         return st.builds(dtype.type, strategy, res)
 
 
+def _to_unix_timestamp(value: Any) -> int:
+    return pd.Timestamp(value).value
+
+
 def numpy_time_dtypes(
     dtype: Union[np.dtype, pd.DatetimeTZDtype], min_value=None, max_value=None
 ):
@@ -255,13 +259,13 @@ def numpy_time_dtypes(
     :param max_value: maximum value of the datatype to create
     :returns: ``hypothesis`` strategy
     """
-    return _datetime_strategy(
-        dtype,
-        st.integers(
-            min_value=MIN_DT_VALUE if min_value is None else min_value,
-            max_value=MAX_DT_VALUE if max_value is None else max_value,
-        ),
+    min_value = (
+        MIN_DT_VALUE if min_value is None else _to_unix_timestamp(min_value)
     )
+    max_value = (
+        MAX_DT_VALUE if max_value is None else _to_unix_timestamp(max_value)
+    )
+    return _datetime_strategy(dtype, st.integers(min_value, max_value))
 
 
 def numpy_complex_dtypes(
@@ -1063,7 +1067,8 @@ def dataframe_strategy(
         }
 
         nullable_columns = {
-            col_name: col.nullable for col_name, col in expanded_columns.items()
+            col_name: col.nullable
+            for col_name, col in expanded_columns.items()
         }
 
         row_strategy = None

--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -230,10 +230,10 @@ def _datetime_strategy(
 
     if isinstance(dtype, pd.DatetimeTZDtype):
 
-        def _to_datetime(value: Any) -> pd.DatetimeTZDtype:
+        def _to_datetime(value) -> pd.DatetimeTZDtype:
             if isinstance(value, pd.Timestamp):
-                return value.tz_convert(tz=dtype.tz)
-            return pd.Timestamp(value, unit=dtype.unit, tz=dtype.tz)
+                return value.tz_convert(tz=dtype.tz)  # type: ignore[union-attr]
+            return pd.Timestamp(value, unit=dtype.unit, tz=dtype.tz)  # type: ignore[union-attr]
 
         return st.builds(_to_datetime, strategy)
     else:

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -357,6 +357,7 @@ def test_check_io() -> None:
     for out_schema in [1, 5.0, "foo", {"foo": "bar"}, ["foo"]]:
 
         # mypy finds correctly the wrong usage
+        # pylint: disable=cell-var-from-loop
         @check_io(out=out_schema)  # type: ignore[arg-type]
         def invalid_out_schema_type(df):
             return df
@@ -688,7 +689,8 @@ def test_check_types_with_literal_type(arg_examples):
         @check_types
         def transform_with_literal(
             df: DataFrame[InSchema],
-            arg: arg_type,  # pylint: disable=unused-argument
+            # pylint: disable=unused-argument,cell-var-from-loop
+            arg: arg_type,
         ) -> DataFrame[OutSchema]:
             return df.assign(b=100)
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2,7 +2,7 @@
 # pylint:disable=missing-class-docstring,missing-function-docstring,too-few-public-methods
 import re
 from decimal import Decimal  # pylint:disable=C0415
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import pandas as pd
 import pytest
@@ -18,10 +18,11 @@ def test_to_schema() -> None:
     class Schema(pa.SchemaModel):
         a: Series[int]
         b: Series[str]
+        c: Series[Any]
         idx: Index[str]
 
     expected = pa.DataFrameSchema(
-        columns={"a": pa.Column(int), "b": pa.Column(str)},
+        columns={"a": pa.Column(int), "b": pa.Column(str), "c": pa.Column()},
         index=pa.Index(str),
     )
 

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -881,30 +881,33 @@ def test_schema_component_with_no_pdtype() -> None:
 def test_datetime_example() -> None:
     """Test Column schema example method generate examples of
     timezone-naive datetimes that pass."""
-    column_schema = pa.Column(
-        "datetime",
-        checks=[
-            pa.Check.eq(pd.Timestamp("2006-01-01")),
-            pa.Check.ne(np.datetime64("2005-02-25")),
-            pa.Check.isin([np.datetime64("2006-01-01")]),
-        ],
-        name="test_datetime",
-    )
-    for _ in range(10):
-        column_schema(column_schema.example())
+
+    for checks in [
+        pa.Check.le(pd.Timestamp("2006-01-01")),
+        pa.Check.ge(np.datetime64("2006-01-01")),
+        pa.Check.eq(pd.Timestamp("2006-01-01")),
+        pa.Check.isin([np.datetime64("2006-01-01")]),
+    ]:
+        column_schema = pa.Column(
+            "datetime", checks=checks, name="test_datetime"
+        )
+        for _ in range(5):
+            column_schema(column_schema.example())
 
 
 def test_datetime_tz_example() -> None:
     """Test Column schema example method generate examples of
     timezone-aware datetimes that pass."""
-    column_schema = pa.Column(
-        pd.DatetimeTZDtype(tz="UTC"),
-        checks=[
-            pa.Check.eq(pd.Timestamp("2006-01-01", tz="UTC")),
-            pa.Check.ne(pd.Timestamp("2006-01-02")),
-            pa.Check.isin([pd.Timestamp("2006-01-01", tz="UTC")]),
-        ],
-        name="test_datetime_tz",
-    )
-    for _ in range(1):
-        column_schema(column_schema.example())
+    for checks in [
+        pa.Check.le(pd.Timestamp("2006-01-01", tz="CET")),
+        pa.Check.ge(pd.Timestamp("2006-01-01", tz="UTC")),
+        pa.Check.eq(pd.Timestamp("2006-01-01", tz="CET")),
+        pa.Check.isin([pd.Timestamp("2006-01-01", tz="UTC")]),
+    ]:
+        column_schema = pa.Column(
+            pd.DatetimeTZDtype(tz="UTC"),
+            checks=checks,
+            name="test_datetime_tz",
+        )
+        for _ in range(5):
+            column_schema(column_schema.example())

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -39,6 +39,8 @@ for data_type in pandas_engine.Engine.get_registered_dtypes():
         continue
     SUPPORTED_DTYPES.add(pandas_engine.Engine.dtype(data_type))
 
+SUPPORTED_DTYPES.add(pandas_engine.Engine.dtype("datetime64[ns, UTC]"))
+
 NUMERIC_DTYPES = [
     data_type for data_type in SUPPORTED_DTYPES if data_type.continuous
 ]
@@ -51,20 +53,19 @@ NULLABLE_DTYPES = [
     and not data_type == pandas_engine.Engine.dtype("object")
 ]
 
-NUMERIC_RANGE_CONSTANT = 10
-DATE_RANGE_CONSTANT = np.timedelta64(NUMERIC_RANGE_CONSTANT, "D")
-COMPLEX_RANGE_CONSTANT = np.complex64(
-    complex(NUMERIC_RANGE_CONSTANT, NUMERIC_RANGE_CONSTANT)  # type: ignore
+
+@pytest.mark.parametrize(
+    "data_type",
+    [
+        pa.Category,
+        pandas_engine.Interval(  # type: ignore # pylint:disable=unexpected-keyword-arg,no-value-for-parameter
+            subtype=np.int64
+        ),
+    ],
 )
-
-
-@pytest.mark.parametrize("data_type", [pa.Category])
 def test_unsupported_pandas_dtype_strategy(data_type):
     """Test unsupported pandas dtype strategy raises error."""
-    with pytest.raises(
-        TypeError,
-        match="data generation for the Category dtype is currently unsupported",
-    ):
+    with pytest.raises(TypeError, match=r"is currently unsupported"):
         strategies.pandas_dtype_strategy(data_type)
 
 
@@ -84,10 +85,14 @@ def test_pandas_dtype_strategy(data_type, data):
     example = data.draw(strategy)
 
     expected_type = strategies.to_numpy_dtype(data_type).type
+    if isinstance(example, pd.Timestamp):
+        example = example.to_numpy()
     assert example.dtype.type == expected_type
 
     chained_strategy = strategies.pandas_dtype_strategy(data_type, strategy)
     chained_example = data.draw(chained_strategy)
+    if isinstance(chained_example, pd.Timestamp):
+        chained_example = chained_example.to_numpy()
     assert chained_example.dtype.type == expected_type
 
 
@@ -871,3 +876,35 @@ def test_schema_component_with_no_pdtype() -> None:
     ]:
         with pytest.raises(pa.errors.SchemaDefinitionError):
             schema_component_strategy(pandera_dtype=None)  # type: ignore
+
+
+def test_datetime_example() -> None:
+    """Test Column schema example method generate examples of
+    timezone-naive datetimes that pass."""
+    column_schema = pa.Column(
+        "datetime",
+        checks=[
+            pa.Check.eq(pd.Timestamp("2006-01-01")),
+            pa.Check.ne(np.datetime64("2005-02-25")),
+            pa.Check.isin([np.datetime64("2006-01-01")]),
+        ],
+        name="test_datetime",
+    )
+    for _ in range(10):
+        column_schema(column_schema.example())
+
+
+def test_datetime_tz_example() -> None:
+    """Test Column schema example method generate examples of
+    timezone-aware datetimes that pass."""
+    column_schema = pa.Column(
+        pd.DatetimeTZDtype(tz="UTC"),
+        checks=[
+            pa.Check.eq(pd.Timestamp("2006-01-01", tz="UTC")),
+            pa.Check.ne(pd.Timestamp("2006-01-02")),
+            pa.Check.isin([pd.Timestamp("2006-01-01", tz="UTC")]),
+        ],
+        name="test_datetime_tz",
+    )
+    for _ in range(1):
+        column_schema(column_schema.example())


### PR DESCRIPTION
Version 0.7.0 introduced support for pandas.DatetimeTZDtype in a `pandera.DataFrameSchema` but that dtype is not recognized by the strategies module. This PR adds support for timezone-aware datetime strategies and fixes #534. 

Hypothesis only supports pure numpy datetime64 (i.e. timezone naive). We have to do a bit of back-and-forth between `pandas.Timestamp` and datetime64 because we want checks to see timezone-aware values and `hypothesis.extra.pandas` strategies to see a `numpy.dtype`. Ideally, we should fix upstream.


In addition, a `TypeError` is now raised when trying to call `stategies.pandas_dtypes_strategy` with an unsupported dtype. That should help users understanding why the strategy failed.
