### PR TITLE
Support for logical data types

### DIFF
--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -21,6 +21,8 @@ class DataType(ABC):
     continuous: Optional[bool] = None
     """Whether the number data type is continuous."""
 
+    is_logical: bool = False
+
     def __init__(self):
         if self.__class__ is DataType:
             raise TypeError(

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -361,6 +361,41 @@ class Complex64(Complex128):
 
 
 ###############################################################################
+# decimal
+###############################################################################
+
+
+@immutable(init=True)
+class Decimal(_Number):
+    """Semantic representation of a decimal data type."""
+
+    exact: bool = dataclasses.field(init=False, default=True)
+    continuous: bool = dataclasses.field(init=False, default=True)
+
+    precision: Optional[int] = None
+    scale: Optional[int] = None
+
+    def __init__(
+        self, precision: Optional[int] = None, scale: Optional[int] = None
+    ):
+        super().__init__()
+        if precision is not None:
+            if precision <= 0:
+                raise ValueError(
+                    f"Decimal precision {precision} must be positive."
+                )
+            if scale is not None and scale > precision:
+                raise ValueError(
+                    f"Decimal scale {scale} must be between 0 and {precision}."
+                )
+        object.__setattr__(self, "precision", precision)
+        object.__setattr__(self, "scale", scale)
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}({self.precision}, {self.scale})"
+
+
+###############################################################################
 # nominal
 ###############################################################################
 


### PR DESCRIPTION
Fixes #788 

So far Pandera only support physical data types, i.e. have a 1-1 relationship with pandas/numpy dtypes. Logical data types represent [the abstracted understanding of that data](https://dylan-profiler.github.io/visions/visions/background/data_type_view.html#decoupling-physical-and-logical-types).

The use-cases are:

1. Logical types that consist of a pandas dtype + a check on values: IP, URLs, paths. These can currently be validated with a `Check` but coercion is not possible.

2. Dtypes unofficially supported by pandas: date, decimal, etc..Another example is the new PydanticModel introduced in https://github.com/pandera-dev/pandera/pull/779

This PR is a proof-of-concept. I've  I added an attribute `DataType.is_logical`. When `True`, we expect `DataType.check` to return a mask of valid data, similar to the output of a check function. This is necessary to report failure cases, which was impossible in my initial proposal #788.

@cosmicBboy I tested this approach with the Decimal data type. I'd like to have your opinion before cleaning up the code and adding robust tests. I played with returning a `Check` or `CheckResult` class but did not find it very elegant.