### PR TITLE
Make SchemaModel use class name, define own config

### DIFF
--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -176,7 +176,7 @@ You can easily convert a :class:`~pandera.model.SchemaModel` class into a
         dtype=None,
         index=None,
         strict=False
-        name=None,
+        name=InputSchema,
         ordered=False,
         unique_column_names=False
     )>

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -156,6 +156,7 @@ class SchemaModel(metaclass=_MetaSchema):
 
     def __init_subclass__(cls, **kwargs):
         """Ensure :class:`~pandera.model_components.FieldInfo` instances."""
+        cls.Config = type('Config', (BaseConfig,), {'name': cls.__name__})
         super().__init_subclass__(**kwargs)
         # pylint:disable=no-member
         subclass_annotations = cls.__dict__.get("__annotations__", {})

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -267,7 +267,9 @@ class SchemaModel(metaclass=_MetaSchema):
         cls: Type[TSchemaModel], *, size: Optional[int] = None
     ) -> DataFrameBase[TSchemaModel]:
         """%(example_doc)s"""
-        return cast(DataFrameBase[TSchemaModel], cls.to_schema().example(size=size))
+        return cast(
+            DataFrameBase[TSchemaModel], cls.to_schema().example(size=size)
+        )
 
     @classmethod
     def _build_columns_index(  # pylint:disable=too-many-locals
@@ -280,7 +282,8 @@ class SchemaModel(metaclass=_MetaSchema):
         Optional[Union[schema_components.Index, schema_components.MultiIndex]],
     ]:
         index_count = sum(
-            annotation.origin in INDEX_TYPES for annotation, _ in fields.values()
+            annotation.origin in INDEX_TYPES
+            for annotation, _ in fields.values()
         )
 
         columns: Dict[str, schema_components.Column] = {}
@@ -310,7 +313,9 @@ class SchemaModel(metaclass=_MetaSchema):
                 annotation.origin in SERIES_TYPES
                 or annotation.raw_annotation in SERIES_TYPES
             ):
-                col_constructor = field.to_column if field else schema_components.Column
+                col_constructor = (
+                    field.to_column if field else schema_components.Column
+                )
 
                 if check_name is False:
                     raise SchemaInitError(
@@ -328,7 +333,9 @@ class SchemaModel(metaclass=_MetaSchema):
                 or annotation.raw_annotation in INDEX_TYPES
             ):
                 if annotation.optional:
-                    raise SchemaInitError(f"Index '{field_name}' cannot be Optional.")
+                    raise SchemaInitError(
+                        f"Index '{field_name}' cannot be Optional."
+                    )
 
                 if check_name is False or (
                     # default single index
@@ -337,7 +344,9 @@ class SchemaModel(metaclass=_MetaSchema):
                 ):
                     field_name = None  # type:ignore
 
-                index_constructor = field.to_index if field else schema_components.Index
+                index_constructor = (
+                    field.to_index if field else schema_components.Index
+                )
                 index = index_constructor(  # type: ignore
                     dtype, checks=field_checks, name=field_name
                 )
@@ -405,7 +414,9 @@ class SchemaModel(metaclass=_MetaSchema):
 
         for model in models:
             config = getattr(model, _CONFIG_KEY, {})
-            base_options, base_extras = _extract_config_options_and_extras(config)
+            base_options, base_extras = _extract_config_options_and_extras(
+                config
+            )
             options.update(base_options)
             extras.update(base_extras)
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -156,7 +156,11 @@ class SchemaModel(metaclass=_MetaSchema):
 
     def __init_subclass__(cls, **kwargs):
         """Ensure :class:`~pandera.model_components.FieldInfo` instances."""
-        cls.Config = type('Config', (BaseConfig,), {'name': cls.__name__})
+        if "Config" in cls.__dict__:
+            cls.Config.name = cls.Config.name or cls.__name__
+        else:
+            cls.Config = type("Config", (BaseConfig,), {"name": cls.__name__})
+
         super().__init_subclass__(**kwargs)
         # pylint:disable=no-member
         subclass_annotations = cls.__dict__.get("__annotations__", {})
@@ -263,9 +267,7 @@ class SchemaModel(metaclass=_MetaSchema):
         cls: Type[TSchemaModel], *, size: Optional[int] = None
     ) -> DataFrameBase[TSchemaModel]:
         """%(example_doc)s"""
-        return cast(
-            DataFrameBase[TSchemaModel], cls.to_schema().example(size=size)
-        )
+        return cast(DataFrameBase[TSchemaModel], cls.to_schema().example(size=size))
 
     @classmethod
     def _build_columns_index(  # pylint:disable=too-many-locals
@@ -278,8 +280,7 @@ class SchemaModel(metaclass=_MetaSchema):
         Optional[Union[schema_components.Index, schema_components.MultiIndex]],
     ]:
         index_count = sum(
-            annotation.origin in INDEX_TYPES
-            for annotation, _ in fields.values()
+            annotation.origin in INDEX_TYPES for annotation, _ in fields.values()
         )
 
         columns: Dict[str, schema_components.Column] = {}
