### PR TITLE
exclude np.float128 type registration in MacM1

### DIFF
--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .. import dtypes, errors
 from ..dtypes import immutable
-from ..system import MAC_M1_PLATFORM, WINDOWS_PLATFORM
+from ..system import FLOAT_128_AVAILABLE
 from . import engine, utils
 from .type_aliases import PandasObject
 
@@ -224,17 +224,16 @@ class UInt8(UInt16):
 _float_equivalents = _build_number_equivalents(
     builtin_name="float",
     pandera_name="Float",
-    sizes=(
-        [64, 32, 16]
-        if WINDOWS_PLATFORM or MAC_M1_PLATFORM
-        else [128, 64, 32, 16]
-    ),
+    sizes=[128, 64, 32, 16] if FLOAT_128_AVAILABLE else [64, 32, 16],
 )
 
 
-if not WINDOWS_PLATFORM or MAC_M1_PLATFORM:
-    # not supported in windows
+if FLOAT_128_AVAILABLE:
+    # not supported in windows:
     # https://github.com/winpython/winpython/issues/613
+    #
+    # or Mac M1:
+    # https://github.com/pandera-dev/pandera/issues/623
     @Engine.register_dtype(equivalents=_float_equivalents[128])
     @immutable
     class Float128(DataType, dtypes.Float128):
@@ -278,11 +277,11 @@ class Float16(Float32):
 _complex_equivalents = _build_number_equivalents(
     builtin_name="complex",
     pandera_name="Complex",
-    sizes=[128, 64] if WINDOWS_PLATFORM or MAC_M1_PLATFORM else [256, 128, 64],
+    sizes=[256, 128, 64] if FLOAT_128_AVAILABLE else [128, 64],
 )
 
 
-if not WINDOWS_PLATFORM or MAC_M1_PLATFORM:
+if FLOAT_128_AVAILABLE:
     # not supported in windows
     # https://github.com/winpython/winpython/issues/613
     @Engine.register_dtype(equivalents=_complex_equivalents[256])

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -5,7 +5,6 @@ import builtins
 import dataclasses
 import datetime
 import inspect
-import platform
 import warnings
 from typing import Any, Dict, List, Union
 
@@ -13,10 +12,9 @@ import numpy as np
 
 from .. import dtypes, errors
 from ..dtypes import immutable
+from ..system import MAC_M1_PLATFORM, WINDOWS_PLATFORM
 from . import engine, utils
 from .type_aliases import PandasObject
-
-WINDOWS_PLATFORM = platform.system() == "Windows"
 
 
 @immutable(init=True)
@@ -226,11 +224,15 @@ class UInt8(UInt16):
 _float_equivalents = _build_number_equivalents(
     builtin_name="float",
     pandera_name="Float",
-    sizes=[64, 32, 16] if WINDOWS_PLATFORM else [128, 64, 32, 16],
+    sizes=(
+        [64, 32, 16]
+        if WINDOWS_PLATFORM or MAC_M1_PLATFORM
+        else [128, 64, 32, 16]
+    ),
 )
 
 
-if not WINDOWS_PLATFORM:
+if not WINDOWS_PLATFORM or MAC_M1_PLATFORM:
     # not supported in windows
     # https://github.com/winpython/winpython/issues/613
     @Engine.register_dtype(equivalents=_float_equivalents[128])
@@ -276,11 +278,11 @@ class Float16(Float32):
 _complex_equivalents = _build_number_equivalents(
     builtin_name="complex",
     pandera_name="Complex",
-    sizes=[128, 64] if WINDOWS_PLATFORM else [256, 128, 64],
+    sizes=[128, 64] if WINDOWS_PLATFORM or MAC_M1_PLATFORM else [256, 128, 64],
 )
 
 
