### PR TITLE
make SchemaError and SchemaErrors picklable

### DIFF
--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -1,5 +1,6 @@
 """pandera-specific errors."""
 
+import warnings
 from collections import defaultdict, namedtuple
 from typing import Any, Dict, List, Union
 
@@ -23,6 +24,20 @@ class ParserError(Exception):
     def __init__(self, message, failure_cases):
         super().__init__(message)
         self.failure_cases = failure_cases
+
+    def __reduce__(self):
+        """Exception.__reduce__ is incompatible. Override with custom layout.
+
+        `failure_cases` is replaced by its string representation.
+        """
+        return ParserError, (
+            str(self),  # message
+            str(self.failure_cases),
+        )
+
+    def __setstate__(self, state):
+        warnings.warn("Pickling ParserError does not preserve state.")
+        return super().__setstate__(state)
 
 
 class SchemaInitError(Exception):
@@ -70,6 +85,10 @@ class SchemaError(Exception):
             self.check_index,
             str(self.check_output) if self.check_output is not None else None,
         )
+
+    def __setstate__(self, state):
+        warnings.warn("Pickling SchemaError does not preserve state.")
+        return super().__setstate__(state)
 
 
 class BaseStrategyOnlyError(Exception):
@@ -267,3 +286,7 @@ class SchemaErrors(Exception):
                 "data": str(self.data),
             },
         )
+
+    def __setstate__(self, state):
+        warnings.warn("Pickling SchemaErrors does not preserve state.")
+        return super().__setstate__(state)

--- a/tests/core/test_errors.py
+++ b/tests/core/test_errors.py
@@ -19,7 +19,97 @@ import pytest
 
 from pandera import Check, Column, DataFrameSchema
 from pandera.engines import pandas_engine
-from pandera.errors import ParserError, SchemaError, SchemaErrors
+from pandera.errors import (
+    ParserError,
+    ReducedPickleExceptionBase,
+    SchemaError,
+    SchemaErrors,
+)
+
+
+class MyError(ReducedPickleExceptionBase):
+    """Generic implementation of `ReducedPickleExceptionBase`."""
+
+    TO_STRING_KEYS = ["foo_a", "foo_c"]
+
+    def __init__(self, foo_a, msg, foo_b):
+        super().__init__(msg)
+        self.foo_a = foo_a
+        self.foo_b = foo_b
+        self.foo_c = 1337
+
+
+@pytest.fixture(name="reduced_pickle_exception")
+def fixture_reduced_pickle_exception() -> MyError:
+    """Fixture for MyError instance."""
+    return MyError(
+        foo_a=lambda x: x + 1,
+        msg="error message",
+        foo_b=42,
+    )
+
+
+class TestReducedPickleException:
+    """Test pickling behavior of `ReducedPickleExceptionBase`.
+
+    Uses `MyError` implementation.
+    """
+
+    @staticmethod
+    def test_pickle(reduced_pickle_exception: MyError) -> None:
+        """Simple test for non-empty pickled object"""
+        pickled = pickle.dumps(reduced_pickle_exception)
+        assert pickled
+
+    def test_unpickle(self, reduced_pickle_exception: MyError) -> None:
+        """Test for expected unpickling behavior.
+
+        Expects a warning.
+        """
+        pickled = pickle.dumps(reduced_pickle_exception)
+        with pytest.warns(
+            UserWarning,
+            match="Pickling MyError does not preserve state: Attributes "
+            r"\['foo_a', 'foo_c'\] become string representations.",
+        ):
+            unpickled = cast(MyError, pickle.loads(pickled))
+        self.validate_unpickled(unpickled)
+
+    @staticmethod
+    def validate_unpickled(exc_unpickled: MyError) -> None:
+        """Validate unpickled exception."""
+        assert str(exc_unpickled) == "error message"
+        assert isinstance(exc_unpickled.foo_a, str)
+        assert "<locals>.<lambda>" in exc_unpickled.foo_a
+        assert exc_unpickled.foo_b == 42
+        assert exc_unpickled.foo_c == "1337"
+
+    @staticmethod
+    def raise_my_error() -> NoReturn:
+        """Throw MyError instance.
+
+        Intended for subprocesses.
+        """
+        raise MyError(
+            foo_a=lambda x: x + 1,
+            msg="error message",
+            foo_b=42,
+        )
+
+    def test_subprocess(self):
+        """Test exception propagation from subprocess."""
+        with multiprocessing.Pool(1) as pool:
+            try:
+                with pytest.warns(
+                    UserWarning,
+                    match="Pickling MyError does not preserve state: Attributes "
+                    r"\['foo_a', 'foo_c'\] become string representations.",
+                ):
+                    pool.apply(self.raise_my_error, args=())
+            except MyError as exc:
+                self.validate_unpickled(exc)
+            else:
+                pytest.fail("MyError not raised")
 
 
 @pytest.fixture(name="int_dataframe")
