### PR TITLE
support timedelta in data synthesis strats

### DIFF
--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -245,10 +245,6 @@ def _datetime_strategy(
         return st.builds(dtype.type, strategy, res)
 
 
-def _to_unix_timestamp(value: Any) -> int:
-    return pd.Timestamp(value).value
-
-
 def numpy_time_dtypes(
     dtype: Union[np.dtype, pd.DatetimeTZDtype], min_value=None, max_value=None
 ):
@@ -259,12 +255,14 @@ def numpy_time_dtypes(
     :param max_value: maximum value of the datatype to create
     :returns: ``hypothesis`` strategy
     """
-    min_value = (
-        MIN_DT_VALUE if min_value is None else _to_unix_timestamp(min_value)
-    )
-    max_value = (
-        MAX_DT_VALUE if max_value is None else _to_unix_timestamp(max_value)
-    )
+
+    def _to_unix(value: Any) -> int:
+        if dtype.type is np.timedelta64:
+            return pd.Timedelta(value).value
+        return pd.Timestamp(value).value
+
+    min_value = MIN_DT_VALUE if min_value is None else _to_unix(min_value)
+    max_value = MAX_DT_VALUE if max_value is None else _to_unix(max_value)
     return _datetime_strategy(dtype, st.integers(min_value, max_value))
 
 

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -1,5 +1,6 @@
-# pylint: disable=undefined-variable,redefined-outer-name,invalid-name,undefined-loop-variable  # noqa
+# pylint: disable=undefined-variable,redefined-outer-name,invalid-name,undefined-loop-variable,too-many-lines  # noqa
 """Unit tests for pandera data generating strategies."""
+import datetime
 import operator
 import re
 from typing import Any, Callable, Optional
@@ -911,7 +912,11 @@ def test_schema_component_with_no_pdtype() -> None:
 @pytest.mark.parametrize(
     "check_arg", [pd.Timestamp("2006-01-01"), np.datetime64("2006-01-01")]
 )
-def test_datetime_example(check_arg) -> None:
+@hypothesis.given(st.data())
+@hypothesis.settings(
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
+def test_datetime_example(check_arg, data) -> None:
     """Test Column schema example method generate examples of
     timezone-naive datetimes that pass."""
 
@@ -924,8 +929,7 @@ def test_datetime_example(check_arg) -> None:
         column_schema = pa.Column(
             "datetime", checks=checks, name="test_datetime"
         )
-        for _ in range(5):
-            column_schema(column_schema.example())
+        column_schema(data.draw(column_schema.strategy()))
 
 
 @pytest.mark.parametrize(
@@ -942,7 +946,11 @@ def test_datetime_example(check_arg) -> None:
         pd.Timestamp("2006-01-01", tz="UTC"),
     ],
 )
-def test_datetime_tz_example(check_arg, dtype) -> None:
+@hypothesis.given(st.data())
+@hypothesis.settings(
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
+def test_datetime_tz_example(dtype, check_arg, data) -> None:
     """Test Column schema example method generate examples of
     timezone-aware datetimes that pass."""
     for checks in [
@@ -956,5 +964,67 @@ def test_datetime_tz_example(check_arg, dtype) -> None:
             checks=checks,
             name="test_datetime_tz",
         )
-        for _ in range(5):
-            column_schema(column_schema.example())
+        column_schema(data.draw(column_schema.strategy()))
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (pd.Timedelta,),
+)
+@pytest.mark.parametrize(
+    "check_arg",
+    [
+        # nanoseconds
+        pd.Timedelta(int(1e9), unit="nanoseconds"),
+        np.timedelta64(int(1e9), "ns"),
+        # microseconds
+        pd.Timedelta(int(1e6), unit="microseconds"),
+        datetime.timedelta(microseconds=int(1e6)),
+        # milliseconds
+        pd.Timedelta(int(1e3), unit="milliseconds"),
+        np.timedelta64(int(1e3), "ms"),
+        datetime.timedelta(milliseconds=int(1e3)),
+        # seconds
+        pd.Timedelta(1, unit="s"),
+        np.timedelta64(1, "s"),
+        datetime.timedelta(seconds=1),
+        # minutes
+        pd.Timedelta(1, unit="m"),
+        np.timedelta64(1, "m"),
+        datetime.timedelta(minutes=1),
+        # hours
+        pd.Timedelta(1, unit="h"),
+        np.timedelta64(1, "h"),
+        datetime.timedelta(hours=1),
+        # days
+        pd.Timedelta(1, unit="day"),
+        np.timedelta64(1, "D"),
+        datetime.timedelta(days=1),
+        # weeks
+        pd.Timedelta(1, unit="W"),
+        np.timedelta64(1, "W"),
+        datetime.timedelta(weeks=1),
+    ],
+)
+@hypothesis.given(st.data())
+@hypothesis.settings(
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
+def test_timedelta(dtype, check_arg, data):
+    """
+    Test Column schema example method generate examples of timedeltas
+    that pass tests.
+    """
+    for checks in [
+        pa.Check.le(check_arg),
+        pa.Check.ge(check_arg),
+        pa.Check.eq(check_arg),
+        pa.Check.isin([check_arg]),
+        pa.Check.in_range(check_arg, check_arg + check_arg),
+    ]:
+        column_schema = pa.Column(
+            dtype,
+            checks=checks,
+            name="test_datetime_tz",
+        )
+        column_schema(data.draw(column_schema.strategy()))


### PR DESCRIPTION
fixes #618.

This PR fixes a bug where timedelta data types were not correctly handled by the `strategies` module.