### PR TITLE
fix field autocompletion

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -45,7 +45,7 @@ from pandera.engines.pandas_engine import (
 from pandera.engines.pandas_engine import _PandasDtype as PandasDtype
 from pandera.engines.pandas_engine import pandas_version
 
-from . import constants, errors, pandas_accessor
+from . import constants, errors, pandas_accessor, typing
 from .checks import Check
 from .decorators import check_input, check_io, check_output, check_types
 from .hypotheses import Hypothesis

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -95,7 +95,7 @@ class FieldInfo:
         return self
 
     def __str__(self):
-        return self.name
+        return self.name.__str__()
 
     def __repr__(self):
         cls = self.__class__

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -92,7 +92,16 @@ class FieldInfo:
         self.original_name = name
 
     def __get__(self, instance: Any, owner: Type) -> str:
-        return self.name
+        return self
+
+    def __hash__(self):
+        return str(self.name).__hash__()
+
+    def __eq__(self, other):
+        return self.name == other
+
+    def __ne__(self, other):
+        return not(self.name == other)
 
     def __set__(self, instance: Any, value: Any) -> None:  # pragma: no cover
         raise AttributeError(f"Can't set the {self.original_name} field.")

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -91,7 +91,7 @@ class FieldInfo:
     def __set_name__(self, owner: Type, name: str) -> None:
         self.original_name = name
 
-    def __get__(self, instance: Any, owner: Type) -> str:
+    def __get__(self, instance: Any, owner: Type) -> "FieldInfo":
         return self
 
     def __hash__(self):
@@ -101,7 +101,7 @@ class FieldInfo:
         return self.name == other
 
     def __ne__(self, other):
-        return not(self.name == other)
+        return self.name != other
 
     def __set__(self, instance: Any, value: Any) -> None:  # pragma: no cover
         raise AttributeError(f"Can't set the {self.original_name} field.")

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -94,6 +94,16 @@ class FieldInfo:
     def __get__(self, instance: Any, owner: Type) -> "FieldInfo":
         return self
 
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        cls = self.__class__
+        return (
+            f'<{cls.__module__}.{cls.__name__}("{self.name}") '
+            f"object at {hex(id(self))}>"
+        )
+
     def __hash__(self):
         return str(self.name).__hash__()
 

--- a/pandera/typing/__init__.py
+++ b/pandera/typing/__init__.py
@@ -56,3 +56,10 @@ if koalas.KOALAS_INSTALLED:
     DATAFRAME_TYPES.update({koalas.DataFrame})
     SERIES_TYPES.update({koalas.Series})
     INDEX_TYPES.update({koalas.Index})
+
+
+__all__ = [
+    "DataFrame",
+    "Series",
+    "Index",
+]

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -123,11 +123,6 @@ class DataFrameBase(Generic[T]):
 class SeriesBase(Generic[GenericDtype]):
     """Pandera Series base class to use for all pandas-like APIs."""
 
-    def __get__(
-        self, instance: object, owner: Type
-    ) -> str:  # pragma: no cover
-        raise AttributeError("Series should resolve to Field-s")
-
 
 # pylint:disable=too-few-public-methods
 class IndexBase(Generic[GenericDtype]):


### PR DESCRIPTION
this PR makes it so that doing SchemaModel.series_field or
SchemaModel.index_field will do proper auto-completion on
an IDE.

It also modifies FieldInfo so that it can be used directly
in accessing the keys of a dataframe instead of returning a
string