-if not WINDOWS_PLATFORM:
+if not WINDOWS_PLATFORM or MAC_M1_PLATFORM:
     # not supported in windows
     # https://github.com/winpython/winpython/issues/613
     @Engine.register_dtype(equivalents=_complex_equivalents[256])

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -10,7 +10,6 @@ import builtins
 import dataclasses
 import datetime
 import inspect
-import platform
 import warnings
 from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Union
@@ -21,6 +20,7 @@ from packaging import version
 
 from .. import dtypes, errors
 from ..dtypes import immutable
+from ..system import MAC_M1_PLATFORM, WINDOWS_PLATFORM
 from . import engine, numpy_engine, utils
 from .type_aliases import PandasDataType, PandasExtensionType, PandasObject
 
@@ -37,9 +37,6 @@ try:
     from typing import Literal  # type: ignore
 except ImportError:
     from typing_extensions import Literal  # type: ignore
-
-
-WINDOWS_PLATFORM = platform.system() == "Windows"
 
 
 def is_extension_dtype(pd_dtype: PandasDataType) -> bool:
@@ -343,7 +340,9 @@ class UINT8(UINT16):
 _register_numpy_numbers(
     builtin_name="float",
     pandera_name="Float",
-    sizes=[64, 32, 16] if WINDOWS_PLATFORM else [128, 64, 32, 16],
+    sizes=[64, 32, 16]
+    if WINDOWS_PLATFORM or MAC_M1_PLATFORM
+    else [128, 64, 32, 16],
 )
 
 # ###############################################################################
