### PR TITLE
set default check n_failure_cases to None

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -46,7 +46,7 @@ from pandera.engines.pandas_engine import (
 from pandera.engines.pandas_engine import _PandasDtype as PandasDtype
 from pandera.engines.pandas_engine import pandas_version
 
-from . import constants, errors, pandas_accessor, typing
+from . import errors, pandas_accessor, typing
 from .checks import Check
 from .decorators import check_input, check_io, check_output, check_types
 from .hypotheses import Hypothesis

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -21,7 +21,7 @@ from typing import (
 
 import pandas as pd
 
-from . import check_utils, constants, errors
+from . import check_utils, errors
 from . import strategies as st
 
 CheckResult = namedtuple(
@@ -115,7 +115,7 @@ class _CheckBase(metaclass=_CheckMeta):
         name: str = None,
         error: Optional[str] = None,
         raise_warning: bool = False,
-        n_failure_cases: Union[int, None] = constants.N_FAILURE_CASES,
+        n_failure_cases: Optional[int] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
         **check_kwargs,

--- a/pandera/constants.py
+++ b/pandera/constants.py
@@ -1,3 +1,0 @@
-"""Constants for use across the library"""
-
-N_FAILURE_CASES = 10  # The number of failure cases to report.

--- a/pandera/model_components.py
+++ b/pandera/model_components.py
@@ -201,7 +201,7 @@ def Field(
     regex: bool = False,
     ignore_na: bool = True,
     raise_warning: bool = False,
-    n_failure_cases: int = 10,
+    n_failure_cases: int = None,
     alias: Any = None,
     check_name: Optional[bool] = None,
     dtype_kwargs: Optional[Dict[str, Any]] = None,

--- a/tests/core/test_errors.py
+++ b/tests/core/test_errors.py
@@ -194,7 +194,7 @@ class TestSchemaError:
                     "index": np.arange(n_tile) * 3,
                     "failure_case": np.full(n_tile, fill_value=-1, dtype=int),
                 }
-            ).head(10)
+            )
         )
         assert exc.check == "<Check isin: isin({0, 1})>"
         assert exc.check_index == 0


### PR DESCRIPTION
Prior to this change, pandera would only report the first 10 unique failure cases for a particular check. Users who want to collect all failure cases would need to set `n_failure_cases = None` at the check level.

This PR makes it so that pandera collects all failure cases by default.