### PR TITLE
fix pandas_engine.DateTime.coerce_value not consistent with coerce

### DIFF
--- a/docs/source/koalas.rst
+++ b/docs/source/koalas.rst
@@ -8,4 +8,4 @@ Data Validation with Koalas
 .. note::
 
     Koalas has been deprecated since version *0.10.0*. Please refer to the
-    `pyspark page <scaling_pyspark>`__ for validating pyspark dataframes.
+    :ref:`pyspark page <scaling_pyspark>` for validating pyspark dataframes.

--- a/docs/source/pyspark.rst
+++ b/docs/source/pyspark.rst
@@ -2,14 +2,14 @@
 
 .. _scaling_pyspark:
 
-Data Validation with Pyspark
-============================
+Data Validation with Pyspark ⭐️ (New)
+=======================================
 
-*new in 0.8.0*
+*new in 0.10.0*
 
 `Pyspark <https://spark.apache.org/docs/3.2.0/api/python/index.html>`__ is a
 distributed compute framework that offers a pandas drop-in replacement dataframe
-implementation via the `pyspark.pandas API <https://spark.apache.org/docs/3.2.0/api/python/reference/pyspark.pandas/index.html>` .
+implementation via the `pyspark.pandas API <https://spark.apache.org/docs/3.2.0/api/python/reference/pyspark.pandas/index.html>`__ .
 You can use pandera to validate :py:func:`~pyspark.pandas.DataFrame`
 and :py:func:`~pyspark.pandas.Series` objects directly. First, install
 ``pandera`` with the ``dask`` extra:

--- a/docs/source/supported_libraries.rst
+++ b/docs/source/supported_libraries.rst
@@ -47,10 +47,10 @@ dataframes.
      - Apply pandera schemas to Dask dataframe partitions.
    * - :ref:`Fugue <scaling_fugue>`
      - Apply pandera schemas to distributed dataframe partitions with Fugue.
-   * - :ref:`Koalas <scaling_koalas>` **[Deprecated]**
+   * - :ref:`Koalas <scaling_koalas>` *[Deprecated]*
      - A pandas drop-in replacement, distributed using a Spark backend.
-   * - :ref:`Pyspark Pandas <scaling_koalas>`
-     - A pandas drop-in replacement, distributed using a Spark backend.
+   * - :ref:`Pyspark <scaling_pyspark>`
+     - Exposes a ``pyspark.pandas`` module, distributed using a Spark backend.
    * - :ref:`Modin <scaling_modin>`
      - A pandas drop-in replacement, distributed using a Ray or Dask backend.
 
@@ -61,7 +61,7 @@ dataframes.
     Dask <dask>
     Fugue <fugue>
     Koalas <koalas>
-    Pyspark <pyspark>
+    Pyspark ⭐️ (New) <pyspark>
     Modin <modin>
 
 

--- a/pandera/version.py
+++ b/pandera/version.py
@@ -1,3 +1,3 @@
 """Version file"""
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"


### PR DESCRIPTION
Fixes #826

For Spark and Modin, `coerce_value` will default to `pandas.to_datetime`, which should have the same performance as `numpy.datetime64()`.