@@ -49,6 +139,7 @@ def fixture_multi_check_schema() -> DataFrameSchema:
     return _multi_check_schema()
 
 
+@pytest.mark.filterwarnings("ignore:Pickling SchemaError")
 class TestSchemaError:
     """Tests pickling behavior of errors.SchemaError."""
 
@@ -96,6 +187,7 @@ class TestSchemaError:
         )
         assert exc.schema == "<Schema Column(name=a, type=DataType(int64))>"
         assert exc.data == str(df)
+        # `failure_cases` is limited to 10 by `n_failure_cases` of `Check`
         assert exc.failure_cases == str(
             pd.DataFrame(
                 {
@@ -110,24 +202,8 @@ class TestSchemaError:
             pd.Series(np.tile([False, True, True], n_tile), name="a")
         )
 
-    def test_subprocess(self, int_dataframe: pd.DataFrame):
-        """Test exception propagation from subprocesses."""
-        with multiprocessing.Pool(1) as pool:
-            try:
-                pool.apply(self._failing_validation, args=(int_dataframe,))
-            except SchemaError as exc:
-                self._validate_error(int_dataframe, 1, exc)
-            else:
-                pytest.fail("SchemaError not raised")
 
-    @staticmethod
-    def _failing_validation(df: pd.DataFrame) -> NoReturn:
-        """Call validation that fails with SchemaError."""
-        schema = DataFrameSchema({"a": Column(int, Check.isin([0, 1]))})
-        schema.validate(df)
-        raise RuntimeError("SchemaError not raised")
-
-
+@pytest.mark.filterwarnings("ignore:Pickling SchemaError")
 class TestSchemaErrors:
     """Tests pickling behavior of errors.SchemaErrors."""
 
@@ -176,22 +252,6 @@ class TestSchemaErrors:
         else:
             pytest.fail("SchemaErrors not raised")
 
-    def test_subprocess(self, int_dataframe: pd.DataFrame):
-        """Run failing subprocess and compare exception."""
-        with multiprocessing.Pool(1) as pool:
-            try:
-                with pytest.warns(UserWarning, match="Pickling"):
-                    pool.apply(self._failing_validation, args=(int_dataframe,))
-            except SchemaErrors as exc_mp:
-                try:
-                    self._failing_validation(int_dataframe)
-                except SchemaErrors as exc_native:
-                    self._compare_exception_with_unpickled(exc_native, exc_mp)
-                else:
-                    pytest.fail("SchemaErrors not raised")
-            else:
-                pytest.fail("SchemaErrors not raised")
-
     @staticmethod
     def _compare_exception_with_unpickled(
         exc_native: SchemaErrors, exc_unpickled: SchemaErrors
@@ -210,39 +270,18 @@ class TestSchemaErrors:
         assert exc_unpickled.failure_cases == str(exc_native.failure_cases)
         assert exc_unpickled.data == str(exc_native.data)
 
-    @staticmethod
-    def _failing_validation(df: pd.DataFrame) -> NoReturn:
-        """Call validation that fails with SchemaErrors."""
-        _multi_check_schema().validate(df, lazy=True)
-        raise RuntimeError("SchemaErrors not raised")
 
-
-class TestParserError:
-    """Tests pickling behavior of errors.ParserError."""
-
-    @staticmethod
-    def _create_parser_error() -> NoReturn:
+@pytest.mark.filterwarnings("ignore:Pickling ParserError")
+def test_pickling_parser_error():
+    """Test pickling behavior of ParserError."""
+    try:
         pandas_engine.Engine.dtype(int).try_coerce(pd.Series(["a", 0, "b"]))
-        raise RuntimeError("ParserError not created")
-
-    def test_pickling(self):
-        """Test for a non-empty pickled object."""
-        try:
-            self._create_parser_error()
-        except ParserError as exc:
-            pickled = pickle.dumps(exc)
-            # must be non-empty byte-array
-            assert pickled
-        else:
-            pytest.fail("ParserError not raised")
-
-    def test_unpickling(self):
-        """Tests content validity of unpickled ParserError."""
-        try:
-            self._create_parser_error()
-        except ParserError as exc:
-            unpickled = pickle.loads(pickle.dumps(exc))
-            assert str(unpickled) == str(exc)
-            assert unpickled.failure_cases == str(exc.failure_cases)
-        else:
-            pytest.fail("ParserError not raised")
+    except ParserError as exc:
+        pickled = pickle.dumps(exc)
+        # must be non-empty byte-array
+        assert pickled
+        unpickled = pickle.loads(pickled)
+        assert str(unpickled) == str(exc)
+        assert unpickled.failure_cases == str(exc.failure_cases)
+    else:
+        pytest.fail("ParserError not raised")

--- a/tests/core/test_errors.py
+++ b/tests/core/test_errors.py
@@ -1,0 +1,219 @@
+"""Test pickling behavior of SchemaError and SchemaErrors.
+
+See issue #713:
+In a multiprocessing or concurrent.futures.ProcessPoolExecutor
+situation if a subprocess does not handle the SchemaError itself, it is pickled
+and piped back to the main process. This requires picklability, and limits the
+pickled size to 2 GiB.
+The Exception contains full data and schema. Most Check objects are not picklable.
+DataFrames may be large. The signature of SchemaError needs special unpickling
+behavior.
+"""
+import multiprocessing
+import pickle
+from typing import NoReturn, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pandera import Check, Column, DataFrameSchema
+from pandera.errors import SchemaError, SchemaErrors
+
+
+@pytest.fixture(name="int_dataframe")
+def fixture_int_dataframe() -> pd.DataFrame:
+    """Fixture for simple DataFrame with one negative value."""
+    return pd.DataFrame({"a": [-1, 0, 1]})
+
+
+def _multi_check_schema() -> DataFrameSchema:
+    """Schema with multiple positivity checks on column `a`"""
+    return DataFrameSchema(
+        {
+            "a": Column(
+                int,
+                [
+                    Check.isin([0, 1]),
+                    Check(lambda x: x >= 0),
+                ],
+            ),
+        }
+    )
+
+
+@pytest.fixture(name="multi_check_schema")
+def fixture_multi_check_schema() -> DataFrameSchema:
+    """Schema with multiple positivity checks on column `a`"""
+    return _multi_check_schema()
+
+
+class TestSchemaError:
+    """Tests pickling behavior of errors.SchemaError."""
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "check_obj", [Check.isin([0, 1]), Check(lambda x: x >= 0)]
+    )
+    def test_pickling(int_dataframe: pd.DataFrame, check_obj: Check):
+        """Test for a non-empty pickled object."""
+        schema = DataFrameSchema({"a": Column(int, check_obj)})
+        try:
+            # fails for element -1
+            schema.validate(int_dataframe)
+        except SchemaError as exc:
+            # must be non-empty byte-array
+            assert pickle.dumps(exc)
+        else:
+            pytest.fail("SchemaError not raised")
+
+    @classmethod
+    @pytest.mark.parametrize("n_tile", [1, 10000])
+    def test_unpickling(cls, int_dataframe: pd.DataFrame, n_tile: int):
+        """Tests content validity of unpickled SchemaError."""
+        df = pd.DataFrame(
+            {"a": np.tile(int_dataframe["a"].to_numpy(), n_tile)}
+        )
+        schema = DataFrameSchema({"a": Column(int, Check.isin([0, 1]))})
+        loaded = None
+        try:
+            # fails for element -1
+            schema.validate(df)
+        except SchemaError as exc:
+            loaded = cast(SchemaError, pickle.loads(pickle.dumps(exc)))
+        else:
+            pytest.fail("SchemaError not raised")
+        assert loaded is not None
+        cls._validate_error(df, n_tile, loaded)
+
+    @staticmethod
+    def _validate_error(df: pd.DataFrame, n_tile: int, exc: SchemaError):
+        """General validation of Exception content."""
+        assert exc is not None
+        assert (
+            "Schema Column(name=a, type=DataType(int64))> "
+            "failed element-wise validator 0" in str(exc)
+        )
+        assert exc.schema == "<Schema Column(name=a, type=DataType(int64))>"
+        assert exc.data == str(df)
+        assert exc.failure_cases == str(
+            pd.DataFrame(
+                {
+                    "index": np.arange(n_tile) * 3,
+                    "failure_case": np.full(n_tile, fill_value=-1, dtype=int),
+                }
+            ).head(10)
+        )
+        assert exc.check == "<Check isin: isin({0, 1})>"
+        assert exc.check_index == 0
+        assert exc.check_output == str(
+            pd.Series(np.tile([False, True, True], n_tile), name="a")
+        )
+
+    @classmethod
+    def test_subprocess(cls, int_dataframe: pd.DataFrame):
+        """Test exception propagation from subprocesses."""
+        with multiprocessing.Pool(1) as pool:
+            try:
+                pool.apply(cls._failing_validation, args=(int_dataframe,))
+            except SchemaError as exc:
+                cls._validate_error(int_dataframe, 1, exc)
+            else:
+                pytest.fail("SchemaError not raised")
+
+    @staticmethod
+    def _failing_validation(df: pd.DataFrame) -> NoReturn:
+        """Call validation that fails with SchemaError."""
+        schema = DataFrameSchema({"a": Column(int, Check.isin([0, 1]))})
+        schema.validate(df)
+        raise RuntimeError("SchemaError not raised")
+
+
+class TestSchemaErrors:
+    """Tests pickling behavior of errors.SchemaErrors."""
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            DataFrameSchema(
+                {
+                    "a": Column(
+                        int,
+                        [
+                            Check.isin([0, 1]),
+                            Check(lambda x: x >= 0),
+                        ],
+                    ),
+                }
+            ),
+            DataFrameSchema(
+                {
+                    "a": Column(int, Check.isin([0, 1])),
+                }
+            ),
+        ],
+    )
+    def test_pickling(int_dataframe: pd.DataFrame, schema: DataFrameSchema):
+        """Test for a non-empty pickled object."""
+        try:
+            schema.validate(int_dataframe, lazy=True)
+        except SchemaErrors as exc:
+            # expect non-empty bytes
+            assert pickle.dumps(exc)
+        else:
+            pytest.fail("SchemaErrors not raised")
+
+    @classmethod
+    def test_unpickling(
+        cls, int_dataframe: pd.DataFrame, multi_check_schema: DataFrameSchema
+    ):
+        """Tests content validity of unpickled SchemaErrors."""
+        try:
+            multi_check_schema.validate(int_dataframe, lazy=True)
+        except SchemaErrors as exc:
+            loaded = pickle.loads(pickle.dumps(exc))
+            assert loaded is not None
+            cls._compare_exception_with_unpickled(exc, loaded)
+        else:
+            pytest.fail("SchemaErrors not raised")
+
+    @classmethod
+    def test_subprocess(cls, int_dataframe: pd.DataFrame):
+        """Run failing subprocess and compare exception."""
+        with multiprocessing.Pool(1) as pool:
+            try:
+                pool.apply(cls._failing_validation, args=(int_dataframe,))
+            except SchemaErrors as exc_mp:
+                try:
+                    cls._failing_validation(int_dataframe)
+                except SchemaErrors as exc_native:
+                    cls._compare_exception_with_unpickled(exc_native, exc_mp)
+                else:
+                    pytest.fail("SchemaErrors not raised")
+            else:
+                pytest.fail("SchemaErrors not raised")
+
+    @staticmethod
+    def _compare_exception_with_unpickled(
+        exc_native: SchemaErrors, exc_unpickled: SchemaErrors
+    ):
+        """Compare content of native SchemaErrors with unpickled one."""
+        assert isinstance(exc_native, SchemaErrors)
+        assert isinstance(exc_unpickled, SchemaErrors)
+        # compare message
+        assert str(exc_unpickled) == str(exc_native)
+        # compare schema_errors as string, as it is a nested container with
+        # elements that compare by identity
+        assert str(exc_unpickled.schema_errors) == str(
+            exc_native.schema_errors
+        )
+        assert exc_unpickled.error_counts == exc_native.error_counts
+        assert exc_unpickled.failure_cases == str(exc_native.failure_cases)
+        assert exc_unpickled.data == str(exc_native.data)
+
+    @staticmethod
+    def _failing_validation(df: pd.DataFrame) -> NoReturn:
+        """Call validation that fails with SchemaErrors."""
+        _multi_check_schema().validate(df, lazy=True)
+        raise RuntimeError("SchemaErrors not raised")


### PR DESCRIPTION
# description
- Solves #713 
- The issue extends to `ParserError`.
- As `BaseException` implements `__reduce__`, which expects an `args` attribute in the object, it needs to be overridden.
- To abstract the logic for all three affected classes, `ReducedPickleExceptionBase` was created as base class for exceptions that need to convert attributes before pickling, so actual changes in the final exception classes are minimal.
   - Its `__reduce__` composes the state from `args`, and `__dict__`, and converts all `__dict__` elements listed in `TO_STRING_KEYS` to strings. The return signature of `__reduce__` uses the three-tuple, that uses `__new__` for object creation and then updates it via `__setstate__`.
   - Its `__setstate__` creates a warning stating the non-conservation of state, listing converted keys.
- Most non-primitive members are converted to string.
- `SchemaErrors.schema_errors` is not primitive, but not transformed in the process. I did not encounter an unpicklable case and it is highly unlikely to become problematic in size.

# rejected ideas - up for discussion
- using `sample` or `head` instead of string conversion to reduce memory footprint of data members. The idea is to allow some degree of inspection. However, all ways to reduce data size are arbitrary to some degree, and string representation breaks any attempt to accidentally use incomplete data in further processing.