### PR TITLE
Add overloads to `infer_schema`

### DIFF
--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -1,6 +1,6 @@
 """Module for inferring dataframe/series schema."""
 
-from typing import Any, Union, overload  # pylint: disable=unused-import
+from typing import overload
 
 import pandas as pd
 

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -15,14 +15,14 @@ from .schemas import DataFrameSchema, SeriesSchema
 
 @overload
 def infer_schema(
-    pandas_obj: pd.DataFrame
+    pandas_obj: pd.DataFrame,
 ) -> DataFrameSchema:  # pragma: no cover
     ...
 
 
 @overload
 def infer_schema(
-    pandas_obj: "pd.Series[Any]"
+    pandas_obj: pd.Series,
 ) -> SeriesSchema:  # pragma: no cover
     ...
 

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -1,6 +1,6 @@
 """Module for inferring dataframe/series schema."""
 
-from typing import Union
+from typing import Union, Any, overload
 
 import pandas as pd
 
@@ -13,8 +13,18 @@ from .schema_statistics import (
 from .schemas import DataFrameSchema, SeriesSchema
 
 
+@overload
+def infer_schema(pandas_obj: pd.DataFrame) -> DataFrameSchema:
+    ...
+
+
+@overload
+def infer_schema(pandas_obj: 'pd.Series[Any]') -> SeriesSchema:
+    ...
+
+
 def infer_schema(
-    pandas_obj: Union[pd.DataFrame, pd.Series]
+    pandas_obj: Union[pd.DataFrame, 'pd.Series[Any]']
 ) -> Union[DataFrameSchema, SeriesSchema]:
     """Infer schema for pandas DataFrame or Series object.
 

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -22,7 +22,7 @@ def infer_schema(
 
 @overload
 def infer_schema(
-    pandas_obj: pd.DataFrame,
+    pandas_obj: pd.DataFrame,  # type: ignore[misc]
 ) -> DataFrameSchema:  # pragma: no cover
     ...
 

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -1,6 +1,6 @@
 """Module for inferring dataframe/series schema."""
 
-from typing import Union, Any, overload
+from typing import Any, Union, overload  # pylint: disable=unused-import
 
 import pandas as pd
 
@@ -19,12 +19,12 @@ def infer_schema(pandas_obj: pd.DataFrame) -> DataFrameSchema:
 
 
 @overload
-def infer_schema(pandas_obj: 'pd.Series[Any]') -> SeriesSchema:
+def infer_schema(pandas_obj: "pd.Series[Any]") -> SeriesSchema:
     ...
 
 
 def infer_schema(
-    pandas_obj: Union[pd.DataFrame, 'pd.Series[Any]']
+    pandas_obj: Union[pd.DataFrame, "pd.Series[Any]"]
 ) -> Union[DataFrameSchema, SeriesSchema]:
     """Infer schema for pandas DataFrame or Series object.
 

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -14,18 +14,16 @@ from .schemas import DataFrameSchema, SeriesSchema
 
 
 @overload
-def infer_schema(pandas_obj: pd.DataFrame) -> DataFrameSchema:
+def infer_schema(pandas_obj: pd.DataFrame) -> DataFrameSchema:  # pragma: no cover
     ...
 
 
 @overload
-def infer_schema(pandas_obj: "pd.Series[Any]") -> SeriesSchema:
+def infer_schema(pandas_obj: "pd.Series[Any]") -> SeriesSchema:  # pragma: no cover
     ...
 
 
-def infer_schema(
-    pandas_obj: Union[pd.DataFrame, "pd.Series[Any]"]
-) -> Union[DataFrameSchema, SeriesSchema]:
+def infer_schema(pandas_obj):
     """Infer schema for pandas DataFrame or Series object.
 
     :param pandas_obj: DataFrame or Series object to infer.

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -21,8 +21,8 @@ def infer_schema(
 
 
 @overload
-def infer_schema(
-    pandas_obj: pd.DataFrame,  # type: ignore[misc]
+def infer_schema(  # type: ignore[misc]
+    pandas_obj: pd.DataFrame,
 ) -> DataFrameSchema:  # pragma: no cover
     ...
 

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -15,15 +15,15 @@ from .schemas import DataFrameSchema, SeriesSchema
 
 @overload
 def infer_schema(
-    pandas_obj: pd.DataFrame,
-) -> DataFrameSchema:  # pragma: no cover
+    pandas_obj: pd.Series,
+) -> SeriesSchema:  # pragma: no cover
     ...
 
 
 @overload
 def infer_schema(
-    pandas_obj: pd.Series,
-) -> SeriesSchema:  # pragma: no cover
+    pandas_obj: pd.DataFrame,
+) -> DataFrameSchema:  # pragma: no cover
     ...
 
 

--- a/pandera/schema_inference.py
+++ b/pandera/schema_inference.py
@@ -14,12 +14,16 @@ from .schemas import DataFrameSchema, SeriesSchema
 
 
 @overload
-def infer_schema(pandas_obj: pd.DataFrame) -> DataFrameSchema:  # pragma: no cover
+def infer_schema(
+    pandas_obj: pd.DataFrame
+) -> DataFrameSchema:  # pragma: no cover
     ...
 
 
 @overload
-def infer_schema(pandas_obj: "pd.Series[Any]") -> SeriesSchema:  # pragma: no cover
+def infer_schema(
+    pandas_obj: "pd.Series[Any]"
+) -> SeriesSchema:  # pragma: no cover
     ...
 
 


### PR DESCRIPTION
The return type of the `infer_schema` function depends on the type of the input object, this PR documents this behaviour in a way that type checkers can understand.

I also changed the `pd.Series` hint to `'pd.Series[Any]'` as the `pd.Series` type is only generic for type checkers and not at runtime.