### PR TITLE
bugfix: allow sample/head/tail when validating frames with unhashable column types

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -2291,9 +2291,7 @@ def _pandas_obj_to_validate(
     if not pandas_obj_subsample:
         return dataframe_or_series
     first, *rest = pandas_obj_subsample
-    if not rest:
-        return first
-    return pd.concat([first, *rest]).drop_duplicates()
+    return first if not rest else pd.concat([first, *rest]).drop_duplicates()
 
 
 def _handle_check_results(

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -2288,11 +2288,12 @@ def _pandas_obj_to_validate(
         pandas_obj_subsample.append(
             dataframe_or_series.sample(sample, random_state=random_state)
         )
-    return (
-        dataframe_or_series
-        if not pandas_obj_subsample
-        else pd.concat(pandas_obj_subsample).drop_duplicates()
-    )
+    if not pandas_obj_subsample:
+        return dataframe_or_series
+    first, *rest = pandas_obj_subsample
+    if not rest:
+        return first
+    return pd.concat([first, *rest]).drop_duplicates()
 
 
 def _handle_check_results(

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -2288,10 +2288,13 @@ def _pandas_obj_to_validate(
         pandas_obj_subsample.append(
             dataframe_or_series.sample(sample, random_state=random_state)
         )
-    if not pandas_obj_subsample:
-        return dataframe_or_series
-    first, *rest = pandas_obj_subsample
-    return first if not rest else pd.concat([first, *rest]).drop_duplicates()
+    return (
+        dataframe_or_series
+        if not pandas_obj_subsample
+        else pd.concat(pandas_obj_subsample).pipe(
+            lambda x: x[~x.index.duplicated()]
+        )
+    )
 
 
 def _handle_check_results(


### PR DESCRIPTION
Fixes #682

While not a complete fix, this PR provides a workaround to the above issue by allowing one of `{sample,head,tail}` in calls to `SchemaModel.validate` on DataFrames with unhashable column types.

As the underlying issue here is with `pandas.DataFrame.drop_duplicates` not supporting unhashable types, this partial fix seems desirable to the alternatives of rolling a custom sampling scheme/duplicate dropper or upstreaming a fix to Pandas (I'm sure there are plenty of valid reasons why unhashable types are not supported for many operations like `drop_duplicates`).

This doesn't seem like something that warrants a specific test or documentation update but I'm happy to provide either/both if you disagree.