### PR TITLE
strategies module supports undefined checks in regex columns

### DIFF
--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -1027,15 +1027,6 @@ def dataframe_strategy(
             else:
                 undefined_strat_df_checks.append(check)
 
-        # collect all non-element-wise column checks with undefined strategies
-        undefined_strat_column_checks: Dict[str, list] = defaultdict(list)
-        for col_name, column in columns.items():
-            undefined_strat_column_checks[col_name].extend(
-                check
-                for check in column.checks
-                if not hasattr(check, "strategy") and not check.element_wise
-            )
-
         # expand column set to generate column names for columns where
         # regex=True.
         expanded_columns = {}
@@ -1064,6 +1055,15 @@ def dataframe_strategy(
                     expanded_columns[regex_col] = deepcopy(column).set_name(
                         regex_col
                     )
+
+        # collect all non-element-wise column checks with undefined strategies
+        undefined_strat_column_checks: Dict[str, list] = defaultdict(list)
+        for col_name, column in expanded_columns.items():
+            undefined_strat_column_checks[col_name].extend(
+                check
+                for check in column.checks
+                if not hasattr(check, "strategy") and not check.element_wise
+            )
 
         # override the column datatype with dataframe-level datatype if
         # specified

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -770,7 +770,7 @@ def test_series_strategy_undefined_check_strategy(
     [
         [
             pa.DataFrameSchema(
-                columns={"column": pa.Column(pa.Int())},
+                columns={"column": pa.Column(int)},
                 checks=[
                     pa.Check(lambda x: x > 0, element_wise=True),
                     pa.Check(lambda x: x > -10, element_wise=True),
@@ -782,7 +782,7 @@ def test_series_strategy_undefined_check_strategy(
             pa.DataFrameSchema(
                 columns={
                     "column": pa.Column(
-                        pa.Int(),
+                        int,
                         checks=[
                             pa.Check(lambda s: s > -10000),
                             pa.Check(lambda s: s > -9999),
@@ -792,9 +792,22 @@ def test_series_strategy_undefined_check_strategy(
             ),
             "Column",
         ],
+        # schema with regex column and custom undefined strategy
         [
             pa.DataFrameSchema(
-                columns={"column": pa.Column(pa.Int())},
+                columns={
+                    "[0-9]+": pa.Column(
+                        int,
+                        checks=[pa.Check(lambda s: True)],
+                        regex=True,
+                    )
+                },
+            ),
+            "Column",
+        ],
+        [
+            pa.DataFrameSchema(
+                columns={"column": pa.Column(int)},
                 checks=[
                     pa.Check(lambda s: s > -10000),
                     pa.Check(lambda s: s > -9999),


### PR DESCRIPTION
Fixes #596

This PR fixes an issue where regex columns with undefined checks strategies would raise a KeyError.