### PR TITLE
Add support for empty data type annotation in SchemaModel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - pytest-xdist
   - pytest-asyncio
   - xdoctest
-  - setuptools = 57.5.0
+  - setuptools < 58.0.0
   - nox = 2020.12.31 # pinning due to UnicodeDecodeError, see https://github.com/pandera-dev/pandera/pull/504/checks?check_run_id=2841360122
   - importlib_metadata # required if python < 3.8
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - pyyaml >=5.1
   - typing_inspect >= 0.6.0
   - typing_extensions >= 3.7.4.3
-  - frictionless
+  - frictionless>=4.16.6
   - pyarrow
 
   # testing and dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - pyyaml >=5.1
   - typing_inspect >= 0.6.0
   - typing_extensions >= 3.7.4.3
-  - frictionless>=4.16.6
+  - frictionless
   - pyarrow
 
   # testing and dependencies
@@ -32,7 +32,7 @@ dependencies:
   - pytest-xdist
   - pytest-asyncio
   - xdoctest
-  - setuptools >= 52.0.0
+  - setuptools = 57.5.0
   - nox = 2020.12.31 # pinning due to UnicodeDecodeError, see https://github.com/pandera-dev/pandera/pull/504/checks?check_run_id=2841360122
   - importlib_metadata # required if python < 3.8
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -34,21 +34,9 @@ from .model_components import (
     FieldInfo,
 )
 from .schemas import DataFrameSchema
-from .typing import LEGACY_TYPING, AnnotationInfo, DataFrame, Index, Series
+from .typing import AnnotationInfo, DataFrame, Index, Series
 
-if LEGACY_TYPING:
-
-    def get_type_hints(
-        obj: Callable[..., Any],
-        globalns: Optional[Dict[str, Any]] = None,
-        localns: Optional[Dict[str, Any]] = None,
-        include_extras: bool = False,
-    ) -> Dict[str, Any]:
-        # pylint:disable=function-redefined, missing-function-docstring, unused-argument
-        return typing.get_type_hints(obj, globalns, localns)
-
-
-elif sys.version_info[:2] < (3, 9):
+if sys.version_info[:2] < (3, 9):
     from typing_extensions import get_type_hints
 else:
     from typing import get_type_hints

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -292,7 +292,10 @@ class SchemaModel:
 
             dtype = None if dtype is Any else dtype
 
-            if annotation.origin is Series:
+            if (
+                annotation.origin is Series
+                or annotation.raw_annotation is Series
+            ):
                 col_constructor = (
                     field.to_column if field else schema_components.Column
                 )
@@ -308,7 +311,10 @@ class SchemaModel:
                     checks=field_checks,
                     name=field_name,
                 )
-            elif annotation.origin is Index:
+            elif (
+                annotation.origin is Index
+                or annotation.raw_annotation is Index
+            ):
                 if annotation.optional:
                     raise SchemaInitError(
                         f"Index '{field_name}' cannot be Optional."

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -1,6 +1,5 @@
 """Typing definitions and helpers."""
 # pylint:disable=abstract-method,disable=too-many-ancestors
-import sys
 from typing import TYPE_CHECKING, Generic, Type, TypeVar
 
 import pandas as pd
@@ -8,8 +7,6 @@ import typing_inspect
 
 from . import dtypes
 from .engines import numpy_engine, pandas_engine
-
-LEGACY_TYPING = sys.version_info[:2] < (3, 7)
 
 Bool = dtypes.Bool  #: ``"bool"`` numpy dtype
 DateTime = dtypes.DateTime  #: ``"datetime64[ns]"`` numpy dtype
@@ -156,18 +153,12 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         self.optional = typing_inspect.is_optional_type(raw_annotation)
         if self.optional and typing_inspect.is_union_type(raw_annotation):
             # Annotated with Optional or Union[..., NoneType]
-            if LEGACY_TYPING:  # pragma: no cover
-                # get_args -> ((pandera.typing.Index, <class 'str'>), <class 'NoneType'>)
-                self.origin, self.arg = typing_inspect.get_args(
-                    raw_annotation
-                )[0]
             # get_args -> (pandera.typing.Index[str], <class 'NoneType'>)
             raw_annotation = typing_inspect.get_args(raw_annotation)[0]
 
-        if not (self.optional and LEGACY_TYPING):
-            self.origin = typing_inspect.get_origin(raw_annotation)
-            args = typing_inspect.get_args(raw_annotation)
-            self.arg = args[0] if args else args
+        self.origin = typing_inspect.get_origin(raw_annotation)
+        args = typing_inspect.get_args(raw_annotation)
+        self.arg = args[0] if args else args
 
         self.metadata = getattr(self.arg, "__metadata__", None)
         if self.metadata:

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -157,7 +157,8 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
             raw_annotation = typing_inspect.get_args(raw_annotation)[0]
 
         self.origin = typing_inspect.get_origin(raw_annotation)
-        args = typing_inspect.get_args(raw_annotation)
+        # Replace empty tuple returned from get_args by None
+        args = typing_inspect.get_args(raw_annotation) or None
         self.arg = args[0] if args else args
 
         self.metadata = getattr(self.arg, "__metadata__", None)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ pytest-cov
 pytest-xdist
 pytest-asyncio
 xdoctest
-setuptools == 57.5.0
+setuptools < 58.0.0
 nox == 2020.12.31
 importlib_metadata
 sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ wrapt
 pyyaml >=5.1
 typing_inspect >= 0.6.0
 typing_extensions >= 3.7.4.3
-frictionless
+frictionless>=4.16.6
 pyarrow
 black >= 20.8b1
 isort >= 5.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ wrapt
 pyyaml >=5.1
 typing_inspect >= 0.6.0
 typing_extensions >= 3.7.4.3
-frictionless>=4.16.6
+frictionless
 pyarrow
 black >= 20.8b1
 isort >= 5.7.0
@@ -23,7 +23,7 @@ pytest-cov
 pytest-xdist
 pytest-asyncio
 xdoctest
-setuptools >= 52.0.0
+setuptools == 57.5.0
 nox == 2020.12.31
 importlib_metadata
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "wrapt",
         "frictionless",
         "pyarrow",
+        "setuptools < 58.0.0",
     ],
     extras_require=extras_require,
     python_requires=">=3.7",

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -116,6 +116,15 @@ def test_optional_index() -> None:
             model.to_schema()
 
 
