### PR TITLE
support frictionless primary keys with multiple fields

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -646,7 +646,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                             check_obj,
                             f"columns '{*lst,}' not unique:\n{failure_cases}",
                             failure_cases=failure_cases,
-                            check="unique",
+                            check="multiple_fields_uniqueness",
                         ),
                     )
 
@@ -1825,7 +1825,7 @@ class SeriesSchemaBase:
                         failure_cases=reshape_failure_cases(
                             series[duplicates]
                         ),
-                        check="no_duplicates",
+                        check="field_uniqueness",
                     ),
                 )
 


### PR DESCRIPTION
re-opening a PR to `dev`, adding support for frictionless primary keys with multiple fields