### PR TITLE
Bugfix/605 IndexError if check raises Exception without args

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -4,6 +4,7 @@
 import copy
 import itertools
 import os
+import traceback
 import warnings
 from functools import wraps
 from pathlib import Path
@@ -1865,8 +1866,12 @@ class SeriesSchemaBase:
             except Exception as err:  # pylint: disable=broad-except
                 # catch other exceptions that may occur when executing the
                 # Check
-                err_str = f'{err.__class__.__name__}("{err.args[0]}")'
-                msg = f"Error while executing check function: {err_str}"
+                err_msg = f'"{err.args[0]}"' if len(err.args) > 0 else ""
+                err_str = f"{err.__class__.__name__}({ err_msg})"
+                msg = (
+                    f"Error while executing check function: {err_str}\n"
+                    + traceback.format_exc()
+                )
                 error_handler.collect_error(
                     "check_error",
                     errors.SchemaError(


### PR DESCRIPTION
Pandera raises an IndexError during validation if a check raises an Exception that does not have arguments (typically a message). fixes #605 

The cause was the following snippet which assumes an exception always has arguments:
https://github.com/pandera-dev/pandera/blob/84ea3c227e638fe36b9e90cbfc5b5632638d4a57/pandera/schemas.py#L1789-L1792

I also appended a traceback in the SchemaError to help users debugging their check (if lazy=False). Let me know if you think that's overkill :)

Example:
```python
import pandas as pd
import pandera as pa


def fail_without_msg(s):
    raise ValueError()


schema = pa.DataFrameSchema(
    {
        "fail": pa.Column(int, pa.Check(fail_without_msg)),
    }
)

schema.validate(pd.DataFrame({"fail": [0]}))
#> Traceback (most recent call last):
#> /tmp/ipykernel_322026/2037979856.py in <module>
#> ----> 1 schema.validate(pd.DataFrame({"fail": [0]}))
#> ...
#> SchemaError: Error while executing check function: ValueError()
#> Traceback (most recent call last):
#>   File "/home/jeffzi/Projects/dev/pandera/pandera/schemas.py", line 1860, in validate
#>     _handle_check_results(
#>   File "/home/jeffzi/Projects/dev/pandera/pandera/schemas.py", line 2179, in _handle_check_results
#>     check_result = check(check_obj, *check_args)
#>   File "/home/jeffzi/Projects/dev/pandera/pandera/checks.py", line 397, in __call__
#>     check_output = check_fn(check_obj)
#>   File "/tmp/ipykernel_322026/35140900.py", line 2, in fail_without_msg
#>     raise ValueError()
#> ValueError
```