### PR TITLE
type annotations for DataFrameSchema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         - id: flynt
 
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.12b0
     hooks:
       - id: black
         args: ["--line-length=79"]

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1,6 +1,7 @@
 """Core pandera schema class definitions."""
 # pylint: disable=too-many-lines
 
+from __future__ import annotations
 import copy
 import itertools
 import os
@@ -8,10 +9,13 @@ import traceback
 import warnings
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, TypeVar, Union, cast
 
 import numpy as np
 import pandas as pd
+
+if TYPE_CHECKING:
+    from pandera.schema_components import Column
 
 from . import check_utils, errors
 from . import strategies as st
@@ -71,7 +75,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
     @deprecate_pandas_dtype
     def __init__(
         self,
-        columns: Optional[Dict[Any, Any]] = None,
+        columns: Optional[Dict[str, Column]] = None,
         checks: CheckList = None,
         index=None,
         dtype: PandasDtypeInputTypes = None,
@@ -159,7 +163,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         if isinstance(checks, (Check, Hypothesis)):
             checks = [checks]
 
-        self.columns = {} if columns is None else columns
+        self.columns: Optional[Dict[str, Column]] = {} if columns is None else columns
 
         if transformer is not None:
             warnings.warn(
@@ -181,11 +185,11 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                 "or `'filter'`."
             )
 
-        self.checks = checks
+        self.checks: CheckList = checks
         self.index = index
-        self.strict = strict
-        self.name = name
-        self.dtype = dtype or pandas_dtype  # type: ignore
+        self.strict: Union[bool, str] = strict
+        self.name: Optional[str] = name
+        self.dtype: PandasDtypeInputTypes = dtype or pandas_dtype  # type: ignore
         self._coerce = coerce
         self._ordered = ordered
         self._unique = unique

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-lines
 
 from __future__ import annotations
+
 import copy
 import itertools
 import os
@@ -9,13 +10,20 @@ import traceback
 import warnings
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import numpy as np
 import pandas as pd
-
-if TYPE_CHECKING:
-    from pandera.schema_components import Column
 
 from . import check_utils, errors
 from . import strategies as st
@@ -31,6 +39,10 @@ from .error_formatters import (
 )
 from .error_handlers import SchemaErrorHandler
 from .hypotheses import Hypothesis
+
+if TYPE_CHECKING:
+    from pandera.schema_components import Column
+
 
 N_INDENT_SPACES = 4
 
@@ -163,7 +175,9 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         if isinstance(checks, (Check, Hypothesis)):
             checks = [checks]
 
-        self.columns: Optional[Dict[str, Column]] = {} if columns is None else columns
+        self.columns: Optional[Dict[str, Column]] = (
+            {} if columns is None else columns
+        )
 
         if transformer is not None:
             warnings.warn(

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -175,7 +175,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         if isinstance(checks, (Check, Hypothesis)):
             checks = [checks]
 
-        self.columns: Optional[Dict[str, Column]] = (
+        self.columns: Dict[str, Column] = (
             {} if columns is None else columns
         )
 


### PR DESCRIPTION
The types for (non-property) `DataFrameSchema` attributes like `columns` are currently not exposed to type-checking systems. That is because there are no type annotations in the `__init__` body where they are assigned-- it's insufficient to just annotate the `__init__` signature. This is covered in [PEP 526](https://www.python.org/dev/peps/pep-0526/#class-and-instance-variable-annotations). This PR adds these annotations.