### PR TITLE
Feature: Add support for Generic to SchemaModel

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,6 +13,7 @@ good-names=
     k,
     v,
     fp,
+    bar,
     _IS_INFERRED,
 
 [MESSAGES CONTROL]

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -1,5 +1,6 @@
 """Class-based api"""
 
+import copy
 import inspect
 import os
 import re
@@ -59,6 +60,7 @@ _CONFIG_KEY = "Config"
 
 
 MODEL_CACHE: Dict[Type["SchemaModel"], DataFrameSchema] = {}
+GENERIC_SCHEMA_CACHE: Dict[Tuple[Type["SchemaModel"], Tuple[Type[Any], ...]], Type["SchemaModel"]] = {}
 F = TypeVar("F", bound=Callable)
 TSchemaModel = TypeVar("TSchemaModel", bound="SchemaModel")
 
@@ -190,6 +192,10 @@ class SchemaModel(metaclass=_MetaSchema):
         }
 
         cls.__fields__ = cls._collect_fields()
+        for field, (annot_info, _) in cls.__fields__.items():
+            if isinstance(annot_info.arg, TypeVar):
+                raise SchemaInitError(f"Field {field} has a generic data type")
+
         check_infos = typing.cast(
             List[FieldCheckInfo], cls._collect_check_infos(CHECK_KEY)
         )
@@ -512,6 +518,37 @@ class SchemaModel(metaclass=_MetaSchema):
     def __modify_schema__(cls, field_schema):
         """Update pydantic field schema."""
         field_schema.update(to_json_schema(cls.to_schema()))
+
+    def __class_getitem__(
+        cls: Type[TSchemaModel], params: Union[Type[Any], Tuple[Type[Any], ...]]
+    ) -> Type[TSchemaModel]:
+        """Parameterize the class's generic arguments with the specified types"""
+        if not hasattr(cls, "__parameters__"):
+            raise TypeError(f"{cls.__name__} must inherit from typing.Generic before being parameterized")
+        __parameters__: tuple[TypeVar, ...] = cls.__parameters__  # type: ignore
+
+        if not isinstance(params, tuple):
+            params = (params, )
+        if len(params) != len(__parameters__):
+            raise ValueError(f"Expected {len(__parameters__)} generic arguments but found {len(params)}")
+        if (cls, params) in GENERIC_SCHEMA_CACHE:
+            return typing.cast(Type[TSchemaModel], GENERIC_SCHEMA_CACHE[(cls, params)])
+
+        param_dict: Dict[TypeVar, Type[Any]] = dict(zip(__parameters__, params))
+        extra: dict[str, Any] = {"__annotations__": {}}
+        for field, (annot_info, field_info) in cls._collect_fields().items():
+            if isinstance(annot_info.arg, TypeVar):
+                if annot_info.arg in param_dict:
+                    raw_annot = annot_info.origin[param_dict[annot_info.arg]]  # type: ignore
+                    if annot_info.optional:
+                        raw_annot = Optional[raw_annot]
+                    extra["__annotations__"][field] = raw_annot
+                    extra[field] = copy.deepcopy(field_info)
+
+        parameterized_name = f"{cls.__name__}[{', '.join(p.__name__ for p in params)}]"
+        parameterized_cls = type(parameterized_name, (cls,), extra)
+        GENERIC_SCHEMA_CACHE[(cls, params)] = parameterized_cls
+        return parameterized_cls
 
 
 def _build_schema_index(

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -372,7 +372,8 @@ class SchemaModel(metaclass=_MetaSchema):
         bases = inspect.getmro(cls)[:-1]  # bases -> SchemaModel -> object
         attrs = {}
         for base in reversed(bases):
-            attrs.update(base.__dict__)
+            if issubclass(base, SchemaModel):
+                attrs.update(base.__dict__)
         return attrs
 
     @classmethod
@@ -412,7 +413,7 @@ class SchemaModel(metaclass=_MetaSchema):
     ) -> Tuple[Type[BaseConfig], Dict[str, Any]]:
         """Collect config options from bases, splitting off unknown options."""
         bases = inspect.getmro(cls)[:-1]
-        bases = typing.cast(Tuple[Type[SchemaModel]], bases)
+        bases = tuple(base for base in bases if issubclass(base, SchemaModel))
         root_model, *models = reversed(bases)
 
         options, extras = _extract_config_options_and_extras(root_model.Config)
