### PR TITLE
Add option to disallow duplicate column names

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -143,6 +143,7 @@ jobs:
         run: |
           mamba install -c conda-forge geopandas
           python -m pip install -U pip
+          python -m pip install pandas==${{ matrix.pandas-version }}
           python -m pip install -r requirements-dev.txt
 
       - run: |

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -773,7 +773,8 @@ data pipeline:
         index=None,
         strict=True
         name=None,
-        ordered=False
+        ordered=False,
+        unique_column_names=False
     )>
 
 If during the course of a data pipeline one of your columns is moved into the
@@ -820,7 +821,8 @@ the pipeline output.
         )>,
         strict=True
         name=None,
-        ordered=False
+        ordered=False,
+        unique_column_names=False
     )>
 
 

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -46,7 +46,8 @@ is a simple example:
         index=<Schema Index(name=None, type=DataType(int64))>,
         strict=False
         name=None,
-        ordered=False
+        ordered=False,
+        unique_column_names=False
     )>
 
 

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -177,7 +177,8 @@ You can easily convert a :class:`~pandera.model.SchemaModel` class into a
         index=None,
         strict=False
         name=None,
-        ordered=False
+        ordered=False,
+        unique_column_names=False
     )>
 
 You can also use the :meth:`~pandera.model.SchemaModel.validate` method to

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -101,6 +101,7 @@ class BaseConfig:  # pylint:disable=R0903
     #: make sure dataframe column names are unique
     allow_duplicate_column_names = False
 
+
 def _is_field(name: str) -> bool:
     """Ignore private and reserved keywords."""
     return not name.startswith("_") and name != _CONFIG_KEY
@@ -233,6 +234,7 @@ class SchemaModel(metaclass=_MetaSchema):
             name=cls.__config__.name,
             ordered=cls.__config__.ordered,
             unique=cls.__config__.unique,
+            allow_duplicate_column_names=cls.__config__.allow_duplicate_column_names,
         )
         if cls not in MODEL_CACHE:
             MODEL_CACHE[cls] = cls.__schema__  # type: ignore

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -99,7 +99,7 @@ class BaseConfig:  # pylint:disable=R0903
     multiindex_ordered: bool = True
 
     #: make sure dataframe column names are unique
-    allow_duplicate_column_names = False
+    allow_duplicate_column_names: bool = True
 
 
 def _is_field(name: str) -> bool:

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -209,7 +209,7 @@ class SchemaModel(metaclass=_MetaSchema):
                 "unique": cls.__config__.unique,
                 "title": cls.__config__.title,
                 "description": cls.__config__.description or cls.__doc__,
-                "allow_duplicate_column_names": cls.__config__.allow_duplicate_column_names,
+                "unique_column_names": cls.__config__.unique_column_names,
             }
         cls.__schema__ = DataFrameSchema(
             columns,

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -98,6 +98,8 @@ class BaseConfig:  # pylint:disable=R0903
     #: validate MultiIndex in order
     multiindex_ordered: bool = True
 
+    #: make sure dataframe column names are unique
+    allow_duplicate_column_names = False
 
 def _is_field(name: str) -> bool:
     """Ignore private and reserved keywords."""

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -806,10 +806,11 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             f"checks={self.checks}, "
             f"index={self.index.__repr__()}, "
             f"coerce={self.coerce}, "
-            f"dtype={self._dtype},"
-            f"strict={self.strict},"
-            f"name={self.name},"
-            f"ordered={self.ordered}"
+            f"dtype={self._dtype}, "
+            f"strict={self.strict}, "
+            f"name={self.name}, "
+            f"ordered={self.ordered}, "
+            f"allow_duplicate_column_names={self.allow_duplicate_column_names}"
             ")>"
         )
 

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -877,7 +877,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             f"{indent}index={index},\n"
             f"{indent}strict={self.strict}\n"
             f"{indent}name={self.name},\n"
