### PR TITLE
Support mypy prototype

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [BASIC]
 good-names=
+    T,
     F,
     logger,
     df,

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - hypothesis >= 5.41.1
   - numpy >= 1.9.0
   - pandas
+  - pandas-stubs
   - scipy
   - wrapt
   - pyyaml >=5.1

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
 
   # modin extra
   - modin
-  - ray
+  - ray <= 1.7.0
 
   # dask extra
   - dask

--- a/noxfile.py
+++ b/noxfile.py
@@ -179,11 +179,16 @@ def install_extras(
     extra: str = "core",
     force_pip: bool = False,
     pandas: str = "latest",
+    pandas_stubs: bool = True,
 ) -> None:
     """Install dependencies."""
     specs, pip_specs = [], []
     pandas_version = "" if pandas == "latest" else f"=={pandas}"
     for spec in REQUIRES[extra].values():
+        if spec == "pandas-stubs" and not pandas_stubs:
+            # this is a temporary measure until all pandas-related mypy errors
+            # are addressed
+            continue
         if spec.split("==")[0] in ALWAYS_USE_PIP:
             pip_specs.append(spec)
         else:
@@ -297,7 +302,7 @@ def lint(session: Session) -> None:
 @nox.session(python=PYTHON_VERSIONS)
 def mypy(session: Session) -> None:
     """Type-check using mypy."""