@@ -434,7 +435,7 @@ class SchemaModel(metaclass=_MetaSchema):
         walk the inheritance tree.
         """
         bases = inspect.getmro(cls)[:-2]  # bases -> SchemaModel -> object
-        bases = typing.cast(Tuple[Type[SchemaModel]], bases)
+        bases = tuple(base for base in bases if issubclass(base, SchemaModel))
 
         method_names = set()
         check_infos = []

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -3,7 +3,7 @@
 import re
 from copy import deepcopy
 from decimal import Decimal  # pylint:disable=C0415
-from typing import Any, Iterable, Optional
+from typing import Any, Generic, Iterable, Optional, TypeVar
 
 import pandas as pd
 import pytest
@@ -1002,3 +1002,29 @@ def test_validate_coerce_on_init():
         match="^expected series 'price' to have type float64, got int64$",
     ):
         DataFrame[SchemaNoCoerce](raw_data)
+
+
+def test_schema_model_generic_inheritance() -> None:
+    """Test that a schema model subclass can also inherit from typing.Generic"""
+
+    T = TypeVar("T")
+
+    class Foo(pa.SchemaModel, Generic[T]):
+        @classmethod
+        def bar(cls) -> T:
+            raise NotImplementedError
+
+    class Bar1(Foo[int]):
+        @classmethod
+        def bar(cls) -> int:
+            return 1
+
+    class Bar2(Foo[str]):
+        @classmethod
+        def bar(cls) -> str:
+            return "1"
+
+    with pytest.raises(NotImplementedError):
+        Foo.bar()
+    assert Bar1.bar() == 1
+    assert Bar2.bar() == "1"

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -9,8 +9,8 @@ import pandas as pd
 import pytest
 
 import pandera as pa
-from pandera.errors import SchemaError, SchemaInitError
 import pandera.extensions as pax
+from pandera.errors import SchemaError, SchemaInitError
 from pandera.typing import DataFrame, Index, Series, String
 
 
@@ -1036,6 +1036,7 @@ def test_generic_no_generic_fields() -> None:
 
     class GenericModel(pa.SchemaModel, Generic[T]):
         x: Series[int]
+
     GenericModel.to_schema()
 
 
@@ -1051,10 +1052,12 @@ def test_generic_model_single_generic_field() -> None:
 
     class IntModel(GenericModel[int]):
         ...
+
     IntModel.to_schema()
 
     class FloatModel(GenericModel[float]):
         ...
+
     FloatModel.to_schema()
 
     IntModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
@@ -1075,13 +1078,17 @@ def test_generic_optional_field() -> None:
 
     class IntYModel(GenericModel[int]):
         ...
+
     IntYModel.validate(pd.DataFrame({"x": [1, 2, 3]}))
     IntYModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
     with pytest.raises(SchemaError):
-        IntYModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]}))
+        IntYModel.validate(
+            pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]})
+        )
 
     class FloatYModel(GenericModel[float]):
         ...
+
     FloatYModel.validate(pd.DataFrame({"x": [1, 2, 3]}))
     with pytest.raises(SchemaError):
         FloatYModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
@@ -1100,25 +1107,47 @@ def test_generic_model_multiple_inheritance() -> None:
 
     class IntYFloatZModel(GenericYModel[int], GenericZModel[float]):
         ...
+
     IntYFloatZModel.to_schema()
-    IntYFloatZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+    IntYFloatZModel.validate(
+        pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]})
+    )
     with pytest.raises(SchemaError):
-        IntYFloatZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+        IntYFloatZModel.validate(
+            pd.DataFrame(
+                {"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}
+            )
+        )
     with pytest.raises(SchemaError):
-        IntYFloatZModel.validate(pd.DataFrame({"x": ["a", "b", "c"], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+        IntYFloatZModel.validate(
+            pd.DataFrame(
+                {"x": ["a", "b", "c"], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}
+            )
+        )
 
     class FloatYIntZModel(GenericYModel[float], GenericZModel[int]):
         ...
+
     FloatYIntZModel.to_schema()
     with pytest.raises(SchemaError):
-        FloatYIntZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
-    FloatYIntZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+        FloatYIntZModel.validate(
+            pd.DataFrame(
+                {"x": [1, 2, 3], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}
+            )
+        )
+    FloatYIntZModel.validate(
+        pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]})
+    )
     with pytest.raises(SchemaError):
-        FloatYIntZModel.validate(pd.DataFrame({"x": ["a", "b", "c"], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+        FloatYIntZModel.validate(
+            pd.DataFrame(
+                {"x": ["a", "b", "c"], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}
+            )
+        )
 
 
 def test_multiple_generic() -> None:
-    """Test that a generic schema with multiple types is handled correctly """
+    """Test that a generic schema with multiple types is handled correctly"""
     T1 = TypeVar("T1", int, float, str)
     T2 = TypeVar("T2", int, float, str)
 
@@ -1128,18 +1157,28 @@ def test_multiple_generic() -> None:
 
     class IntYFloatZModel(GenericModel[int, float]):
         ...
+
     IntYFloatZModel.to_schema()
     IntYFloatZModel.to_schema()
-    IntYFloatZModel.validate(pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+    IntYFloatZModel.validate(
+        pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]})
+    )
     with pytest.raises(SchemaError):
-        IntYFloatZModel.validate(pd.DataFrame({"y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+        IntYFloatZModel.validate(
+            pd.DataFrame({"y": [4.0, 5.0, 6.0], "z": [1, 2, 3]})
+        )
 
     class FloatYIntZModel(GenericModel[float, int]):
         ...
+
     FloatYIntZModel.to_schema()
     with pytest.raises(SchemaError):
-        FloatYIntZModel.validate(pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
-    FloatYIntZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+        FloatYIntZModel.validate(
+            pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]})
+        )
+    FloatYIntZModel.validate(
+        pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]})
+    )
 
 
 def test_repeated_generic() -> None:
@@ -1154,11 +1193,17 @@ def test_repeated_generic() -> None:
 
     class IntYGenericZModel(GenericYZModel[int, T3], Generic[T3]):
         ...
+
     with pytest.raises(SchemaInitError):
         IntYGenericZModel.to_schema()
 
     class IntYFloatZModel(IntYGenericZModel[float]):
         ...
-    IntYFloatZModel.validate(pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+
+    IntYFloatZModel.validate(
+        pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]})
+    )
     with pytest.raises(SchemaError):
-        IntYFloatZModel.validate(pd.DataFrame({"y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+        IntYFloatZModel.validate(
+            pd.DataFrame({"y": [4.0, 5.0, 6.0], "z": [1, 2, 3]})
+        )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 import pandera as pa
+from pandera.errors import SchemaError, SchemaInitError
 import pandera.extensions as pax
 from pandera.typing import DataFrame, Index, Series, String
 
@@ -1028,3 +1029,136 @@ def test_schema_model_generic_inheritance() -> None:
         Foo.bar()
     assert Bar1.bar() == 1
     assert Bar2.bar() == "1"
+
+
+def test_generic_no_generic_fields() -> None:
+    T = TypeVar("T", int, float, str)
+
+    class GenericModel(pa.SchemaModel, Generic[T]):
+        x: Series[int]
+    GenericModel.to_schema()
+
+
+def test_generic_model_single_generic_field() -> None:
+    T = TypeVar("T", int, float, str)
+
+    class GenericModel(pa.SchemaModel, Generic[T]):
+        x: Series[int]
+        y: Series[T]
+
+    with pytest.raises(SchemaInitError):
+        GenericModel.to_schema()
+
+    class IntModel(GenericModel[int]):
+        ...
+    IntModel.to_schema()
+
+    class FloatModel(GenericModel[float]):
+        ...
+    FloatModel.to_schema()
+
+    IntModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+    with pytest.raises(SchemaError):
+        FloatModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+
+    with pytest.raises(SchemaError):
+        IntModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5, 6]}))
+    FloatModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5, 6]}))
+
+
+def test_generic_optional_field() -> None:
+    T = TypeVar("T", int, float, str)
+
+    class GenericModel(pa.SchemaModel, Generic[T]):
+        x: Series[int]
+        y: Optional[Series[T]]
+
+    class IntYModel(GenericModel[int]):
+        ...
+    IntYModel.validate(pd.DataFrame({"x": [1, 2, 3]}))
+    IntYModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+    with pytest.raises(SchemaError):
+        IntYModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]}))
+
+    class FloatYModel(GenericModel[float]):
+        ...
+    FloatYModel.validate(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(SchemaError):
+        FloatYModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+    FloatYModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]}))
+
+
+def test_generic_model_multiple_inheritance() -> None:
+    T = TypeVar("T", int, float, str)
+
+    class GenericYModel(pa.SchemaModel, Generic[T]):
+        x: Series[int]
+        y: Series[T]
+
+    class GenericZModel(pa.SchemaModel, Generic[T]):
+        z: Series[T]
+
+    class IntYFloatZModel(GenericYModel[int], GenericZModel[float]):
+        ...
+    IntYFloatZModel.to_schema()
+    IntYFloatZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+    with pytest.raises(SchemaError):
+        IntYFloatZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+    with pytest.raises(SchemaError):
+        IntYFloatZModel.validate(pd.DataFrame({"x": ["a", "b", "c"], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+
+    class FloatYIntZModel(GenericYModel[float], GenericZModel[int]):
+        ...
+    FloatYIntZModel.to_schema()
+    with pytest.raises(SchemaError):
+        FloatYIntZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+    FloatYIntZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+    with pytest.raises(SchemaError):
+        FloatYIntZModel.validate(pd.DataFrame({"x": ["a", "b", "c"], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+
+
+def test_multiple_generic() -> None:
+    """Test that a generic schema with multiple types is handled correctly """
+    T1 = TypeVar("T1", int, float, str)
+    T2 = TypeVar("T2", int, float, str)
+
+    class GenericModel(pa.SchemaModel, Generic[T1, T2]):
+        y: Series[T1]
+        z: Series[T2]
+
+    class IntYFloatZModel(GenericModel[int, float]):
+        ...
+    IntYFloatZModel.to_schema()
+    IntYFloatZModel.to_schema()
+    IntYFloatZModel.validate(pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+    with pytest.raises(SchemaError):
+        IntYFloatZModel.validate(pd.DataFrame({"y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+
+    class FloatYIntZModel(GenericModel[float, int]):
+        ...
+    FloatYIntZModel.to_schema()
+    with pytest.raises(SchemaError):
+        FloatYIntZModel.validate(pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+    FloatYIntZModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))
+
+
+def test_repeated_generic() -> None:
+    """Test that repeated use of Generic in a class hierachy results in the correct types"""
+    T1 = TypeVar("T1", int, float, str)
+    T2 = TypeVar("T2", int, float, str)
+    T3 = TypeVar("T3", int, float, str)
+
+    class GenericYZModel(pa.SchemaModel, Generic[T1, T2]):
+        y: Series[T1]
+        z: Series[T2]
+
+    class IntYGenericZModel(GenericYZModel[int, T3], Generic[T3]):
+        ...
+    with pytest.raises(SchemaInitError):
+        IntYGenericZModel.to_schema()
+
+    class IntYFloatZModel(IntYGenericZModel[float]):
+        ...
+    IntYFloatZModel.validate(pd.DataFrame({"y": [4, 5, 6], "z": [1.0, 2.0, 3.0]}))
+    with pytest.raises(SchemaError):
+        IntYFloatZModel.validate(pd.DataFrame({"y": [4.0, 5.0, 6.0], "z": [1, 2, 3]}))


### PR DESCRIPTION
Currently, *SchemaModel* is not compatible with *typing.Generic*. There are 2 straightforward applications in which I see *Generic* being useful:

1) In cases where SchemaModel sub-class methods involving generic types:
e.g.
```python
import pandera as pa
from typing import TypeVar, Generic

T = TypeVar("T")

class Foo(pa.SchemaModel, Generic[T]):
    @classmethod
    def bar(cls) -> T:
        raise NotImplementedError

class Bar1(Foo[int]):
    @classmethod
    def bar(cls) -> int:
        return 1

class Bar2(Foo[str]):
    @classmethod
    def bar(cls) -> str:
        return "1"
```
Currently, this won't work as it results in the following error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/cluster/home/willems/.local/lib/python3.9/site-packages/pandera/model.py", line 169, in __init_subclass__
    cls.__config__, cls.__extras__ = cls._collect_config_and_extras()
  File "/cluster/home/willems/.local/lib/python3.9/site-packages/pandera/model.py", line 407, in _collect_config_and_extras
    options, extras = _extract_config_options_and_extras(root_model.Config)
AttributeError: type object 'Generic' has no attribute 'Config'
```

2) A far more interesting application is when the types of fields are generic:
```python
import pandera as pa
from typing import TypeVar, Generic
from pandera.errors import SchemaError

class GenericModel(pa.SchemaModel, Generic[T]):
    x: Series[int]
    y: Series[T]

class IntModel(GenericModel[int]):
    ...

class FloatModel(GenericModel[float]):
    ...

IntModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
with pytest.raises(SchemaError):
    FloatModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))

with pytest.raises(SchemaError):
    IntModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5, 6]}))
FloatModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5, 6]}))
```
This application is also not currently supported.


This PR makes a few minor modifications to SchemaModel to enable both applications of *Generic*. I've also added a set of unit tests that suggest this is working as intended. The code required to enable Generic types in fields was heavily inspired by what's present in [pydantic](https://github.com/samuelcolvin/pydantic/blob/master/pydantic/generics.py#L43)

I wasn't sure whether it'd be ideal for *SchemaModel* to natively support generic arguments, or whether it'd be better to create a sub-class like *GenericSchemaModel* that enables this functionality. Ultimately, I opted for the former, as the changes seemed fairly minimal.

I tried to follow the best practice dev docs, but ran into a few issues:
1) The FastAPI unit tests seem to fail
2) The *black* formatting run by nox seemed to abort in an exception

Would love to get your thoughts on the utility of this and the prototype I've provided