-            f"{indent}ordered={self.ordered}\n"
+            f"{indent}ordered={self.ordered},\n"
             f"{indent}unique_column_names={self.unique_column_names}\n"
             ")>"
         )
@@ -972,7 +972,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=None,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         .. seealso:: :func:`remove_columns`
@@ -1022,7 +1023,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=None,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         .. seealso:: :func:`add_columns`
@@ -1083,7 +1085,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=None,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         .. seealso:: :func:`rename_columns`
@@ -1143,7 +1146,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=None,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         .. note:: This is the successor to the ``update_column`` method, which
@@ -1225,7 +1229,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=None,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         .. seealso:: :func:`update_column`
@@ -1300,7 +1305,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=None,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         .. note:: If an index is present in the schema, it will also be
@@ -1400,7 +1406,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=<Schema Index(name=category, type=DataType(str))>,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         If you have an existing index in your schema, and you would like to
@@ -1435,7 +1442,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             )>,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         .. seealso:: :func:`reset_index`
@@ -1531,7 +1539,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=None,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         This reclassifies an index (or indices) as a column (or columns).
@@ -1560,7 +1569,8 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             index=<Schema Index(name=unique_id2, type=DataType(str))>,
             strict=False
             name=None,
-            ordered=False
+            ordered=False,
+            unique_column_names=False
         )>
 
         .. seealso:: :func:`set_index`

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -246,6 +246,16 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         """Set ordered attribute"""
         self._ordered = value
 
+    @property
+    def allow_duplicate_column_names(self):
+        """Whether multiple columns with the same name can be present."""
+        return self._allow_duplicate_column_names
+
+    @allow_duplicate_column_names.setter
+    def allow_duplicate_column_names(self, value: bool) -> None:
+        """Set allow_duplicated_column_names attribute"""
+        self._allow_duplicate_column_names = value
+
     # the _is_inferred getter and setter methods are not public
     @property
     def _is_inferred(self) -> bool:

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -139,6 +139,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             .. warning:: This option will be deprecated in 0.8.0
 
         :param unique: a list of columns that should be jointly unique.
+        :param unique_column_names: whether or not column names must be unique.
         :param title: A human-readable label for the schema.
         :param description: An arbitrary textual description of the schema.
 
@@ -639,7 +640,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                         self,
                         check_obj,
                         msg,
-                        failure_cases=reshape_failure_cases(pd.Series(failed)),
+                        failure_cases=scalar_failure_case(failed),
                         check="dataframe_column_labels_unique",
                     ),
                 )

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -858,6 +858,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             f"{indent}strict={self.strict}\n"
             f"{indent}name={self.name},\n"
             f"{indent}ordered={self.ordered}\n"
+            f"{indent}allow_duplicate_column_names={self.allow_duplicate_column_names}\n"
             ")>"
         )
 

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -100,7 +100,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         ordered: bool = False,
         pandas_dtype: PandasDtypeInputTypes = None,
         unique: Optional[Union[str, List[str]]] = None,
-        allow_duplicate_column_names: bool = True,
+        unique_column_names: bool = False,
         title: Optional[str] = None,
         description: Optional[str] = None,
     ) -> None:
@@ -212,7 +212,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         self._coerce = coerce
         self._ordered = ordered
         self._unique = unique
-        self._allow_duplicate_column_names = allow_duplicate_column_names
+        self._unique_column_names = unique_column_names
         self._title = title
         self._description = description
         self._validate_schema()
@@ -253,14 +253,14 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         self._ordered = value
 
     @property
-    def allow_duplicate_column_names(self):
+    def unique_column_names(self):
         """Whether multiple columns with the same name can be present."""
-        return self._allow_duplicate_column_names
+        return self._unique_column_names
 
-    @allow_duplicate_column_names.setter
-    def allow_duplicate_column_names(self, value: bool) -> None:
+    @unique_column_names.setter
+    def unique_column_names(self, value: bool) -> None:
         """Set allow_duplicated_column_names attribute"""