-    install_extras(session, extra="all")
+    install_extras(session, extra="all", pandas_stubs=False)
     args = session.posargs or SOURCE_PATHS
     session.run("mypy", "--follow-imports=silent", *args, silent=True)
 

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -45,7 +45,13 @@ from pandera.engines.pandas_engine import (
 from pandera.engines.pandas_engine import _PandasDtype as PandasDtype
 from pandera.engines.pandas_engine import pandas_version
 
-from . import constants, errors, pandas_accessor
+from . import (
+    constants,
+    errors,
+    koalas_accessor,
+    modin_accessor,
+    pandas_accessor,
+)
 from .checks import Check
 from .decorators import check_input, check_io, check_output, check_types
 from .hypotheses import Hypothesis

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -45,13 +45,7 @@ from pandera.engines.pandas_engine import (
 from pandera.engines.pandas_engine import _PandasDtype as PandasDtype
 from pandera.engines.pandas_engine import pandas_version
 
-from . import (
-    constants,
-    errors,
-    koalas_accessor,
-    modin_accessor,
-    pandas_accessor,
-)
+from . import constants, errors, pandas_accessor
 from .checks import Check
 from .decorators import check_input, check_io, check_output, check_types
 from .hypotheses import Hypothesis
@@ -71,5 +65,21 @@ try:
     import dask.dataframe
 
     from . import dask_accessor
+except ImportError:
+    pass
+
+
+try:
+    import databricks.koalas
+
+    from . import koalas_accessor
+except ImportError:
+    pass
+
+
+try:
+    import modin.pandas
+
+    from . import modin_accessor
 except ImportError:
     pass

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -536,7 +536,17 @@ def check_types(
         pass-through.
         """
         schema, optional = annotated_schemas.get(arg_name, (None, None))
-        if schema and not (optional and arg_value is None):
+        if (
+            schema
+            and not (optional and arg_value is None)
+            # the pandera.schema attribute should only be available when
+            # scheam.validate has been called in the DF. There's probably
+            # a better way of doing this
+            and (
+                arg_value.pandera.schema is None
+                or arg_value.pandera.schema != schema
+            )
+        ):
             try:
                 return schema.validate(
                     arg_value, head, tail, sample, random_state, lazy, inplace

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -540,7 +540,7 @@ def check_types(
             schema
             and not (optional and arg_value is None)
             # the pandera.schema attribute should only be available when
-            # scheam.validate has been called in the DF. There's probably
+            # schema.validate has been called in the DF. There's probably
             # a better way of doing this
             and (
                 arg_value.pandera.schema is None

--- a/pandera/koalas_accessor.py
+++ b/pandera/koalas_accessor.py
@@ -1,0 +1,14 @@
+"""Register koalas accessor for pandera schema metadata."""
+
+from databricks.koalas.extensions import (
+    register_dataframe_accessor,
+    register_series_accessor,
+)
+
+from pandera.pandas_accessor import (
+    PanderaDataFrameAccessor,
+    PanderaSeriesAccessor,
+)
+
+register_dataframe_accessor("pandera")(PanderaDataFrameAccessor)
+register_series_accessor("pandera")(PanderaSeriesAccessor)

--- a/pandera/modin_accessor.py
+++ b/pandera/modin_accessor.py
@@ -1,0 +1,98 @@
+"""Custom accessor functionality for modin.
+
+Source code adapted from koalas implementation:
+https://koalas.readthedocs.io/en/latest/_modules/databricks/koalas/extensions.html#register_dataframe_accessor
+"""
+
+import warnings
+
+from pandera.pandas_accessor import (
+    PanderaDataFrameAccessor,
+    PanderaSeriesAccessor,
+)
+
+
+# pylint: disable=too-few-public-methods
+class CachedAccessor:
+    """
+    Custom property-like object.
+
+    A descriptor for caching accessors:
+
+    :param name: Namespace that accessor's methods, properties, etc will be
+        accessed under, e.g. "foo" for a dataframe accessor yields the accessor
+        ``df.foo``
+    :param cls: Class with the extension methods.
+
+    For accessor, the class's __init__ method assumes that you are registering
+    an accessor for one of ``Series``, ``DataFrame``, or ``Index``.
+    """
+
+    def __init__(self, name, accessor):
+        self._name = name
+        self._accessor = accessor
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self._accessor
+        accessor_obj = self._accessor(obj)
+        object.__setattr__(obj, self._name, accessor_obj)
+        return accessor_obj
+
+
+def _register_accessor(name, cls):
+    """
+    Register a custom accessor on {class} objects.
+
+    :param name: Name under which the accessor should be registered. A warning
+        is issued if this name conflicts with a preexisting attribute.
+    :returns: A class decorator callable.
+    """
+
+    def decorator(accessor):
+        if hasattr(cls, name):
+            msg = (
+                f"registration of accessor {accessor} under name '{name}' for "
+                "type {cls.__name__} is overriding a preexisting attribute "
+                "with the same name."
+            )
+
+            warnings.warn(
+                msg,
+                UserWarning,
+                stacklevel=2,
+            )
+        setattr(cls, name, CachedAccessor(name, accessor))
+        return accessor
+
+    return decorator
+
+
+def register_dataframe_accessor(name):
+    """
+    Register a custom accessor with a DataFrame
+
+    :param name: name used when calling the accessor after its registered
+    :returns: a class decorator callable.
+    """
+    # pylint: disable=import-outside-toplevel
+    from modin.pandas import DataFrame
+
+    return _register_accessor(name, DataFrame)
+
+
+def register_series_accessor(name):
+    """
+    Register a custom accessor with a Series object
+
+    :param name: name used when calling the accessor after its registered
+    :returns: a callable class decorator
+    """
+    # pylint: disable=import-outside-toplevel
+    from modin.pandas import Series
+
+    return _register_accessor(name, Series)
+
+
+register_dataframe_accessor("pandera")(PanderaDataFrameAccessor)
+register_series_accessor("pandera")(PanderaSeriesAccessor)

--- a/pandera/modin_accessor.py
+++ b/pandera/modin_accessor.py
@@ -33,7 +33,7 @@ class CachedAccessor:
         self._accessor = accessor
 
     def __get__(self, obj, cls):
-        if obj is None:
+        if obj is None:  # pragma: no cover
             return self._accessor
         accessor_obj = self._accessor(obj)
         object.__setattr__(obj, self._name, accessor_obj)

--- a/pandera/pandas_accessor.py
+++ b/pandera/pandas_accessor.py
@@ -33,6 +33,10 @@ class PanderaAccessor:
         """Access schema metadata."""
         return self._schema
 
+    def validate(self, **kwargs):
+        """A utility to validate a dataframe."""
+        return self.schema(self._pandas_obj, **kwargs)
+
 
 @pd.api.extensions.register_dataframe_accessor("pandera")
 class PanderaDataFrameAccessor(PanderaAccessor):

--- a/pandera/pandas_accessor.py
+++ b/pandera/pandas_accessor.py
@@ -1,14 +1,12 @@
 """Register pandas accessor for pandera schema metadata."""
 
-from typing import Optional, TypeVar, Union
+from typing import Optional, Union
 
 import pandas as pd
 
 from . import schemas
 
 Schemas = Union[schemas.DataFrameSchema, schemas.SeriesSchema]
-
-T = TypeVar("T")
 
 
 class PanderaAccessor:

--- a/pandera/pandas_accessor.py
+++ b/pandera/pandas_accessor.py
@@ -34,7 +34,11 @@ class PanderaAccessor:
         return self._schema
 
     def validate(self, **kwargs):
-        """A utility to validate a dataframe."""
+        """A utility to validate a dataframe.
+
+        Forwards **kwargs to the schema.validate method.
+        """
+        # pylint: disable=not-callable
         return self.schema(self._pandas_obj, **kwargs)
 
 

--- a/pandera/pandas_accessor.py
+++ b/pandera/pandas_accessor.py
@@ -1,12 +1,14 @@
 """Register pandas accessor for pandera schema metadata."""
 
-from typing import Optional, Union
+from typing import Optional, TypeVar, Union
 
 import pandas as pd
 
 from . import schemas
 
 Schemas = Union[schemas.DataFrameSchema, schemas.SeriesSchema]
+
+T = TypeVar("T")
 
 
 class PanderaAccessor:
@@ -32,14 +34,6 @@ class PanderaAccessor:
     def schema(self) -> Optional[Schemas]:
         """Access schema metadata."""
         return self._schema
-
-    def validate(self, **kwargs):
-        """A utility to validate a dataframe.
-
-        Forwards **kwargs to the schema.validate method.
-        """
-        # pylint: disable=not-callable
-        return self.schema(self._pandas_obj, **kwargs)
 
 
 @pd.api.extensions.register_dataframe_accessor("pandera")

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -141,9 +141,6 @@ class DataFrameBase(pd.DataFrame):
     initialization.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def __setattr__(self, name: str, value: Any) -> None:
         object.__setattr__(self, name, value)
         if name == "__orig_class__":
@@ -160,6 +157,7 @@ class DataFrameBase(pd.DataFrame):
                 self.pandera.schema is None
                 or self.pandera.schema != schema_model.to_schema()
             ):
+                # pylint: disable=self-cls-assignment
                 self = schema_model.validate(self)
                 self.pandera.add_schema(schema_model.to_schema())
 

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -163,10 +163,6 @@ class DataFrameBase(pd.DataFrame):
                 self = schema_model.validate(self)
                 self.pandera.add_schema(schema_model.to_schema())
 
-    def __getattribute__(self, name: str) -> Any:
-        attribute = object.__getattribute__(self, name)
-        return attribute
-
 
 # pylint:disable=too-few-public-methods
 class DataFrame(Generic[T], DataFrameBase):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ packaging >= 20.0
 hypothesis >= 5.41.1
 numpy >= 1.9.0
 pandas
+pandas-stubs
 scipy
 wrapt
 pyyaml >=5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ pydantic
 koalas
 pyspark
 modin
-ray
+ray <= 1.7.0
 dask
 distributed
 black >= 20.8b1

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ _extras_require = {
     "hypotheses": ["scipy"],
     "io": ["pyyaml >= 5.1", "black", "frictionless"],
     "koalas": ["koalas", "pyspark"],
-    "modin": ["modin", "ray", "dask"],
-    "modin-ray": ["modin", "ray"],
+    "modin": ["modin", "ray <= 1.7.0", "dask"],
+    "modin-ray": ["modin", "ray <= 1.7.0"],
     "modin-dask": ["modin", "dask"],
     "dask": ["dask"],
     }

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ _extras_require = {
     "modin-ray": ["modin", "ray"],
     "modin-dask": ["modin", "dask"],
     "dask": ["dask"],
-    "mypy": ["pandas-stubs"],
-}
+    }
 extras_require = {
     **_extras_require,
     "all": list(set(x for y in _extras_require.values() for x in y)),

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ _extras_require = {
     "modin-ray": ["modin", "ray"],
     "modin-dask": ["modin", "dask"],
     "dask": ["dask"],
+    "mypy": ["pandas-stubs"],
 }
 extras_require = {
     **_extras_require,

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "packaging >= 20.0",
         "numpy >= 1.9.0",
         "pandas >= 1.0",
+        "pandas-stubs",
         "typing_extensions >= 3.7.4.3 ; python_version<'3.8'",
         "typing_inspect >= 0.6.0",
         "wrapt",

--- a/tests/core/static/pandas_dataframe.py
+++ b/tests/core/static/pandas_dataframe.py
@@ -1,8 +1,11 @@
+# pylint: skip-file
 """Unit tests for static type checking of dataframes.
 
 This test module uses https://github.com/davidfritzsche/pytest-mypy-testing to
 run statically check the functions marked pytest.mark.mypy_testing
 """
+
+from typing import cast
 
 import pandas as pd
 
@@ -54,3 +57,7 @@ def fn_mutate_inplace(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
 
 def fn_assign_and_get_index(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
     return df.assign(foo=30).iloc[:3]  # okay for mypy, pandera raises error
+
+
+def fn_cast_dataframe(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
+    return cast(DataFrame[SchemaOut], df)  # okay for mypy

--- a/tests/core/static/pandas_dataframe.py
+++ b/tests/core/static/pandas_dataframe.py
@@ -1,0 +1,56 @@
+"""Unit tests for static type checking of dataframes.
+
+This test module uses https://github.com/davidfritzsche/pytest-mypy-testing to
+run statically check the functions marked pytest.mark.mypy_testing
+"""
+
+import pandas as pd
+
+import pandera as pa
+from pandera.typing import DataFrame, Series
+
+
+class Schema(pa.SchemaModel):
+    id: Series[int]
+    name: Series[str]
+
+
+class SchemaOut(pa.SchemaModel):
+    age: Series[int]
+
+
+class AnotherSchema(pa.SchemaModel):
+    id: Series[int]
+    first_name: Series[str]
+
+
+pd_df = pd.DataFrame({"id": [1], "name": ["foo"]})
+valid_df = DataFrame[Schema]({"id": [1], "name": ["foo"]})
+another_df = DataFrame[AnotherSchema]({"id": [1], "first_name": ["foo"]})
+
+
+def fn(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
+    return df.assign(age=30).pipe(DataFrame[SchemaOut])
+
+
+def fn_pipe_correct_type(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
+    return df.assign(age=30).pipe(DataFrame[AnotherSchema])  # mypy error
+
+
+def fn_assign_copy(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
+    return df.assign(age=30)  # mypy error
+
+
+fn(valid_df)
+fn(pd_df)  # mypy error
+fn(another_df)  # mypy error
+
+
+def fn_mutate_inplace(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
+    out = df.assign(age=30).pipe(DataFrame[SchemaOut])
+    out.drop(["age"], axis=1, inplace=True)
+    return out  # okay for mypy, pandera raises error
+
+
+def fn_assign_and_get_index(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
+    return df.assign(foo=30).iloc[:3]  # okay for mypy, pandera raises error

--- a/tests/core/static/pandas_dataframe.py
+++ b/tests/core/static/pandas_dataframe.py
@@ -33,7 +33,7 @@ def fn(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
     return df.assign(age=30).pipe(DataFrame[SchemaOut])
 
 
-def fn_pipe_correct_type(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
+def fn_pipe_incorrect_type(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
     return df.assign(age=30).pipe(DataFrame[AnotherSchema])  # mypy error
 
 

--- a/tests/core/test_static_type_checking.py
+++ b/tests/core/test_static_type_checking.py
@@ -51,7 +51,7 @@ def test_mypy_pandas_dataframe(capfd) -> None:
     )
     errors = _get_mypy_errors(capfd.readouterr().out)
     # assert error messages on particular lines of code
-    assert errors[37] == {
+    assert errors[40] == {
         "msg": (
             'Argument 1 to "pipe" of "NDFrame" has incompatible type '
             '"Type[DataFrame[Any]]"; expected '
@@ -60,7 +60,7 @@ def test_mypy_pandas_dataframe(capfd) -> None:
         ),
         "errcode": "arg-type",
     }
-    assert errors[41] == {
+    assert errors[44] == {
         "msg": (
             "Incompatible return value type (got "
             '"pandas.core.frame.DataFrame", expected '
@@ -68,7 +68,7 @@ def test_mypy_pandas_dataframe(capfd) -> None:
         ),
         "errcode": "return-value",
     }
-    assert errors[45] == {
+    assert errors[48] == {
         "msg": (
             'Argument 1 to "fn" has incompatible type '
             '"pandas.core.frame.DataFrame"; expected '
@@ -76,7 +76,7 @@ def test_mypy_pandas_dataframe(capfd) -> None:
         ),
         "errcode": "arg-type",
     }
-    assert errors[46] == {
+    assert errors[49] == {
         "msg": (
             'Argument 1 to "fn" has incompatible type '
             '"DataFrame[AnotherSchema]"; expected "DataFrame[Schema]"'

--- a/tests/core/test_static_type_checking.py
+++ b/tests/core/test_static_type_checking.py
@@ -1,0 +1,93 @@
+"""Unit tests for static type checking of dataframes.
+
+This module uses subprocess and the pytest.capdf fixture to capture the output
+of calling mypy on the python modules in the tests/core/static folder.
+"""
+
+import os
+import re
+import subprocess
+import typing
+from pathlib import Path
+
+import pytest
+
+import pandera as pa
+from tests.core.static import pandas_dataframe
+
+test_module_dir = Path(os.path.dirname(__file__))
+
+
+def _get_mypy_errors(stdout) -> typing.Dict[int, str]:
+    """Parse line number and error message."""
+    errors = {}
+    # last line is summary of errors
+    for error in [x for x in stdout.split("\n") if x != ""][:-1]:
+        matches = re.match(
+            r".+\.py:(?P<lineno>\d+): error: (?P<msg>.+)  \[(?P<errcode>.+)\]",
+            error,
+        ).groupdict()
+        errors[int(matches["lineno"])] = {
+            "msg": matches["msg"],
+            "errcode": matches["errcode"],
+        }
+    return errors
+
+
+def test_mypy_pandas_dataframe(capfd) -> None:
+    """Test that mypy raises expected errors on pandera-decorated functions."""
+    subprocess.run(
+        ["mypy", str(test_module_dir / "static" / "pandas_dataframe.py")],
+        text=True,
+    )
+    errors = _get_mypy_errors(capfd.readouterr().out)
+    # assert error messages on particular lines of code
+    assert errors[37] == {
+        "msg": (
+            'Argument 1 to "pipe" of "NDFrame" has incompatible type '
+            '"Type[DataFrame[Any]]"; expected '
+            '"Union[Callable[..., DataFrame[SchemaOut]], '
+            'Tuple[Callable[..., DataFrame[SchemaOut]], str]]"'
+        ),
+        "errcode": "arg-type",
+    }
+    assert errors[41] == {
+        "msg": (
+            "Incompatible return value type (got "
+            '"pandas.core.frame.DataFrame", expected '
+            '"pandera.typing.DataFrame[SchemaOut]")'
+        ),
+        "errcode": "return-value",
+    }
+    assert errors[45] == {
+        "msg": (
+            'Argument 1 to "fn" has incompatible type '
+            '"pandas.core.frame.DataFrame"; expected '
+            '"pandera.typing.DataFrame[Schema]"'
+        ),
+        "errcode": "arg-type",
+    }
+    assert errors[46] == {
+        "msg": (
+            'Argument 1 to "fn" has incompatible type '
+            '"DataFrame[AnotherSchema]"; expected "DataFrame[Schema]"'
+        ),
+        "errcode": "arg-type",
+    }
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        pandas_dataframe.fn_mutate_inplace,
+        pandas_dataframe.fn_assign_and_get_index,
+    ],
+)
+def test_pandera_runtime_errors(fn) -> None:
+    """Test that pandera catches cases that mypy doesn't catch."""
+
+    # both functions don't add a required column "age"
+    try:
+        pa.check_types(fn)(pandas_dataframe.valid_df)
+    except pa.errors.SchemaError as e:
+        assert e.failure_cases["failure_case"].item() == "age"

--- a/tests/modin/test_modin_accessor.py
+++ b/tests/modin/test_modin_accessor.py
@@ -1,0 +1,24 @@
+"""Unit tests of modin accessor functionality.
+
+Since modin doesn't currently support the pandas accessor extension API,
+pandera implements it.
+"""
+
+import pytest
+
+from pandera import modin_accessor
+
+
+# pylint: disable=too-few-public-methods
+class CustomAccessor:
+    """Mock accessor class"""
+
+    def __init__(self, obj):
+        self._obj = obj
+
+
+def test_modin_accessor_warning():
+    """Test that modin accessor raises warning when name already exists."""
+    modin_accessor.register_dataframe_accessor("foo")(CustomAccessor)
+    with pytest.warns(UserWarning):
+        modin_accessor.register_dataframe_accessor("foo")(CustomAccessor)


### PR DESCRIPTION
### Prototype for mypy support

FYI @jeffzi

Here's a first pass at adding mypy support to pandera. There are a bunch of ideas in there that do that and a few others that are more or less related. I'm not tied to any of the implementation details, just the outcome of efficiently offering additional type-safety, mainly via mypy but also with dataframes validated at initialization.

#### Add [pandas-stubs](https://github.com/VirtusLab/pandas-stubs) as a core dependency

This library enables the static checking of `pandera.typing.DataFrame` generics. Should this be in `extras`?

Also added a few mypy tests `tests/core/test_static_type_checking.py` with the accompanying script `tests/core/static/pandas_dataframe.py` to make sure the expected errors are being raised.

#### Initializing DataFrames with `pandera.typing.DataFrame[Schema]`

`pandera.typing.DataFrame[Schema]({"foo": [1]})` will now create an instance of the `pandera.typing.DataFrame` generic type and make sure it's validated against `Schema` at initialization time.

#### Problem: Double Validation

Assume you want the keep the linter happy, and consider the following code:

```python
import pandera as pa
from pandera.typing import Series, DataFrame

class Schema(pa.SchemaModel):
    x: Series[int]

class SchemaOut(Schema):
    y: Series[int]


@pa.check_types
def wrong_func(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
    return df.assign(y=1)  # mypy error, wrong return type

# so convert it to the right type before returning
@pa.check_types
def right_func(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
    return df.assign(y=1).pipe(DataFrame[SchemaOut])  # validated during dataframe init

df = DataFrame[Schema]({"x": [0]})
right_func(df)  # validated via decorator
```

The solution implemented so far are to prevent validation on `DataFrame[Schema]` initialization or `check_types` validation when `df.pandera.schema is None` and `df.pandera.schema != new_schema` where `new_schema` is taken from the annotation information provided by `DataFrame[T]`.