### PR TITLE
more detailed docstring of pandera.model_components.Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,25 @@ on GitHub.
 Go [here](https://github.com/pandera-dev/pandera/issues) to submit feature
 requests or bugfixes.
 
-## Other Data Validation Libraries
+## Why `pandera`?
+
+- [dataframe-centric data types](https://pandera.readthedocs.io/en/stable/dtypes.html),
+  [column nullability](https://pandera.readthedocs.io/en/stable/dataframe_schemas.html#null-values-in-columns),
+  and [uniqueness](https://pandera.readthedocs.io/en/stable/dataframe_schemas.html#validating-the-joint-uniqueness-of-columns)
+  are first-class concepts.
+- Define [schema models](https://pandera.readthedocs.io/en/stable/schema_models.html) with the class-based API with
+  [pydantic](https://pydantic-docs.helpmanual.io/)-style syntax and validate dataframes using the typing syntax.
+- `check_input` and `check_output` [decorators](https://pandera.readthedocs.io/en/stable/decorators.html#decorators-for-pipeline-integration)
+  enable seamless integration with existing code.
+- [`Check`s](https://pandera.readthedocs.io/en/stable/checks.html) provide flexibility and performance by providing access to `pandas`
+  API by design and offers built-in checks for common data tests.
+- [`Hypothesis`](https://pandera.readthedocs.io/en/stable/hypothesis.html) class provides a tidy-first interface for statistical hypothesis
+  testing.
+- `Check`s and `Hypothesis` objects support both [tidy and wide data validation](https://pandera.readthedocs.io/en/stable/checks.html#wide-checks).
+- Use schemas as generative contracts to [synthesize data](https://pandera.readthedocs.io/en/stable/data_synthesis_strategies.html) for unit testing.
+- [Schema inference](https://pandera.readthedocs.io/en/stable/schema_inference.html) allows you to bootstrap schemas from data.
+
+## Alternative Data Validation Libraries
 
 Here are a few other alternatives for validating Python data structures.
 
@@ -178,23 +196,14 @@ Here are a few other alternatives for validating Python data structures.
 - [PandasSchema](https://github.com/TMiguelT/PandasSchema)
 - [pandas-validator](https://github.com/c-data/pandas-validator)
 - [table_enforcer](https://github.com/xguse/table_enforcer)
+- [dataenforce](https://github.com/CedricFR/dataenforce)
+- [strictly typed pandas](https://github.com/nanne-aben/strictly_typed_pandas)
+- [marshmallow-dataframe](https://github.com/facultyai/marshmallow-dataframe)
 
 **Other tools for data validation**
 
 - [great_expectations](https://github.com/great-expectations/great_expectations)
-
-## Why `pandera`?
-
-- `pandas`-centric data types, column nullability, and uniqueness are
-  first-class concepts.
-- `check_input` and `check_output` decorators enable seamless integration with
-  existing code.
-- `Check`s provide flexibility and performance by providing access to `pandas`
-  API by design and offers built-in checks for common data tests.
-- `Hypothesis` class provides a tidy-first interface for statistical hypothesis
-  testing.
-- `Check`s and `Hypothesis` objects support both tidy and wide data validation.
-- Comprehensive documentation on key functionality.
+- [frictionless schema](https://framework.frictionlessdata.io/docs/guides/framework/schema-guide/)
 
 ## How to Cite
 

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -188,9 +188,16 @@ def Field(
     The keyword-only arguments from ``eq`` to ``str_startswith`` are dispatched
     to the built-in `~pandera.checks.Check` methods.
 
-    :param nullable: whether or not the column/index is nullable.
-    :param unique: whether column values should be unique
-    :param allow_duplicates: whether or not to accept duplicate values.
+    :param nullable: Whether or not the column/index can contain null values.
+    :param unique: Whether column values should be unique.
+    :param allow_duplicates: Whether or not column can contain duplicate
+        values.
+
+        .. warning::
+
+            This option will be deprecated in 0.8.0. Use the ``unique``
+            argument instead.
+
     :param coerce: coerces the data type if ``True``.
     :param regex: whether or not the field name or alias is a regex pattern.
     :param ignore_na: whether or not to ignore null values in the checks.


### PR DESCRIPTION
As suggested by @cosmicBboy at discussion #668 , this PR details documentation of `pandera.model_components.Field`.

Please keep in mind the following for review:
1. I am only assuming that deprecation is planned for `0.8.0`. If that is wrong, maybe change to `...will be deprecated soon`.
2. I have not checked if the updated docstring will be parsed correctly for Readthedocs. Formatting is just copied from the docstring of `pandera.schema_components.Column`.

Also: thanks a lot for this super useful package :-)