+def test_empty_dtype() -> None:
+    expected = pa.DataFrameSchema({"empty_column": pa.Column()})
+
+    class EmptyDtypeSchema(pa.SchemaModel):
+        empty_column: pa.typing.Series
+
+    assert EmptyDtypeSchema.to_schema() == expected
+
+
 def test_schemamodel_with_fields() -> None:
     """Test that Fields are translated in the schema."""
 

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -9,13 +9,12 @@ import pytest
 
 import pandera as pa
 from pandera.dtypes import DataType
-from pandera.typing import LEGACY_TYPING, Series
+from pandera.typing import Series
 
-if not LEGACY_TYPING:
-    try:  # python 3.9+
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
+try:  # python 3.9+
+    from typing import Annotated  # type: ignore
+except ImportError:
+    from typing_extensions import Annotated  # type: ignore
 
 
 class SchemaBool(pa.SchemaModel):
@@ -304,23 +303,24 @@ def test_legacy_default_pandas_extension_dtype(
     _test_default_annotated_dtype(model, dtype, has_mandatory_args)
 
 
-if not LEGACY_TYPING:
+class SchemaAnnotatedCategoricalDtype(pa.SchemaModel):
+    col: Series[Annotated[pd.CategoricalDtype, ["b", "a"], True]]
 
-    class SchemaAnnotatedCategoricalDtype(pa.SchemaModel):
-        col: Series[Annotated[pd.CategoricalDtype, ["b", "a"], True]]
 
-    class SchemaAnnotatedDatetimeTZDtype(pa.SchemaModel):
-        col: Series[Annotated[pd.DatetimeTZDtype, "ns", "est"]]
+class SchemaAnnotatedDatetimeTZDtype(pa.SchemaModel):
+    col: Series[Annotated[pd.DatetimeTZDtype, "ns", "est"]]
 
-    if pa.PANDAS_1_3_0_PLUS:
 
-        class SchemaAnnotatedIntervalDtype(pa.SchemaModel):
-            col: Series[Annotated[pd.IntervalDtype, "int32", "both"]]
+if pa.PANDAS_1_3_0_PLUS:
 
-    else:
+    class SchemaAnnotatedIntervalDtype(pa.SchemaModel):
+        col: Series[Annotated[pd.IntervalDtype, "int32", "both"]]
 
-        class SchemaAnnotatedIntervalDtype(pa.SchemaModel):  # type: ignore
-            col: Series[Annotated[pd.IntervalDtype, "int32"]]
+
+else:
+
+    class SchemaAnnotatedIntervalDtype(pa.SchemaModel):  # type: ignore
+        col: Series[Annotated[pd.IntervalDtype, "int32"]]
 
     class SchemaAnnotatedPeriodDtype(pa.SchemaModel):
         col: Series[Annotated[pd.PeriodDtype, "D"]]


### PR DESCRIPTION
Fixes #522.

example:
```python
import pandera as pa

class Model(pa.SchemaModel):
    a: pa.typing.Series
    
assert pa.DataFrameSchema({"a": pa.Column()}) == Model.to_schema()
``` 

I also took the opportunity to remove artifacts from py3.6 support that was dropped recently.