@@ -309,9 +310,7 @@ class SchemaModel(metaclass=_MetaSchema):
                 annotation.origin in SERIES_TYPES
                 or annotation.raw_annotation in SERIES_TYPES
             ):
-                col_constructor = (
-                    field.to_column if field else schema_components.Column
-                )
+                col_constructor = field.to_column if field else schema_components.Column
 
                 if check_name is False:
                     raise SchemaInitError(
@@ -329,9 +328,7 @@ class SchemaModel(metaclass=_MetaSchema):
                 or annotation.raw_annotation in INDEX_TYPES
             ):
                 if annotation.optional:
-                    raise SchemaInitError(
-                        f"Index '{field_name}' cannot be Optional."
-                    )
+                    raise SchemaInitError(f"Index '{field_name}' cannot be Optional.")
 
                 if check_name is False or (
                     # default single index
@@ -340,9 +337,7 @@ class SchemaModel(metaclass=_MetaSchema):
                 ):
                     field_name = None  # type:ignore
 
-                index_constructor = (
-                    field.to_index if field else schema_components.Index
-                )
+                index_constructor = field.to_index if field else schema_components.Index
                 index = index_constructor(  # type: ignore
                     dtype, checks=field_checks, name=field_name
                 )
@@ -410,9 +405,7 @@ class SchemaModel(metaclass=_MetaSchema):
 
         for model in models:
             config = getattr(model, _CONFIG_KEY, {})
-            base_options, base_extras = _extract_config_options_and_extras(
-                config
-            )
+            base_options, base_extras = _extract_config_options_and_extras(config)
             options.update(base_options)
             extras.update(base_extras)
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -157,7 +157,11 @@ class SchemaModel(metaclass=_MetaSchema):
     def __init_subclass__(cls, **kwargs):
         """Ensure :class:`~pandera.model_components.FieldInfo` instances."""
         if "Config" in cls.__dict__:
-            cls.Config.name = cls.Config.name if hasattr(cls.Config, 'name') else cls.__name__
+            cls.Config.name = (
+                cls.Config.name
+                if hasattr(cls.Config, "name")
+                else cls.__name__
+            )
         else:
             cls.Config = type("Config", (BaseConfig,), {"name": cls.__name__})
 

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -157,7 +157,7 @@ class SchemaModel(metaclass=_MetaSchema):
     def __init_subclass__(cls, **kwargs):
         """Ensure :class:`~pandera.model_components.FieldInfo` instances."""
         if "Config" in cls.__dict__:
-            cls.Config.name = cls.Config.name or cls.__name__
+            cls.Config.name = cls.Config.name if hasattr(cls.Config, 'name') else cls.__name__
         else:
             cls.Config = type("Config", (BaseConfig,), {"name": cls.__name__})
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,6 +1,7 @@
 """Tests schema creation and validation from type annotations."""
 # pylint:disable=missing-class-docstring,missing-function-docstring,too-few-public-methods
 import re
+from copy import deepcopy
 from decimal import Decimal  # pylint:disable=C0415
 from typing import Any, Iterable, Optional
 
@@ -25,6 +26,7 @@ def test_to_schema_and_validate() -> None:
         idx: Index[str]
 
     expected = pa.DataFrameSchema(
+        name="Schema",
         columns={"a": pa.Column(int), "b": pa.Column(str), "c": pa.Column()},
         index=pa.Index(str),
     )
@@ -38,7 +40,7 @@ def test_to_schema_and_validate() -> None:
 def test_empty_schema() -> None:
     """Test that SchemaModel supports empty schemas."""
 
-    empty_schema = pa.DataFrameSchema()
+    empty_schema = pa.DataFrameSchema(name="EmptySchema")
 
     class EmptySchema(pa.SchemaModel):
         pass
@@ -51,13 +53,21 @@ def test_empty_schema() -> None:
     class EmptySubSchema(Schema):
         pass
 
-    schema = pa.DataFrameSchema({"a": pa.Column(int)})
-    assert schema == EmptySubSchema.to_schema()
+    empty_sub_schema = pa.DataFrameSchema(
+        name="EmptySubSchema",
+        columns={"a": pa.Column(int)},
+    )
+    assert empty_sub_schema == EmptySubSchema.to_schema()
+
+    empty_parent_schema = pa.DataFrameSchema(
+        name="EmptyParentSchema",
+        columns={"a": pa.Column(int)},
+    )
 
     class EmptyParentSchema(EmptySchema):
         a: Series[int]
 