-        self._allow_duplicate_column_names = value
+        self._unique_column_names = value
 
     @property
     def title(self):
@@ -626,7 +626,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                                 check="column_ordered",
                             ),
                         )
-        if self._allow_duplicate_column_names is False:
+        if self._unique_column_names:
             failed = check_obj.columns[check_obj.columns.duplicated()]
             if failed.any():
                 msg = (
@@ -828,7 +828,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             f"strict={self.strict}, "
             f"name={self.name}, "
             f"ordered={self.ordered}, "
-            f"allow_duplicate_column_names={self.allow_duplicate_column_names}"
+            f"unique_column_names={self.unique_column_names}"
             ")>"
         )
 
@@ -877,7 +877,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             f"{indent}strict={self.strict}\n"
             f"{indent}name={self.name},\n"
             f"{indent}ordered={self.ordered}\n"
-            f"{indent}allow_duplicate_column_names={self.allow_duplicate_column_names}\n"
+            f"{indent}unique_column_names={self.unique_column_names}\n"
             ")>"
         )
 

--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -211,8 +211,8 @@ def register_check_strategy(strategy_fn: StrategyFn):
 # pylint: disable=line-too-long
 # Values taken from
 # https://hypothesis.readthedocs.io/en/latest/_modules/hypothesis/extra/numpy.html#from_dtype  # noqa
-MIN_DT_VALUE = -(2 ** 63)
-MAX_DT_VALUE = 2 ** 63 - 1
+MIN_DT_VALUE = -(2**63)
+MAX_DT_VALUE = 2**63 - 1
 
 
 def _is_datetime_tz(pandera_dtype: DataType) -> bool:

--- a/pandera/typing/config.py
+++ b/pandera/typing/config.py
@@ -37,7 +37,7 @@ class BaseConfig:  # pylint:disable=R0903
     multiindex_ordered: bool = True
 
     #: make sure dataframe column names are unique
-    allow_duplicate_column_names: bool = True
+    unique_column_names: bool = False
 
     #: data format before validation. This option only applies to
     #: schemas used in the context of the pandera type constructor

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -665,6 +665,7 @@ def test_config() -> None:
             multiindex_coerce = True
             multiindex_strict = True
             multiindex_name: Optional[str] = "mi"
+            allow_duplicate_column_names = False
 
     class Child(Base):
         b: Series[int]
@@ -686,6 +687,7 @@ def test_config() -> None:
         coerce=True,
         strict=True,
         ordered=True,
+        allow_duplicate_column_names=False,
     )
 
     assert expected == Child.to_schema()

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -665,7 +665,7 @@ def test_config() -> None:
             multiindex_coerce = True
             multiindex_strict = True
             multiindex_name: Optional[str] = "mi"
-            allow_duplicate_column_names = False
+            unique_column_names = True
 
     class Child(Base):
         b: Series[int]
@@ -689,7 +689,7 @@ def test_config() -> None:
         coerce=True,
         strict=True,
         ordered=True,
-        allow_duplicate_column_names=False,
+        unique_column_names=True,
         description="foo",
         title="bar",
     )

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -324,7 +324,7 @@ def test_duplicate_columns_dataframe():
         columns={i: Column(int) for i in col_labels},
         unique_column_names=True,
     )
-    
+
     assert schema.unique_column_names
 
     with pytest.raises(
@@ -332,7 +332,7 @@ def test_duplicate_columns_dataframe():
         match="dataframe contains multiple columns with label",
     ):
         schema.validate(frame)