@@ -353,7 +352,7 @@ _register_numpy_numbers(
 _register_numpy_numbers(
     builtin_name="complex",
     pandera_name="Complex",
-    sizes=[128, 64] if WINDOWS_PLATFORM else [256, 128, 64],
+    sizes=[128, 64] if WINDOWS_PLATFORM or MAC_M1_PLATFORM else [256, 128, 64],
 )
 
 # ###############################################################################

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -20,7 +20,7 @@ from packaging import version
 
 from .. import dtypes, errors
 from ..dtypes import immutable
-from ..system import MAC_M1_PLATFORM, WINDOWS_PLATFORM
+from ..system import FLOAT_128_AVAILABLE
 from . import engine, numpy_engine, utils
 from .type_aliases import PandasDataType, PandasExtensionType, PandasObject
 
@@ -340,9 +340,7 @@ class UINT8(UINT16):
 _register_numpy_numbers(
     builtin_name="float",
     pandera_name="Float",
-    sizes=[64, 32, 16]
-    if WINDOWS_PLATFORM or MAC_M1_PLATFORM
-    else [128, 64, 32, 16],
+    sizes=[128, 64, 32, 16] if FLOAT_128_AVAILABLE else [64, 32, 16],
 )
 
 # ###############################################################################
@@ -352,7 +350,7 @@ _register_numpy_numbers(
 _register_numpy_numbers(
     builtin_name="complex",
     pandera_name="Complex",
-    sizes=[128, 64] if WINDOWS_PLATFORM or MAC_M1_PLATFORM else [256, 128, 64],
+    sizes=[256, 128, 64] if FLOAT_128_AVAILABLE else [128, 64],
 )
 
 # ###############################################################################

--- a/pandera/system.py
+++ b/pandera/system.py
@@ -1,8 +1,7 @@
-"""System/OS global variables."""
+"""Global variables relating to OS."""
 
-import platform
+import numpy as np
 
-WINDOWS_PLATFORM = platform.system() == "Windows"
-MAC_M1_PLATFORM = (
-    platform.platform() == "Darwin" and platform.machine().startswith("arm")
-)
+# Windows and Mac M1 don't support floats of this precision:
+# https://github.com/pandera-dev/pandera/issues/623
+FLOAT_128_AVAILABLE = hasattr(np, "float128")

--- a/pandera/system.py
+++ b/pandera/system.py
@@ -1,0 +1,8 @@
+"""System/OS global variables."""
+
+import platform
+
+WINDOWS_PLATFORM = platform.system() == "Windows"
+MAC_M1_PLATFORM = (
+    platform.platform() == "Darwin" and platform.machine().startswith("arm")
+)

--- a/tests/core/test_deprecations.py
+++ b/tests/core/test_deprecations.py
@@ -3,7 +3,7 @@
 import pytest
 
 import pandera as pa
-from pandera.system import MAC_M1_PLATFORM, WINDOWS_PLATFORM
+from pandera.system import FLOAT_128_AVAILABLE
 
 
 @pytest.mark.parametrize(
@@ -43,7 +43,7 @@ def test_deprecate_pandas_dtype(schema_cls, as_pos_arg):
 def test_deprecate_pandas_dtype_enum(schema_cls):
     """Test that using the PandasDtype enum raises a DeprecationWarning."""
     for attr in pa.PandasDtype:
-        if (WINDOWS_PLATFORM or MAC_M1_PLATFORM) and attr in {
+        if not FLOAT_128_AVAILABLE and attr in {
             "Float128",
             "Complex256",
         }:

--- a/tests/core/test_deprecations.py
+++ b/tests/core/test_deprecations.py
@@ -1,12 +1,9 @@
 """Unit tests for deprecated features."""
 
-import platform
-
 import pytest
 
 import pandera as pa
-
-WINDOWS_PLATFORM = platform.system() == "Windows"
+from pandera.system import MAC_M1_PLATFORM, WINDOWS_PLATFORM
 
 
 @pytest.mark.parametrize(
@@ -46,7 +43,10 @@ def test_deprecate_pandas_dtype(schema_cls, as_pos_arg):
 def test_deprecate_pandas_dtype_enum(schema_cls):
     """Test that using the PandasDtype enum raises a DeprecationWarning."""
     for attr in pa.PandasDtype:
-        if WINDOWS_PLATFORM and attr in {"Float128", "Complex256"}:
+        if (WINDOWS_PLATFORM or MAC_M1_PLATFORM) and attr in {
+            "Float128",
+            "Complex256",
+        }:
             continue
         with pytest.warns(DeprecationWarning):
             pandas_dtype = getattr(pa.PandasDtype, attr)

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -5,7 +5,6 @@ coercion examples."""
 import dataclasses
 import datetime
 import inspect
-import platform
 from decimal import Decimal
 from typing import Any, Dict, List, Tuple
 
@@ -19,8 +18,7 @@ from hypothesis import strategies as st
 
 import pandera as pa
 from pandera.engines import pandas_engine
-
-WINDOWS_PLATFORM = platform.system() == "Windows"
+from pandera.system import MAC_M1_PLATFORM, WINDOWS_PLATFORM
 
 # List dtype classes and associated pandas alias,
 # except for parameterizable dtypes that should also list examples of
@@ -85,7 +83,7 @@ complex_dtypes = {
 }
 
 
-if not WINDOWS_PLATFORM:
+if not WINDOWS_PLATFORM or MAC_M1_PLATFORM:
     float_dtypes.update(
         {
             pa.Float128: "float128",

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -18,7 +18,7 @@ from hypothesis import strategies as st
 
 import pandera as pa
 from pandera.engines import pandas_engine
-from pandera.system import MAC_M1_PLATFORM, WINDOWS_PLATFORM
+from pandera.system import FLOAT_128_AVAILABLE
 
 # List dtype classes and associated pandas alias,
 # except for parameterizable dtypes that should also list examples of
@@ -83,7 +83,7 @@ complex_dtypes = {
 }
 
 
-if not WINDOWS_PLATFORM or MAC_M1_PLATFORM:
+if FLOAT_128_AVAILABLE:
     float_dtypes.update(
         {
             pa.Float128: "float128",


### PR DESCRIPTION
#623 reports an issue with importing `np.float128` in MacOS, M11 architecture. This PR may (?) address it