### PR TITLE
fix date parsing bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,5 +59,6 @@ repos:
         pass_filenames: false
         additional_dependencies:
         - types-click
+        - types-python-dateutil
         - types-pyyaml
-        - types-pkg_resources
+        - types-python-dateutil

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
 
   # pandera dependencies
+  - python-dateutil
   - packaging >= 20.0
   - hypothesis >= 5.41.1
   - numpy >= 1.9.0
@@ -53,5 +54,6 @@ dependencies:
   - pip:
     - furo
     - types-click
+    - types-python-dateutil
     - types-pyyaml
     - types-pkg_resources

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 # See that file for comments about the need/usage of each dependency.
 
 pip
+python-dateutil
 packaging >= 20.0
 hypothesis >= 5.41.1
 numpy >= 1.9.0


### PR DESCRIPTION
fixes #639

This PR makes it so that datetime parsing errors raised by `dateutil` are caught and reported as coercion failures in pandera