### PR TITLE
Add overloads to `schema.to_yaml`

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -20,6 +20,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    overload,
 )
 
 import numpy as np
@@ -1363,7 +1364,15 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         return pandera.io.from_yaml(yaml_schema)
 
-    def to_yaml(self, stream: Optional[os.PathLike] = None):
+    @overload
+    def to_yaml(self, stream: None = None) -> str:
+        ...
+
+    @overload
+    def to_yaml(self, stream: os.PathLike) -> None:
+        ...
+
+    def to_yaml(self, stream: Optional[os.PathLike] = None) -> Optional[str]:
         """Write DataFrameSchema to yaml file.
 
         :param stream: file stream to write to. If None, dumps to string.

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1365,11 +1365,11 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         return pandera.io.from_yaml(yaml_schema)
 
     @overload
-    def to_yaml(self, stream: None = None) -> str:
+    def to_yaml(self, stream: None = None) -> str:  # pragma: no cover
         ...
 
     @overload
-    def to_yaml(self, stream: os.PathLike) -> None:
+    def to_yaml(self, stream: os.PathLike) -> None:  # pragma: no cover
         ...
 
     def to_yaml(self, stream: Optional[os.PathLike] = None) -> Optional[str]:


### PR DESCRIPTION
Because this function was previously unannotated, Pyright inferred the return type to be `None` when it is `str | None`. This PR adds overload definitions to the `to_yaml` function to define the API contract in a way that type checkers can understand.

It should be noted that I didn't update `pandera.io.to_yaml` as the rest of that module is untyped, I will happily make the changes there too if required.

As an aside, if you're interested in ensuring that the whole codebase is type hinted you can [install pyright](https://github.com/microsoft/pyright#command-line) and run `pyright --verifytypes`.