-        
+
     schema.unique_column_names = False
     assert not schema.unique_column_names
 

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -315,6 +315,23 @@ def test_ordered_dataframe(
         schema.validate(df, lazy=True)
 
 
+def test_duplicate_columns_dataframe():
+    """Test that duplicate columns are detected."""
+    col_labels = ["a", "a", "b"]
+    frame = pd.DataFrame(data=[[1, 2, 3]], columns=col_labels)
+
+    schema = DataFrameSchema(
+        columns={i: Column(int) for i in col_labels},
+        allow_duplicate_column_names=False,
+    )
+
+    with pytest.raises(
+        errors.SchemaError,
+        match="dataframe contains multiple columns with label",
+    ):
+        schema.validate(frame)
+
+
 def test_series_schema() -> None:
     """Tests that a SeriesSchema Check behaves as expected for integers and
     strings. Tests error cases for types, duplicates, name errors, and issues

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -322,7 +322,7 @@ def test_duplicate_columns_dataframe():
 
     schema = DataFrameSchema(
         columns={i: Column(int) for i in col_labels},
-        allow_duplicate_column_names=False,
+        unique_column_names=True,
     )
 
     with pytest.raises(

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -324,12 +324,17 @@ def test_duplicate_columns_dataframe():
         columns={i: Column(int) for i in col_labels},
         unique_column_names=True,
     )
+    
+    assert schema.unique_column_names
 
     with pytest.raises(
         errors.SchemaError,
         match="dataframe contains multiple columns with label",
     ):
         schema.validate(frame)
+        
+    schema.unique_column_names = False
+    assert not schema.unique_column_names
 
 
 def test_series_schema() -> None:

--- a/tests/mypy/test_static_type_checking.py
+++ b/tests/mypy/test_static_type_checking.py
@@ -119,7 +119,10 @@ PANDAS_CONCAT_FALSE_POSITIVES = {
 
 PANDAS_TIME_FALSE_POSITIVES = {
     4: {
-        "msg": 'Unsupported operand types for + ("Timestamp" and "YearEnd")',  # noqa
+        "msg": (
+            'Unsupported operand types for + ("Timestamp" and "YearEnd")',
+            'No overload variant of "__add__" of "Timestamp" matches argument type "YearEnd"',  # noqa
+        ),
         "errcode": "operator",
     },
     6: {
@@ -175,7 +178,12 @@ def test_pandas_stubs_false_positives(
         text=True,
     )
     resulting_errors = _get_mypy_errors(capfd.readouterr().out)
-    assert resulting_errors == expected_errors
+    for lineno, error in resulting_errors.items():
+        assert error["errcode"] == expected_errors[lineno]["errcode"]
+        if isinstance(expected_errors[lineno]["msg"], tuple):
+            assert error["msg"] in expected_errors[lineno]["msg"]
+        else:
+            assert error["msg"] == expected_errors[lineno]["msg"]
 
 
 @pytest.mark.parametrize("module", ["pandas_concat", "pandas_time"])


### PR DESCRIPTION
Closes #707 - I've interpreted this as something to add to the `DataFrameSchema` and then feed through to the `SchemaModel` config, I hope that's right.

@cosmicBboy I've attempted this in the spot that seemed logical to me, I'm not sure if that's the "right" spot though.

Similarly with tests, I've made a best guess as to where to put them.

I haven't added docstrings yet, I thought I would wait for some feedback first, and check on naming, since the current name I have is a bit long.

I had a tiny bit of trouble in setting up a dev env, the pinned version of mypy (0.921) isn't on conda forge, so I used 0.920, and running `pre-commit run --all` shows 5 pylint failures in tests/mypy/test_static_type_checking.py (but that's not a problem as such since I haven't modified those files, they don't get checked again as part of the pre commit hook).

I've also had some problems with what seems to be nox, conda and windows interactions, but pytest tests are passing in the dev environment (aside from what looks to be an issue with hypothesis generating pandas StringArrays containing nans instead of pd.NA). 

Edit: I ran the github actions on my fork: https://github.com/m-richards/pandera/pull/1 and while they're not finished running it seems like I haven't broken things too badly, failing because of the aforementioned lack of docstrings.