### PR TITLE
Lazy SchemaErrors contain schema name

### DIFF
--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -146,19 +146,18 @@ class SchemaErrors(ReducedPickleExceptionBase):
         data: Union[pd.Series, pd.DataFrame],
     ):
         error_counts, failure_cases = self._parse_schema_errors(schema_errors)
-        super().__init__(self._message(error_counts, failure_cases))
         self.schema = schema
+        super().__init__(self._message(error_counts, failure_cases))
         self.schema_errors = schema_errors
         self.error_counts = error_counts
         self.failure_cases = failure_cases
         self.data = data
 
-    @staticmethod
-    def _message(error_counts, schema_errors):
+    def _message(self, error_counts, schema_errors):
         """Format error message."""
         msg = (
-            f"A total of {sum(error_counts.values())} "
-            "schema errors were found.\n"
+            f"Schema {self.schema.name}: A total of "
+            f"{sum(error_counts.values())} schema errors were found.\n"
         )
 
         msg += "\nError Counts"

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1077,7 +1077,7 @@ def test_lazy_dataframe_validation_error() -> None:
     }
 
     with pytest.raises(
-        errors.SchemaErrors, match="^A total of .+ schema errors were found"
+        errors.SchemaErrors, match="A total of .+ schema errors were found"
     ):
         schema.validate(dataframe, lazy=True)
 


### PR DESCRIPTION
I tried to change the Exception str API minimally so the relevant tests:

```
tests/core/test_model.py::test_check_multiple_columns
tests/core/test_model.py::test_check_regex
tests/core/test_model.py::test_dataframe_check
tests/core/test_schema_components.py::tests_multi_index_subindex_coerce
tests/core/test_schemas.py::test_ordered_dataframe[columns0-None]
tests/core/test_schemas.py::test_ordered_dataframe[None-index1]
tests/core/test_schemas.py::test_lazy_dataframe_validation_error
```

do not need to change (regarding regexp assertions), but only `tests/core/test_schemas.py::test_lazy_dataframe_validation_error` as the regexp there was pinned to beginning of line.

The exact string formatting is just a proposal, of course. WDYT?