### PR TITLE
implement coercion-on-initialization for DataFrame[SchemaModel] types

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,4 +25,5 @@ disable=
     no-else-return,
     inconsistent-return-statements,
     protected-access,
-    too-many-ancestors
+    too-many-ancestors,
+    too-many-lines

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -159,14 +159,13 @@ class DataFrameBase(Generic[T]):
 
             # prevent the double validation problem by preventing checks for
             # dataframes with a defined pandera.schema
-            pandera = getattr(self, "pandera")
+            pandera_accessor = getattr(self, "pandera")
             if (
-                pandera.schema is None
-                or pandera.schema != schema_model.to_schema()
+                pandera_accessor.schema is None
+                or pandera_accessor.schema != schema_model.to_schema()
             ):
-                # pylint: disable=self-cls-assignment
-                self = schema_model.validate(self)
-                pandera.add_schema(schema_model.to_schema())
+                pandera_accessor.add_schema(schema_model.to_schema())
+                self.__dict__ = schema_model.validate(self).__dict__
 
 
 # pylint:disable=too-few-public-methods

--- a/pandera/typing/dask.py
+++ b/pandera/typing/dask.py
@@ -1,7 +1,6 @@
 """Pandera type annotations for Dask."""
 
-import inspect
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from .common import DataFrameBase, IndexBase, SeriesBase
 from .pandas import GenericDtype, Schema
@@ -31,26 +30,6 @@ if DASK_INSTALLED:
 
         *new in 0.8.0*
         """
-
-        def __setattr__(self, name: str, value: Any) -> None:
-            object.__setattr__(self, name, value)
-            if name == "__orig_class__":
-                class_args = getattr(self.__orig_class__, "__args__", None)
-                if class_args is not None and any(
-                    x.__name__ == "SchemaModel"
-                    for x in inspect.getmro(class_args[0])
-                ):
-                    schema_model = value.__args__[0]
-
-                # prevent the double validation problem by preventing checks
-                # for dataframes with a defined pandera.schema
-                if (
-                    self.pandera.schema is None
-                    or self.pandera.schema != schema_model.to_schema()
-                ):
-                    # pylint: disable=self-cls-assignment
-                    self.__dict__ = schema_model.validate(self).__dict__
-                    self.pandera.add_schema(schema_model.to_schema())
 
     # pylint:disable=too-few-public-methods
     class Series(SeriesBase, dd.Series, Generic[GenericDtype]):  # type: ignore

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -997,7 +997,6 @@ def test_validate_coerce_on_init():
     assert isinstance(pandera_validated_df, DataFrame)
     assert isinstance(pandas_df, pd.DataFrame)
 
-    Schema.Config.coerce = False
     with pytest.raises(
         pa.errors.SchemaError,
         match="^expected series 'price' to have type float64, got int64$",

--- a/tests/dask/test_dask.py
+++ b/tests/dask/test_dask.py
@@ -1,6 +1,5 @@
 """ Tests that basic Pandera functionality works for Dask objects. """
 
-
 import dask.dataframe as dd
 import pandas as pd
 import pytest


### PR DESCRIPTION
The PR:
- better naming in `DataFrameBase.__setattr__` method
- assign validated data to `self.__dict__` so that coercion occurs after dataframe init
- add test case