-    assert schema == EmptyParentSchema.to_schema()
+    assert empty_parent_schema == EmptyParentSchema.to_schema()
 
 
 def test_invalid_annotations() -> None:
@@ -121,7 +131,10 @@ def test_optional_index() -> None:
 
 
 def test_empty_dtype() -> None:
-    expected = pa.DataFrameSchema({"empty_column": pa.Column()})
+    expected = pa.DataFrameSchema(
+        name="EmptyDtypeSchema",
+        columns={"empty_column": pa.Column()},
+    )
 
     class EmptyDtypeSchema(pa.SchemaModel):
         empty_column: pa.typing.Series
@@ -139,6 +152,7 @@ def test_schemamodel_with_fields() -> None:
 
     actual = Schema.to_schema()
     expected = pa.DataFrameSchema(
+        name="Schema",
         columns={
             "a": pa.Column(
                 int, checks=[pa.Check.equal_to(9), pa.Check.not_equal_to(0)]
@@ -169,12 +183,13 @@ def test_multiindex() -> None:
         b: Index[str]
 
     expected = pa.DataFrameSchema(
+        name="Schema",
         index=pa.MultiIndex(
             [
                 pa.Index(int, name="a", checks=pa.Check.gt(0)),
                 pa.Index(str, name="b"),
             ]
-        )
+        ),
     )
     assert expected == Schema.to_schema()
 
@@ -457,6 +472,7 @@ def test_inherit_schemamodel_fields() -> None:
         b: Series[int]
 
     expected = pa.DataFrameSchema(
+        name="Child",
         columns={"a": pa.Column(int), "b": pa.Column(int)},
         index=pa.Index(str),
     )
@@ -488,26 +504,35 @@ def test_inherit_schemamodel_fields_alias() -> None:
         pass
 
     expected_mid = pa.DataFrameSchema(
+        name="Mid",
         columns={"a": pa.Column(int), "_b": pa.Column(str)},
         index=pa.Index(str),
     )
     expected_child_override_attr = expected_mid.rename_columns(
         {"_b": "b"}
     ).update_column("b", dtype=int)
+    expected_child_override_attr.name = "ChildOverrideAttr"
+
     expected_child_override_alias = expected_mid.rename_columns(
         {"_b": "new_b"}
     )
+    expected_child_override_alias.name = "ChildOverrideAlias"
+
     expected_child_new_attr = expected_mid.add_columns(
         {
             "c": pa.Column(int),
         }
     )
+    expected_child_new_attr.name = "ChildNewAttr"
+
+    expected_child_empty = deepcopy(expected_mid)
+    expected_child_empty.name = "ChildEmpty"
 
     assert expected_mid == Mid.to_schema()
     assert expected_child_override_attr == ChildOverrideAttr.to_schema()
     assert expected_child_override_alias == ChildOverrideAlias.to_schema()
     assert expected_child_new_attr == ChildNewAttr.to_schema()
-    assert expected_mid == ChildEmpty.to_schema()
+    assert expected_child_empty == ChildEmpty.to_schema()
 
 
 def test_inherit_field_checks() -> None:
@@ -866,6 +891,7 @@ def test_field_name_access_inherit() -> None:
         i3: Index[int] = pa.Field(alias="_i3")
 
     expected_base = pa.DataFrameSchema(
+        name="Base",
         columns={
             "a": pa.Column(int),
             "b": pa.Column(int),
@@ -881,6 +907,7 @@ def test_field_name_access_inherit() -> None:
     )
 
     expected_child = pa.DataFrameSchema(
+        name="Child",
         columns={
             "a": pa.Column(int),
             "_b": pa.Column(str),

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -945,3 +945,23 @@ def test_column_access_regex() -> None:
         col_regex: Series[str] = pa.Field(alias="column_([0-9])+", regex=True)
 
     assert Schema.col_regex == "column_([0-9])+"
+
+
+def test_schema_name_override():
+    """
+    Test that setting name in Config manually does not propagate to other
+    SchemaModels.
+    """
+
+    class Foo(pa.SchemaModel):
+        pass
+
+    class Bar(pa.SchemaModel):
+        pass
+
+    assert Foo.Config.name == "Foo"
+
+    Foo.Config.name = "foo"
+
+    assert Foo.Config.name == "foo"
+    assert Bar.Config.name == "Bar"


### PR DESCRIPTION
Addresses #760. Also addresses an unrelated issue:

```python
import pandera as pa

class Foo(pa.SchemaModel):
    pass

class Bar(pa.SchemaModel):
    pass

Foo.Config.name = 'foo'
Bar.Config.name  # => 'foo'
```

I realize that setting `name` on `Foo.Config` outside the class definition is not the intended usage, but people still might do it if they are dynamically generating SchemaModels. Better to not be able to alter the global default config from a subclass.

NOTE: There are a few tests that need to be updated, I'll do that if @cosmicBboy you agree with this change.