### PR TITLE
Correctly handling single string constraints

### DIFF
--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -51,9 +51,7 @@ def register_check_statistics(statistics_args):
             args_dict = {**dict(zip(arg_names, args)), **kwargs}
             check = class_method(cls, *args, **kwargs)
             check.statistics = {
-                stat: args_dict.get(stat)
-                for stat in statistics_args
-                if args_dict.get(stat) is not None or check.name != 'in_range'
+                stat: args_dict.get(stat) for stat in statistics_args
             }
             check.statistics_args = statistics_args
             return check

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -53,7 +53,7 @@ def register_check_statistics(statistics_args):
             check.statistics = {
                 stat: args_dict.get(stat)
                 for stat in statistics_args
-                if args_dict.get(stat) is not None
+                if args_dict.get(stat) is not None or check.name != 'in_range'
             }
             check.statistics_args = statistics_args
             return check

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -57,10 +57,7 @@ def _serialize_check_stats(check_stats, dtype=None):
         return stat
 
     # for unary checks, return a single value instead of a dictionary
-    if len(check_stats) == 1 and not list(check_stats.keys())[0] in [
-        "max_value",
-        "min_value",
-    ]:
+    if len(check_stats) == 1:
         return handle_stat_dtype(list(check_stats.values())[0])
 
     # otherwise return a dictionary of keyword args needed to create the Check

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -57,7 +57,8 @@ def _serialize_check_stats(check_stats, dtype=None):
         return stat
 
     # for unary checks, return a single value instead of a dictionary
-    if len(check_stats) == 1:
+    if len(check_stats) == 1 and not list(
+            check_stats.keys())[0] in ['max_value', 'min_value']:
         return handle_stat_dtype(list(check_stats.values())[0])
 
     # otherwise return a dictionary of keyword args needed to create the Check

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -57,8 +57,10 @@ def _serialize_check_stats(check_stats, dtype=None):
         return stat
 
     # for unary checks, return a single value instead of a dictionary
-    if len(check_stats) == 1 and not list(
-            check_stats.keys())[0] in ['max_value', 'min_value']:
+    if len(check_stats) == 1 and not list(check_stats.keys())[0] in [
+        "max_value",
+        "min_value",
+    ]:
         return handle_stat_dtype(list(check_stats.values())[0])
 
     # otherwise return a dictionary of keyword args needed to create the Check

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -126,6 +126,8 @@ columns:
       in_range:
         min_value: 0
         max_value: 10
+        include_min: null
+        include_max: null
     unique: false
     coerce: false
     required: true
@@ -139,6 +141,8 @@ columns:
       in_range:
         min_value: -10
         max_value: 20
+        include_min: null
+        include_max: null
     unique: false
     coerce: false
     required: true
@@ -763,6 +767,8 @@ columns:
       in_range:
         min_value: 10
         max_value: 99
+        include_min: null
+        include_max: null
     unique: true
     coerce: true
     required: true

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -800,7 +800,9 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      str_length: 3
+      str_length:
+        min_value: 3
+        max_value: null
     unique: false
     coerce: true
     required: true
@@ -809,7 +811,9 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      str_length: 3
+      str_length:
+        min_value: null
+        max_value: 3
     unique: false
     coerce: true
     required: true


### PR DESCRIPTION
Hello

This PR should fix #591 

Might also need to check the deserialization, but it seems that this part is correctly handled.

To verify:

Passing the following json to the `from_frictionless_schema()`-function:
```python
import pandas as pd
from pandera.io import from_frictionless_schema

FRICTIONLESS_SCHEMA = {
    "fields": [{
        "name": "foo",
        "constraints": {
            "maxLength": 20
        },
        "type": "string"
    }]
}

schema = from_frictionless_schema(FRICTIONLESS_SCHEMA)
```

The frictionless schema is correctly parsed to a pandera schema:
```python
schema.columns['foo'].checks
```

Output: ```[<Check str_length: str_length(None, 20)>]```

However, serializing the schema to YAML using the `to_yaml()`-function yielded the following output:

```yaml
schema_type: dataframe
version: 0.7.0
columns:
  foo:
    dtype: string[python]
    nullable: true
    checks:
      str_length: 20
    allow_duplicates: true
    coerce: true
    required: true
    regex: false
checks: null
index: null
coerce: true
strict: true
```

With proposed changes:
```yaml
schema_type: dataframe
version: 0.7.0
columns:
  foo:
    dtype: string[python]
    nullable: true
    checks:
      str_length: 
        max_value: 20
    allow_duplicates: true
    coerce: true
    required: true
    regex: false
checks: null
index: null
coerce: true
strict: true
```

