### PR TITLE
Strategies should not rely on pandas dtype aliases

### DIFF
--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -831,7 +831,7 @@ def series_strategy(
         )
         .filter(lambda x: x.shape[0] > 0)
         .map(lambda x: x.rename(name))
-        .map(lambda x: x.astype(str(pandera_dtype)))
+        .map(lambda x: x.astype(pandera_dtype.type))
     )
     if nullable:
         strategy = null_field_masks(strategy)
@@ -918,7 +918,7 @@ def index_strategy(
         min_size=0 if size is None else size,
         max_size=size,
         unique=unique,
-    ).map(lambda x: x.astype(str(pandera_dtype)))
+    ).map(lambda x: x.astype(pandera_dtype.type))
     if name is not None:
         strategy = strategy.map(lambda index: index.rename(name))
     if nullable:
@@ -1068,12 +1068,11 @@ def dataframe_strategy(
         # override the column datatype with dataframe-level datatype if
         # specified
         col_dtypes = {
-            col_name: str(col.dtype)
+            col_name: col.dtype.type
             if pandera_dtype is None
-            else str(pandera_dtype)
+            else pandera_dtype.type
             for col_name, col in expanded_columns.items()
         }
-
         nullable_columns = {
             col_name: col.nullable
             for col_name, col in expanded_columns.items()
@@ -1132,7 +1131,7 @@ def multiindex_strategy(
     :param pandera_dtype: :class:`pandera.dtypes.DataType` instance.
     :param strategy: an optional hypothesis strategy. If specified, the
         pandas dtype strategy will be chained onto this strategy.
-    :param indexes: a list of :class:`~pandera.schema_components.Inded`
+    :param indexes: a list of :class:`~pandera.schema_components.Index`
         objects.
     :param size: number of elements in the Series.
     :returns: ``hypothesis`` strategy.
@@ -1145,7 +1144,7 @@ def multiindex_strategy(
         )
     indexes = [] if indexes is None else indexes
     index_dtypes = {
-        index.name if index.name is not None else i: str(index.dtype)
+        index.name if index.name is not None else i: index.dtype.type
         for i, index in enumerate(indexes)
     }
     nullable_index = {

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -908,15 +908,18 @@ def test_schema_component_with_no_pdtype() -> None:
             schema_component_strategy(pandera_dtype=None)  # type: ignore
 
 
-def test_datetime_example() -> None:
+@pytest.mark.parametrize(
+    "check_arg", [pd.Timestamp("2006-01-01"), np.datetime64("2006-01-01")]
+)
+def test_datetime_example(check_arg) -> None:
     """Test Column schema example method generate examples of
     timezone-naive datetimes that pass."""
 
     for checks in [
-        pa.Check.le(pd.Timestamp("2006-01-01")),
-        pa.Check.ge(np.datetime64("2006-01-01")),
-        pa.Check.eq(pd.Timestamp("2006-01-01")),
-        pa.Check.isin([np.datetime64("2006-01-01")]),
+        pa.Check.le(check_arg),
+        pa.Check.ge(check_arg),
+        pa.Check.eq(check_arg),
+        pa.Check.isin([check_arg]),
     ]:
         column_schema = pa.Column(
             "datetime", checks=checks, name="test_datetime"
@@ -925,17 +928,31 @@ def test_datetime_example() -> None:
             column_schema(column_schema.example())
 
 
-def test_datetime_tz_example() -> None:
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        pd.DatetimeTZDtype(tz="UTC"),
+        pd.DatetimeTZDtype(tz="dateutil/US/Central"),
+    ),
+)
+@pytest.mark.parametrize(
+    "check_arg",
+    [
+        pd.Timestamp("2006-01-01", tz="CET"),
+        pd.Timestamp("2006-01-01", tz="UTC"),
+    ],
+)
+def test_datetime_tz_example(check_arg, dtype) -> None:
     """Test Column schema example method generate examples of
     timezone-aware datetimes that pass."""
     for checks in [
-        pa.Check.le(pd.Timestamp("2006-01-01", tz="CET")),
-        pa.Check.ge(pd.Timestamp("2006-01-01", tz="UTC")),
-        pa.Check.eq(pd.Timestamp("2006-01-01", tz="CET")),
-        pa.Check.isin([pd.Timestamp("2006-01-01", tz="UTC")]),
+        pa.Check.le(check_arg),
+        pa.Check.ge(check_arg),
+        pa.Check.eq(check_arg),
+        pa.Check.isin([check_arg]),
     ]:
         column_schema = pa.Column(
-            pd.DatetimeTZDtype(tz="UTC"),
+            dtype,
             checks=checks,
             name="test_datetime_tz",
         )


### PR DESCRIPTION
Prior to version 0.7.0, pandera relied on the string alias of pandas dtype in many places, i.e obtained via`str()`. There are 2 main issues with pandas string aliases:

1. They do not guarantee to encode all information for parameterized dtypes. e.g. `str(pd.CategoricalDtype(["A", "B"], ordered=True)) == "category"`
2. Pandas does not guarantee to recognize all string aliases. e.g:
```python
import pandas as pd

data = pd.Series(["2021-01-01 00:00"])
# ok
data.astype(pd.DatetimeTZDtype(tz="dateutil/US/Central"))
#> 0   2021-01-01 00:00:00-06:00
dtype: datetime64[ns, tzfile('/usr/share/zoneinfo/US/Central')]

# fail
pandas_dtype = str(pd.DatetimeTZDtype(tz="dateutil/US/Central"))
try:
    data.astype(pandas_dtype)
except TypeError:
    print(pandas_dtype)
#> datetime64[ns, tzfile('/usr/share/zoneinfo/US/Central')]
```

Therefore, pandera should avoid relying on the string aliases. It was still the case in the `strategy module` which made impossible to generate examples for dtype `pd.DatetimeTZDtype(tz="dateutil/US/Central")`, as reported by @th0ger in https://github.com/pandera-dev/pandera/issues/534#issuecomment-918005583.

All data types defined in `pandas_engine` and `numpy_engine` have an attribute `.type` which holds the native dtype represented. I've used that attribute to coerce instead of `str(pandera_dtype)`. 