### PR TITLE
remove assumption from nullable strategies

### DIFF
--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -87,8 +87,6 @@ def null_field_masks(draw, strategy: Optional[SearchStrategy]):
     val = draw(strategy)
     size = val.shape[0]
     null_mask = draw(st.lists(st.booleans(), min_size=size, max_size=size))
-    # assume that there is at least one masked value
-    hypothesis.assume(any(null_mask))
     if isinstance(val, pd.Index):
         val = val.to_series()
         val = _mask(val, null_mask)
@@ -127,8 +125,6 @@ def null_dataframe_masks(
         index=pdst.range_indexes(min_size=size, max_size=size),
     )
     null_mask = draw(mask_st)
-    # assume that there is at least one masked value
-    hypothesis.assume(null_mask.any(axis=None))
     for column in val:
         val[column] = _mask(val[column], null_mask[column])
     return val

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -696,7 +696,7 @@ def test_check_nullable_field_strategy(
     example = data.draw(strat)
 
     if nullable:
-        assert example.isna().any()
+        assert example.isna().sum() >= 0
     else:
         assert example.notna().all()
 
@@ -717,7 +717,7 @@ def test_check_nullable_dataframe_strategy(data_type, nullable, data):
     )
     example = data.draw(strat)
     if nullable:
-        assert example.isna().any(axis=None)
+        assert example.isna().sum(axis=None).item() >= 0
     else:
         assert example.notna().all(axis=None)
 


### PR DESCRIPTION
fixes #640. This PR improves the performance of schema strategies that
involve nullable fields. Before, this strategy tries to find a case with at least
one null value. Loosen this assumption so that there _can_ be null values
in a nullable field, but it's not necessary

Instead of a 10x performance hit it's a
2x performance hit for specifying a nullable column.